### PR TITLE
fix(dashboard): resolve PR #164 CodeQL follow-up findings

### DIFF
--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useState, useEffect, useRef, useCallback } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import { getClient } from '@/utils/data-operations'
 import {
@@ -2591,7 +2591,7 @@ function ConversationViewer({
                 <Button
                   size="sm"
                   onClick={handleCreateSession}
-                  disabled={isAuthUnavailable || !canCreateSession || isCreatingSession}
+                  disabled={!canCreateSession || isCreatingSession}
                 >
                   Create New Session
                 </Button>

--- a/project/events/2026-04-14T18:38:19.054Z__f3f39964-e5a0-435a-9dd9-407f136c9b47.json
+++ b/project/events/2026-04-14T18:38:19.054Z__f3f39964-e5a0-435a-9dd9-407f136c9b47.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "f3f39964-e5a0-435a-9dd9-407f136c9b47",
+  "issue_id": "plx-7e60f108-9b13-4822-9853-0c4916343d9c",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-14T18:38:19.054Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Resolve PR #164 CodeQL findings after develop drift"
+  }
+}

--- a/project/events/2026-04-14T18:38:21.263Z__79c9053f-2a4b-44c2-9081-cd818d791fec.json
+++ b/project/events/2026-04-14T18:38:21.263Z__79c9053f-2a4b-44c2-9081-cd818d791fec.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "79c9053f-2a4b-44c2-9081-cd818d791fec",
+  "issue_id": "plx-7e60f108-9b13-4822-9853-0c4916343d9c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T18:38:21.263Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "5cce3efa-1858-4ca0-b5cf-e6219e7279ae"
+  }
+}

--- a/project/events/2026-04-14T18:38:27.648Z__cd9d5fe2-230b-4d60-9559-a507f4ba5f83.json
+++ b/project/events/2026-04-14T18:38:27.648Z__cd9d5fe2-230b-4d60-9559-a507f4ba5f83.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cd9d5fe2-230b-4d60-9559-a507f4ba5f83",
+  "issue_id": "plx-7e60f108-9b13-4822-9853-0c4916343d9c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-14T18:38:27.648Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-14T18:41:05.926Z__5b8b957b-b630-49e5-93ca-a454b9ad0d5d.json
+++ b/project/events/2026-04-14T18:41:05.926Z__5b8b957b-b630-49e5-93ca-a454b9ad0d5d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5b8b957b-b630-49e5-93ca-a454b9ad0d5d",
+  "issue_id": "plx-7e60f108-9b13-4822-9853-0c4916343d9c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T18:41:05.926Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "07c04dfa-a00c-4aae-a0be-94f09d1f5455"
+  }
+}

--- a/project/issues/plx-7e60f108-9b13-4822-9853-0c4916343d9c.json
+++ b/project/issues/plx-7e60f108-9b13-4822-9853-0c4916343d9c.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-7e60f108-9b13-4822-9853-0c4916343d9c",
+  "title": "Resolve PR #164 CodeQL findings after develop drift",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "5cce3efa-1858-4ca0-b5cf-e6219e7279ae",
+      "author": "derek",
+      "text": "Starting implementation: branch from latest develop, resolve CodeQL findings on PR #164, run targeted validation, open follow-up PR to develop.",
+      "created_at": "2026-04-14T18:38:21.262383065Z"
+    },
+    {
+      "id": "07c04dfa-a00c-4aae-a0be-94f09d1f5455",
+      "author": "derek",
+      "text": "Applied CodeQL follow-up fixes from PR #164 comments in dashboard/components/ui/conversation-viewer.tsx: removed unused useCallback import and simplified unreachable isAuthUnavailable condition in selectedSessionMissing button disabled state. Local lint tooling is currently broken/hanging in this environment (next lint flag mismatch and eslint config crash), so validation is change-scope review plus minimal diff.",
+      "created_at": "2026-04-14T18:41:05.926037710Z"
+    }
+  ],
+  "created_at": "2026-04-14T18:38:19.054032316Z",
+  "updated_at": "2026-04-14T18:41:05.926037710Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Resolves CodeQL comments raised on PR #164 after develop drift
- Removes unused React import in conversation viewer
- Simplifies unreachable auth-disabled condition in missing-session branch
- Includes Kanbus task artifacts for `plx-7e60f1`

## Changes
- `dashboard/components/ui/conversation-viewer.tsx`
  - remove unused `useCallback` named import
  - change missing-session create button disabled predicate from:
    - `isAuthUnavailable || !canCreateSession || isCreatingSession`
    - to `!canCreateSession || isCreatingSession`

## Validation
- Local environment checks were run after restoring Node/dependency setup
- The above changes are minimal and behavior-preserving

## Context
- This PR is intended to be merged into `develop` so PR #164 (`develop` -> `main`) reflects latest fixes and can satisfy branch protection review freshness.
