### PR TITLE
fix(dashboard): restore authenticated account resolution

### DIFF
--- a/dashboard/app/client-layout.tsx
+++ b/dashboard/app/client-layout.tsx
@@ -51,15 +51,21 @@ function resolveAmplifyOutputs(): Record<string, any> | null {
     )
   }
 
+  const configuredData = outputs?.data || {}
+  const configuredDefaultAuth = configuredData.default_authorization_type
+  const configuredAuthTypes = Array.isArray(configuredData.authorization_types)
+    ? configuredData.authorization_types
+    : null
+
   return {
     ...(outputs || {}),
     data: {
-      ...(outputs?.data || {}),
+      ...configuredData,
       url: endpointOverride,
       api_key: apiKeyOverride,
       aws_region: resolvedRegion,
-      default_authorization_type: "API_KEY",
-      authorization_types: ["API_KEY"],
+      default_authorization_type: configuredDefaultAuth || "API_KEY",
+      authorization_types: configuredAuthTypes?.length ? configuredAuthTypes : ["API_KEY"],
     },
   }
 }

--- a/dashboard/utils/amplify-helpers.ts
+++ b/dashboard/utils/amplify-helpers.ts
@@ -1,16 +1,6 @@
 import type { Schema } from "@/amplify/data/resource"
 import type { AmplifyListResult, AmplifyGetResult } from "@/types/shared"
 
-const DEFAULT_LIST_AUTH_MODE: 'apiKey' | undefined = process.env.NEXT_PUBLIC_PLEXUS_API_KEY
-  ? 'apiKey'
-  : undefined
-
-const withDefaultListAuth = <T extends Record<string, any>>(options: T): T | (T & { authMode: 'apiKey' }) => (
-  DEFAULT_LIST_AUTH_MODE
-    ? { ...options, authMode: DEFAULT_LIST_AUTH_MODE }
-    : options
-)
-
 interface ScoringJobsSubscriptionData {
   items: Schema['ScoringJob']['type'][]
   isSynced: boolean
@@ -140,8 +130,7 @@ export async function listFromModel<T extends { id: string }>(
               }
             }
           `,
-          variables,
-          authMode: 'apiKey'
+          variables
         });
 
         if (graphqlResponse?.errors) {
@@ -157,7 +146,7 @@ export async function listFromModel<T extends { id: string }>(
         console.error('GraphQL query failed:', gsiError);
         
         // Fall back to filtered list with sorting
-        response = await model.list(withDefaultListAuth({
+        response = await model.list({
           filter: { accountId: { eq: accountId } },
           limit: 100,
           nextToken,
@@ -165,7 +154,7 @@ export async function listFromModel<T extends { id: string }>(
             field: 'updatedAt',
             direction: 'DESC'
           }
-        }));
+        });
       }
     } else {
       const options: any = {}
@@ -173,7 +162,7 @@ export async function listFromModel<T extends { id: string }>(
       if (nextToken) options.nextToken = nextToken
       if (limit) options.limit = limit
       
-      response = await model.list(withDefaultListAuth(options))
+      response = await model.list(options)
     }
 
     // Sort the results in memory if we have them

--- a/project/events/2026-04-14T16:13:57.942Z__c4eed659-a4ee-4e05-bfb3-0cc97d477381.json
+++ b/project/events/2026-04-14T16:13:57.942Z__c4eed659-a4ee-4e05-bfb3-0cc97d477381.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c4eed659-a4ee-4e05-bfb3-0cc97d477381",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-14T16:13:57.942Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "## Problem\nDashboard shell renders after login, but all top pages display 'Error: No account found' and page content never loads.\n\n## Repro\n1. Run  in .\n2. Login to dashboard.\n3. Observe nav renders but content regions fail with no account.\n\n## Expected\nAuthenticated users with valid env config should resolve account and load page content.\n\n## Initial hypothesis\nMismatch or timing issue in account-key/account-context resolution between env bootstrap and page data hooks.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-b13120eb-5b86-4098-94e6-422ffc0412a3",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix dashboard post-login 'No account found' content load failure"
+  }
+}

--- a/project/events/2026-04-14T16:14:01.485Z__31c5ada3-bec3-44e9-987f-9b1efcb18e50.json
+++ b/project/events/2026-04-14T16:14:01.485Z__31c5ada3-bec3-44e9-987f-9b1efcb18e50.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "31c5ada3-bec3-44e9-987f-9b1efcb18e50",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-14T16:14:01.485Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-14T16:14:01.485Z__3bb86932-644b-4a6d-88c1-27f5c094a672.json
+++ b/project/events/2026-04-14T16:14:01.485Z__3bb86932-644b-4a6d-88c1-27f5c094a672.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "3bb86932-644b-4a6d-88c1-27f5c094a672",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-14T16:14:01.485Z",
+  "actor_id": "derek",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "## Problem\nDashboard shell renders after login, but all top pages display 'Error: No account found' and page content never loads.\n\n## Repro\n1. Run  in .\n2. Login to dashboard.\n3. Observe nav renders but content regions fail with no account.\n\n## Expected\nAuthenticated users with valid env config should resolve account and load page content.\n\n## Initial hypothesis\nMismatch or timing issue in account-key/account-context resolution between env bootstrap and page data hooks.",
+        "to": "## Problem\nDashboard shell renders after login, but all top pages display `Error: No account found` and page content never loads.\n\n## Repro\n1. Run `npm run dev:web` in `dashboard/`.\n2. Login to dashboard.\n3. Observe nav renders but content regions fail with no account.\n\n## Expected\nAuthenticated users with valid env config should resolve account and load page content.\n\n## Initial hypothesis\nMismatch or timing issue in account-key/account-context resolution between env bootstrap and page data hooks."
+      }
+    }
+  }
+}

--- a/project/events/2026-04-14T16:14:06.613Z__a18ff261-9ece-49f0-8186-d088ed06d4da.json
+++ b/project/events/2026-04-14T16:14:06.613Z__a18ff261-9ece-49f0-8186-d088ed06d4da.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a18ff261-9ece-49f0-8186-d088ed06d4da",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T16:14:06.613Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "ca845588-9004-4f84-a51e-ed1d4a168aa5"
+  }
+}

--- a/project/events/2026-04-14T16:16:31.141Z__98d9b1ac-b17a-4e5a-ab1d-b983af2f9460.json
+++ b/project/events/2026-04-14T16:16:31.141Z__98d9b1ac-b17a-4e5a-ab1d-b983af2f9460.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "98d9b1ac-b17a-4e5a-ab1d-b983af2f9460",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T16:16:31.141Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "bbc8edc6-9403-451e-83cb-37a738eb05a3"
+  }
+}

--- a/project/events/2026-04-14T16:16:44.021Z__cb2a0e92-956b-4ed3-bdff-09b2db1abc7a.json
+++ b/project/events/2026-04-14T16:16:44.021Z__cb2a0e92-956b-4ed3-bdff-09b2db1abc7a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cb2a0e92-956b-4ed3-bdff-09b2db1abc7a",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T16:16:44.021Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "1f3162fc-8222-48d6-8ec4-fb2380a0ab79"
+  }
+}

--- a/project/events/2026-04-14T16:21:36.874Z__c530acc6-4b3c-4b21-8041-85ac20d54005.json
+++ b/project/events/2026-04-14T16:21:36.874Z__c530acc6-4b3c-4b21-8041-85ac20d54005.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c530acc6-4b3c-4b21-8041-85ac20d54005",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T16:21:36.874Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "33ee38e1-b07b-480e-b257-1a47263f85a2"
+  }
+}

--- a/project/events/2026-04-14T16:29:23.844Z__4bcbc29f-64bd-431b-9ca5-22ae96d76661.json
+++ b/project/events/2026-04-14T16:29:23.844Z__4bcbc29f-64bd-431b-9ca5-22ae96d76661.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4bcbc29f-64bd-431b-9ca5-22ae96d76661",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T16:29:23.844Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "dbe7d941-ffda-4c0f-94bc-66e2421128e0"
+  }
+}

--- a/project/events/2026-04-14T16:29:26.493Z__547deef2-f147-4c5a-acda-3eb57e7f399e.json
+++ b/project/events/2026-04-14T16:29:26.493Z__547deef2-f147-4c5a-acda-3eb57e7f399e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "547deef2-f147-4c5a-acda-3eb57e7f399e",
+  "issue_id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T16:29:26.493Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "465f75ea-6b9f-48c4-8030-cdf677719709"
+  }
+}

--- a/project/issues/plx-ee1949e0-88de-4154-94af-f44a26b5473d.json
+++ b/project/issues/plx-ee1949e0-88de-4154-94af-f44a26b5473d.json
@@ -1,0 +1,43 @@
+{
+  "id": "plx-ee1949e0-88de-4154-94af-f44a26b5473d",
+  "title": "Fix dashboard post-login 'No account found' content load failure",
+  "description": "## Problem\nDashboard shell renders after login, but all top pages display `Error: No account found` and page content never loads.\n\n## Repro\n1. Run `npm run dev:web` in `dashboard/`.\n2. Login to dashboard.\n3. Observe nav renders but content regions fail with no account.\n\n## Expected\nAuthenticated users with valid env config should resolve account and load page content.\n\n## Initial hypothesis\nMismatch or timing issue in account-key/account-context resolution between env bootstrap and page data hooks.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b13120eb-5b86-4098-94e6-422ffc0412a3",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "ca845588-9004-4f84-a51e-ed1d4a168aa5",
+      "author": "derek",
+      "text": "Started investigation. Next: locate where dashboard throws 'No account found', validate runtime env propagation for NEXT_PUBLIC_PLEXUS_ACCOUNT_KEY, and patch account resolution so authenticated users can load content.",
+      "created_at": "2026-04-14T16:14:06.613032322Z"
+    },
+    {
+      "id": "bbc8edc6-9403-451e-83cb-37a738eb05a3",
+      "author": "derek",
+      "text": "Root cause confirmed: AppSync  calls are unauthorized in this environment, but dashboard startup code forced Data auth to API key and helper calls also injected . After login this caused account/evaluation queries to fail, leaving selectedAccount null and rendering .\n\nImplemented fixes:\n1) : preserve  and  from  when applying URL/API key overrides, instead of forcing API_KEY-only.\n2) : removed automatic apiKey authMode injection and removed hardcoded  in evaluation query path.\n\nValidation:  passes.",
+      "created_at": "2026-04-14T16:16:31.141187527Z"
+    },
+    {
+      "id": "1f3162fc-8222-48d6-8ec4-fb2380a0ab79",
+      "author": "derek",
+      "text": "Root cause confirmed: AppSync API-key calls are unauthorized in this environment, but dashboard startup code forced Data auth to API key and helper calls also injected authMode apiKey. After login this caused account and evaluation queries to fail, leaving selectedAccount null and rendering No account found.\n\nImplemented fixes:\n1) dashboard/app/client-layout.tsx now preserves default_authorization_type and authorization_types from amplify_outputs.json when applying URL/API key overrides, instead of forcing API_KEY-only.\n2) dashboard/utils/amplify-helpers.ts no longer auto-injects authMode apiKey and no longer hardcodes authMode apiKey in the evaluation query path.\n\nValidation: npm test -- --runInBand components/__tests__/evaluations-dashboard.test.tsx (pass).",
+      "created_at": "2026-04-14T16:16:44.021737513Z"
+    },
+    {
+      "id": "33ee38e1-b07b-480e-b257-1a47263f85a2",
+      "author": "derek",
+      "text": "Follow-up verification requested: checked git history for auth regressions. Found recent commits introducing API-key forcing behavior: \n- 2026-04-07 commit 31dbe5cb added default_authorization_type API_KEY and authorization_types [API_KEY] in dashboard/app/client-layout.tsx.\n- 2026-04-01 commit e694b909 added DEFAULT_LIST_AUTH_MODE apiKey injection in dashboard/utils/amplify-helpers.ts.\n- Earlier 2025-02-05 commit d3617268 added authMode apiKey to evaluation GraphQL query path.\nThis confirms the fix addressed concrete historical changes rather than a speculative patch.",
+      "created_at": "2026-04-14T16:21:36.874250586Z"
+    }
+  ],
+  "created_at": "2026-04-14T16:13:57.942842448Z",
+  "updated_at": "2026-04-14T16:21:36.874250586Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-ee1949e0-88de-4154-94af-f44a26b5473d.json
+++ b/project/issues/plx-ee1949e0-88de-4154-94af-f44a26b5473d.json
@@ -34,10 +34,22 @@
       "author": "derek",
       "text": "Follow-up verification requested: checked git history for auth regressions. Found recent commits introducing API-key forcing behavior: \n- 2026-04-07 commit 31dbe5cb added default_authorization_type API_KEY and authorization_types [API_KEY] in dashboard/app/client-layout.tsx.\n- 2026-04-01 commit e694b909 added DEFAULT_LIST_AUTH_MODE apiKey injection in dashboard/utils/amplify-helpers.ts.\n- Earlier 2025-02-05 commit d3617268 added authMode apiKey to evaluation GraphQL query path.\nThis confirms the fix addressed concrete historical changes rather than a speculative patch.",
       "created_at": "2026-04-14T16:21:36.874250586Z"
+    },
+    {
+      "id": "dbe7d941-ffda-4c0f-94bc-66e2421128e0",
+      "author": "derek",
+      "text": "Created fix branch  from develop and committed the dashboard auth resolution plus Kanbus artifacts in commit . Remaining untracked files intentionally excluded: scoring_jobs_20260409_203632.csv, scripts/list_scorecards_with_score_external_id.py.",
+      "created_at": "2026-04-14T16:29:23.844728080Z"
+    },
+    {
+      "id": "465f75ea-6b9f-48c4-8030-cdf677719709",
+      "author": "derek",
+      "text": "Created fix branch fix/dashboard-account-auth-resolution from develop and committed the dashboard auth resolution plus Kanbus artifacts in commit 2fbbc4b9. Remaining untracked files intentionally excluded: scoring_jobs_20260409_203632.csv, scripts/list_scorecards_with_score_external_id.py.",
+      "created_at": "2026-04-14T16:29:26.493467422Z"
     }
   ],
   "created_at": "2026-04-14T16:13:57.942842448Z",
-  "updated_at": "2026-04-14T16:21:36.874250586Z",
+  "updated_at": "2026-04-14T16:29:26.493467422Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
**Summary**
- Preserve configured Amplify data auth modes when applying local API URL/key overrides in `dashboard/app/client-layout.tsx`.
- Remove implicit `authMode: 'apiKey'` injection from `dashboard/utils/amplify-helpers.ts` list/query paths.
- Keep Kanbus tracking artifacts for `plx-ee1949` in `project/issues/` and `project/events/`.

**Why**
- Dashboard pages were rendering shell UI but failing to load content after login with `Error: No account found`.
- The dashboard client path was forcing API key auth in places where this environment requires authenticated user auth, causing account/evaluation queries to fail.

**Validation**
- `cd dashboard && npm test -- --runInBand components/__tests__/evaluations-dashboard.test.tsx`
- Manual verification in local dev: login now resolves account context and `/lab/*` content loads.

**Expected Outcome**
- Authenticated dashboard sessions use the intended Amplify auth configuration and can resolve account-scoped data reliably.
- Local API endpoint/key overrides no longer collapse auth to API-key-only mode.

**Kanbus / Task Tracking**
- `plx-ee1949`
