### PR TITLE
hotfix(score-processor): fix Decimal/float cost accumulation crash

### DIFF
--- a/plexus/Scorecard.py
+++ b/plexus/Scorecard.py
@@ -698,8 +698,8 @@ class Scorecard:
                 self.completion_tokens += score_total_cost.get("completion_tokens", 0)
                 self.cached_tokens += score_total_cost.get("cached_tokens", 0)
                 self.llm_calls += score_total_cost.get("llm_calls", 0)
-                self.input_cost += score_total_cost.get("input_cost", 0)
-                self.output_cost += score_total_cost.get("output_cost", 0)
+                self.input_cost += Decimal(str(score_total_cost.get("input_cost", 0)))
+                self.output_cost += Decimal(str(score_total_cost.get("output_cost", 0)))
                 self.total_cost += Decimal(str(score_total_cost.get("total_cost", 0)))
                 self.scorecard_total_cost += Decimal(
                     str(score_total_cost.get("total_cost", 0))

--- a/plexus/Scorecard_test.py
+++ b/plexus/Scorecard_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch, MagicMock
 from plexus.Scorecard import Scorecard
 import pytest
 import logging
+from decimal import Decimal
 
 def create_mock_score_instance():
     """Helper function to create a properly mocked score instance"""
@@ -670,6 +671,74 @@ class TestScorecard:
         finally:
             # Restore the original method
             self.scorecard.score_names_to_process = original_method
+
+    @pytest.mark.asyncio
+    async def test_score_entire_text_handles_float_costs(self):
+        """Regression: float cost values should be accumulated into Decimal totals."""
+        simple_config = {
+            'name': 'TestScorecard',
+            'id': 'test-scorecard-123',
+            'scores': [
+                {'name': 'FloatCostScore', 'id': 1}
+            ]
+        }
+        self.scorecard.properties = simple_config
+        self.scorecard.scores = simple_config['scores']
+
+        def get_properties_side_effect(score_name):
+            for score in simple_config['scores']:
+                if score['name'] == score_name:
+                    return score
+            return None
+        self.mock_registry.get_properties.side_effect = get_properties_side_effect
+
+        mock_score_class = MagicMock()
+        mock_score_instance = MagicMock()
+
+        async def mock_predict(*args, **kwargs):
+            return Mock(value='Pass')
+
+        mock_score_instance.predict = mock_predict
+
+        def mock_get_accumulated_costs():
+            return {
+                'prompt_tokens': 100,
+                'completion_tokens': 50,
+                'cached_tokens': 0,
+                'llm_calls': 1,
+                'input_cost': 0.10,
+                'output_cost': 0.05,
+                'total_cost': 0.15,
+                'cost_per_text': 0.15,
+            }
+
+        mock_score_instance.get_accumulated_costs = mock_get_accumulated_costs
+
+        async def mock_create(**kwargs):
+            return mock_score_instance
+
+        mock_score_class.create = mock_create
+        self.mock_registry.get.side_effect = lambda score_name: mock_score_class
+
+        # Use the real implementation so we exercise cost accumulation behavior.
+        original_get_score_result = self.scorecard.get_score_result
+        self.scorecard.get_score_result = Scorecard.get_score_result.__get__(self.scorecard, Scorecard)
+        original_method = self.scorecard.score_names_to_process
+        self.scorecard.score_names_to_process = lambda: ['FloatCostScore']
+
+        try:
+            result = await self.scorecard.score_entire_text(
+                text="Sample text",
+                metadata={},
+                modality="test"
+            )
+            assert len(result) == 1
+            assert self.scorecard.input_cost == Decimal("0.1")
+            assert self.scorecard.output_cost == Decimal("0.05")
+            assert self.scorecard.total_cost == Decimal("0.15")
+        finally:
+            self.scorecard.score_names_to_process = original_method
+            self.scorecard.get_score_result = original_get_score_result
 
 if __name__ == '__main__':
     pytest.main()

--- a/project/events/2026-04-14T17:23:45.221Z__72e95f64-5e51-43dc-94ba-97483bc1f730.json
+++ b/project/events/2026-04-14T17:23:45.221Z__72e95f64-5e51-43dc-94ba-97483bc1f730.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "72e95f64-5e51-43dc-94ba-97483bc1f730",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-14T17:23:45.221Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "## Problem\nProduction score-processing Lambda fails during initialization with  from GraphQL account lookup ().\n\n## Evidence\nLambda stack trace shows failure path in  during  called by .\n\n## Expected\nLambda should authenticate correctly against AppSync and resolve account by key in production.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-f8aff74b-6412-4367-829d-0b5e2eec8e62",
+    "priority": 0,
+    "status": "open",
+    "title": "Fix score-processing Lambda UnauthorizedException on account lookup"
+  }
+}

--- a/project/events/2026-04-14T17:23:50.795Z__69b895d0-3f5e-40a5-af25-9e6655242275.json
+++ b/project/events/2026-04-14T17:23:50.795Z__69b895d0-3f5e-40a5-af25-9e6655242275.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "69b895d0-3f5e-40a5-af25-9e6655242275",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-14T17:23:50.795Z",
+  "actor_id": "derek",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "## Problem\nProduction score-processing Lambda fails during initialization with  from GraphQL account lookup ().\n\n## Evidence\nLambda stack trace shows failure path in  during  called by .\n\n## Expected\nLambda should authenticate correctly against AppSync and resolve account by key in production.",
+        "to": "## Problem\nProduction score-processing Lambda fails during initialization with UnauthorizedException from GraphQL account lookup (Account.get_by_key).\n\n## Evidence\nLambda stack trace shows failure path in plexus/dashboard/api/client.py during client.execute called by plexus/dashboard/api/models/account.py:get_by_key.\n\n## Expected\nLambda should authenticate correctly against AppSync and resolve account by key in production."
+      }
+    }
+  }
+}

--- a/project/events/2026-04-14T17:23:50.795Z__e6aa434c-2a1c-45de-bd14-d343a9a16abe.json
+++ b/project/events/2026-04-14T17:23:50.795Z__e6aa434c-2a1c-45de-bd14-d343a9a16abe.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e6aa434c-2a1c-45de-bd14-d343a9a16abe",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-14T17:23:50.795Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-14T17:23:50.807Z__803a45ad-42dd-41ae-b8a0-6afca7bc8261.json
+++ b/project/events/2026-04-14T17:23:50.807Z__803a45ad-42dd-41ae-b8a0-6afca7bc8261.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "803a45ad-42dd-41ae-b8a0-6afca7bc8261",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T17:23:50.807Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "413de461-a30c-4843-965c-f0bed9f154c1"
+  }
+}

--- a/project/events/2026-04-14T17:52:14.587Z__6743e4f0-b999-4a1e-90cf-ba85ececf946.json
+++ b/project/events/2026-04-14T17:52:14.587Z__6743e4f0-b999-4a1e-90cf-ba85ececf946.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6743e4f0-b999-4a1e-90cf-ba85ececf946",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T17:52:14.587Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "89360026-4327-468e-9e1c-cf5957eed1b8"
+  }
+}

--- a/project/events/2026-04-14T17:52:18.405Z__22496e18-5aa8-4595-81ee-8e0d5c3b8048.json
+++ b/project/events/2026-04-14T17:52:18.405Z__22496e18-5aa8-4595-81ee-8e0d5c3b8048.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "22496e18-5aa8-4595-81ee-8e0d5c3b8048",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T17:52:18.405Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "2e5e5774-ce8b-4bf1-a7f4-25b56629a661"
+  }
+}

--- a/project/events/2026-04-14T17:54:30.690Z__3917e0de-5d9d-420a-954c-5a7beca34d27.json
+++ b/project/events/2026-04-14T17:54:30.690Z__3917e0de-5d9d-420a-954c-5a7beca34d27.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3917e0de-5d9d-420a-954c-5a7beca34d27",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T17:54:30.690Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "ee0f4ff9-9254-4038-b67c-0248032a3cc0"
+  }
+}

--- a/project/events/2026-04-14T17:58:02.384Z__7ea83cb5-ff39-435c-aa98-efdcf3a8c4dd.json
+++ b/project/events/2026-04-14T17:58:02.384Z__7ea83cb5-ff39-435c-aa98-efdcf3a8c4dd.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7ea83cb5-ff39-435c-aa98-efdcf3a8c4dd",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T17:58:02.384Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "8e62d3f1-d187-4701-b554-2d3dff7f609c"
+  }
+}

--- a/project/events/2026-04-14T18:05:06.379Z__afd9a7a1-e17a-4c88-8298-6b8b32052235.json
+++ b/project/events/2026-04-14T18:05:06.379Z__afd9a7a1-e17a-4c88-8298-6b8b32052235.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "afd9a7a1-e17a-4c88-8298-6b8b32052235",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T18:05:06.379Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "f16ea48c-33a0-44b6-b8ed-92f173d43bed"
+  }
+}

--- a/project/events/2026-04-14T18:06:36.030Z__e71fa2ec-03df-4571-bfd2-92c514c85b1f.json
+++ b/project/events/2026-04-14T18:06:36.030Z__e71fa2ec-03df-4571-bfd2-92c514c85b1f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e71fa2ec-03df-4571-bfd2-92c514c85b1f",
+  "issue_id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T18:06:36.030Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "00b2eb72-dc79-45aa-b5e6-49d6c3971090"
+  }
+}

--- a/project/issues/plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22.json
+++ b/project/issues/plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22.json
@@ -1,0 +1,55 @@
+{
+  "id": "plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22",
+  "title": "Fix score-processing Lambda UnauthorizedException on account lookup",
+  "description": "## Problem\nProduction score-processing Lambda fails during initialization with UnauthorizedException from GraphQL account lookup (Account.get_by_key).\n\n## Evidence\nLambda stack trace shows failure path in plexus/dashboard/api/client.py during client.execute called by plexus/dashboard/api/models/account.py:get_by_key.\n\n## Expected\nLambda should authenticate correctly against AppSync and resolve account by key in production.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 0,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-f8aff74b-6412-4367-829d-0b5e2eec8e62",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "413de461-a30c-4843-965c-f0bed9f154c1",
+      "author": "derek",
+      "text": "Started investigation. Next step: trace Lambda GraphQL auth mode/header selection in plexus/dashboard/api/client.py and runtime env wiring in score-processing Lambda resources.",
+      "created_at": "2026-04-14T17:23:50.807017591Z"
+    },
+    {
+      "id": "89360026-4327-468e-9e1c-cf5957eed1b8",
+      "author": "derek",
+      "text": "Implemented fix for Lambda crash  in plexus/Scorecard.py by normalizing input/output costs to Decimal before accumulation. Added regression test  in plexus/Scorecard_test.py.\n\nValidation attempt:  failed in this shell because pytest is not installed ().",
+      "created_at": "2026-04-14T17:52:14.587642251Z"
+    },
+    {
+      "id": "2e5e5774-ce8b-4bf1-a7f4-25b56629a661",
+      "author": "derek",
+      "text": "Implemented fix for Lambda crash in plexus/Scorecard.py by normalizing input and output costs to Decimal before accumulation. Added regression test test_score_entire_text_handles_float_costs in plexus/Scorecard_test.py. Validation attempt with pytest failed in this shell because pytest is not installed in the active interpreter (ModuleNotFoundError).",
+      "created_at": "2026-04-14T17:52:18.405776086Z"
+    },
+    {
+      "id": "ee0f4ff9-9254-4038-b67c-0248032a3cc0",
+      "author": "derek",
+      "text": "Regression analysis: likely recent. LangGraphScore cost computation changed in commit 90b108bf (2026-04-13) to litellm.cost_per_token and returns float input_cost/output_cost/total_cost. Scorecard accumulators are Decimal, and input/output paths were not Decimal-normalized, which causes Decimal + float TypeError at runtime.\n\nWork is now on branch fix/score-processor-decimal-cost-regression (not develop).\n\nValidation attempt in local venv: pytest collection failed because litellm is missing in .venv (ModuleNotFoundError), so full test run is blocked by environment dependency.",
+      "created_at": "2026-04-14T17:54:30.690364680Z"
+    },
+    {
+      "id": "8e62d3f1-d187-4701-b554-2d3dff7f609c",
+      "author": "derek",
+      "text": "Environment fix applied for full test execution: used poetry-managed environment and installed missing runtime deps used by Scorecard imports. Ran full test file (not subset): poetry run pytest -q plexus/Scorecard_test.py -> 8 passed, 0 failed (warnings only). Regression test for float cost accumulation passes.",
+      "created_at": "2026-04-14T17:58:02.383893652Z"
+    },
+    {
+      "id": "f16ea48c-33a0-44b6-b8ed-92f173d43bed",
+      "author": "derek",
+      "text": "Pre-PR Lambda image verification completed locally via container smoke test: Building Docker image...\ncd .. && docker buildx build \\\n\t--platform linux/amd64 \\\n\t--load \\\n\t-f score-processor-lambda/Dockerfile \\\n\t-t score-processor-lambda:latest \\\n\t.\n✓ Image built: score-processor-lambda:latest\nRunning smoke test in container...\ndocker run --rm \\\n\t-v /home/derek/projects/Plexus/score-processor-lambda/tests/smoke_test.py:/var/task/smoke_test.py \\\n\t--entrypoint python \\\n\tscore-processor-lambda:latest \\\n\tsmoke_test.py\n======================================================================\nLAMBDA CONTAINER SMOKE TEST\n======================================================================\n\n▶ Import core dependencies\n    - langchain: 0.3.27\n    - langchain-core: 0.3.78\n    - tactus: 0.44.0\n  ✓ PASS\n\n▶ Verify pinned LangChain versions\n    - All versions match requirements.txt\n  ✓ PASS\n\n▶ Import Plexus modules\n    - All Plexus models import successfully\n  ✓ PASS\n\n▶ Import handler module\n    - Handler module loads correctly\n  ✓ PASS\n\n▶ Initialize LambdaJobProcessor\n    - LambdaJobProcessor initialized successfully\n  ✓ PASS\n\n▶ Verify NLTK data\n    - NLTK punkt data found\n  ✓ PASS\n\n▶ Check writable directories\n    - /tmp is writable\n  ✓ PASS\n\n▶ Verify tactus version\n    - tactus version matches: 0.44.0\n  ✓ PASS\n\n▶ Instantiate TactusRuntime and MemoryStorage\n    - MemoryStorage instantiated successfully\n    - TactusRuntime instantiated successfully\n  ✓ PASS\n\n▶ Import TactusScore and scoring utilities\n    - TactusScore imported successfully\n    - create_scorecard_instance_for_single_score imported successfully\n    - Scorecard imported successfully\n  ✓ PASS\n\n======================================================================\nRESULTS: 10 passed, 0 failed\n======================================================================. Docker image built from current branch code and smoke_test.py ran inside container. Result: 10 passed, 0 failed. This validates runtime imports, handler initialization, tactus/scorecard loading, and writable dirs in Lambda-like container.",
+      "created_at": "2026-04-14T18:05:06.379246988Z"
+    }
+  ],
+  "created_at": "2026-04-14T17:23:45.220921989Z",
+  "updated_at": "2026-04-14T18:05:06.379246988Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22.json
+++ b/project/issues/plx-6978a44a-12e8-4430-bf02-14c6bfcb5f22.json
@@ -46,10 +46,16 @@
       "author": "derek",
       "text": "Pre-PR Lambda image verification completed locally via container smoke test: Building Docker image...\ncd .. && docker buildx build \\\n\t--platform linux/amd64 \\\n\t--load \\\n\t-f score-processor-lambda/Dockerfile \\\n\t-t score-processor-lambda:latest \\\n\t.\n✓ Image built: score-processor-lambda:latest\nRunning smoke test in container...\ndocker run --rm \\\n\t-v /home/derek/projects/Plexus/score-processor-lambda/tests/smoke_test.py:/var/task/smoke_test.py \\\n\t--entrypoint python \\\n\tscore-processor-lambda:latest \\\n\tsmoke_test.py\n======================================================================\nLAMBDA CONTAINER SMOKE TEST\n======================================================================\n\n▶ Import core dependencies\n    - langchain: 0.3.27\n    - langchain-core: 0.3.78\n    - tactus: 0.44.0\n  ✓ PASS\n\n▶ Verify pinned LangChain versions\n    - All versions match requirements.txt\n  ✓ PASS\n\n▶ Import Plexus modules\n    - All Plexus models import successfully\n  ✓ PASS\n\n▶ Import handler module\n    - Handler module loads correctly\n  ✓ PASS\n\n▶ Initialize LambdaJobProcessor\n    - LambdaJobProcessor initialized successfully\n  ✓ PASS\n\n▶ Verify NLTK data\n    - NLTK punkt data found\n  ✓ PASS\n\n▶ Check writable directories\n    - /tmp is writable\n  ✓ PASS\n\n▶ Verify tactus version\n    - tactus version matches: 0.44.0\n  ✓ PASS\n\n▶ Instantiate TactusRuntime and MemoryStorage\n    - MemoryStorage instantiated successfully\n    - TactusRuntime instantiated successfully\n  ✓ PASS\n\n▶ Import TactusScore and scoring utilities\n    - TactusScore imported successfully\n    - create_scorecard_instance_for_single_score imported successfully\n    - Scorecard imported successfully\n  ✓ PASS\n\n======================================================================\nRESULTS: 10 passed, 0 failed\n======================================================================. Docker image built from current branch code and smoke_test.py ran inside container. Result: 10 passed, 0 failed. This validates runtime imports, handler initialization, tactus/scorecard loading, and writable dirs in Lambda-like container.",
       "created_at": "2026-04-14T18:05:06.379246988Z"
+    },
+    {
+      "id": "00b2eb72-dc79-45aa-b5e6-49d6c3971090",
+      "author": "derek",
+      "text": "Pushed fix branch fix/score-processor-decimal-cost-regression and opened PR to develop: https://github.com/AnthusAI/Plexus/pull/163. Includes Decimal/float accumulation fix + regression test + Kanbus artifacts. Validation recorded in PR: poetry run pytest -q plexus/Scorecard_test.py (8 passed) and score-processor-lambda make test-smoke (10 passed, 0 failed).",
+      "created_at": "2026-04-14T18:06:36.030334754Z"
     }
   ],
   "created_at": "2026-04-14T17:23:45.220921989Z",
-  "updated_at": "2026-04-14T18:05:06.379246988Z",
+  "updated_at": "2026-04-14T18:06:36.030334754Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
**Summary**
- Fix `Scorecard` cost accumulation to avoid `Decimal += float` runtime failures in score processing.
- Convert `input_cost` and `output_cost` additions to `Decimal(str(...))` in `plexus/Scorecard.py`.
- Add regression coverage in `plexus/Scorecard_test.py` for float-returning cost payloads.
- Include Kanbus tracking artifacts for `plx-6978a4`.

**Why**
- Production score-processor Lambda was failing with:
  - `TypeError: unsupported operand type(s) for +=: 'decimal.Decimal' and 'float'`
- Regression source is consistent with recent cost-path changes where score implementations can return float costs.

**Validation**
- `poetry run pytest -q plexus/Scorecard_test.py`
  - Result: `8 passed` (warnings only)
- `cd score-processor-lambda && make test-smoke`
  - Result: `10 passed, 0 failed` in Lambda container smoke test

**Expected Outcome**
- Score-processor Lambda no longer crashes on cost accumulation when per-score costs are floats.
- Scoring jobs proceed past `score_entire_text` and produce results normally.

**Kanbus / Task Tracking**
- `plx-6978a4`
