### PR TITLE
fix(reports): update feedback contradictions tests for name-based scorecard lookup

### DIFF
--- a/plexus/reports/blocks/feedback_contradictions_test.py
+++ b/plexus/reports/blocks/feedback_contradictions_test.py
@@ -30,8 +30,8 @@ async def test_feedback_contradictions_mode_returns_contradiction_payload(monkey
     block.report_block_id = 'block-123'
 
     monkeypatch.setattr(
-        'plexus.reports.blocks.feedback_contradictions.Scorecard.get_by_external_id',
-        lambda external_id, client: SimpleNamespace(id='scorecard-1', name='CMG EDU'),
+        'plexus.reports.blocks.feedback_contradictions.Scorecard.get_by_name',
+        lambda name, client: SimpleNamespace(id='scorecard-1', name='CMG EDU'),
     )
     monkeypatch.setattr(
         block,
@@ -90,8 +90,8 @@ async def test_feedback_contradictions_mode_aligned_includes_dataset_payload(mon
     block.report_block_id = 'block-456'
 
     monkeypatch.setattr(
-        'plexus.reports.blocks.feedback_contradictions.Scorecard.get_by_external_id',
-        lambda external_id, client: SimpleNamespace(id='scorecard-1', name='CMG EDU'),
+        'plexus.reports.blocks.feedback_contradictions.Scorecard.get_by_name',
+        lambda name, client: SimpleNamespace(id='scorecard-1', name='CMG EDU'),
     )
     monkeypatch.setattr(
         block,
@@ -179,8 +179,8 @@ async def test_feedback_contradictions_applies_max_feedback_items_cap(monkeypatc
     block.report_block_id = 'block-789'
 
     monkeypatch.setattr(
-        'plexus.reports.blocks.feedback_contradictions.Scorecard.get_by_external_id',
-        lambda external_id, client: SimpleNamespace(id='scorecard-1', name='CMG EDU'),
+        'plexus.reports.blocks.feedback_contradictions.Scorecard.get_by_name',
+        lambda name, client: SimpleNamespace(id='scorecard-1', name='CMG EDU'),
     )
     monkeypatch.setattr(
         block,

--- a/project/events/2026-04-14T21:52:38.918Z__1dc5655f-3e36-4088-8ee6-56e2e6ef8e0d.json
+++ b/project/events/2026-04-14T21:52:38.918Z__1dc5655f-3e36-4088-8ee6-56e2e6ef8e0d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1dc5655f-3e36-4088-8ee6-56e2e6ef8e0d",
+  "issue_id": "plx-3c73348a-163a-436e-8b26-0da2bca510cc",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T21:52:38.918Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "265129eb-a419-4afb-b2af-546d2a06f556"
+  }
+}

--- a/project/events/2026-04-14T21:52:45.556Z__3164c8f7-f4eb-40d6-b348-050b968d4612.json
+++ b/project/events/2026-04-14T21:52:45.556Z__3164c8f7-f4eb-40d6-b348-050b968d4612.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3164c8f7-f4eb-40d6-b348-050b968d4612",
+  "issue_id": "plx-3c73348a-163a-436e-8b26-0da2bca510cc",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T21:52:45.556Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "ad143417-3042-4c9b-b980-1032f176d8e8"
+  }
+}

--- a/project/events/2026-04-14T22:14:46.989Z__e3417b1b-02e5-4e8d-92b6-f9ad74138cb0.json
+++ b/project/events/2026-04-14T22:14:46.989Z__e3417b1b-02e5-4e8d-92b6-f9ad74138cb0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e3417b1b-02e5-4e8d-92b6-f9ad74138cb0",
+  "issue_id": "plx-3c73348a-163a-436e-8b26-0da2bca510cc",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:14:46.989Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "cb2289ce-b262-4327-825d-0be53201063c"
+  }
+}

--- a/project/events/2026-04-14T22:14:47.099Z__421936ba-8402-471d-b6bc-5276c098fe26.json
+++ b/project/events/2026-04-14T22:14:47.099Z__421936ba-8402-471d-b6bc-5276c098fe26.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "421936ba-8402-471d-b6bc-5276c098fe26",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-14T22:14:47.099Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "sub-task",
+    "labels": [],
+    "parent": "plx-3c73348a-163a-436e-8b26-0da2bca510cc",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix develop CI regressions blocking PR #167 review"
+  }
+}

--- a/project/events/2026-04-14T22:14:51.979Z__1476fdd8-3d78-42a5-95cb-04fba2cbd219.json
+++ b/project/events/2026-04-14T22:14:51.979Z__1476fdd8-3d78-42a5-95cb-04fba2cbd219.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1476fdd8-3d78-42a5-95cb-04fba2cbd219",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-14T22:14:51.979Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-14T22:14:51.985Z__b58c83a6-c0fa-4048-a63a-c5d2c82fdb92.json
+++ b/project/events/2026-04-14T22:14:51.985Z__b58c83a6-c0fa-4048-a63a-c5d2c82fdb92.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b58c83a6-c0fa-4048-a63a-c5d2c82fdb92",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:14:51.985Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "a6c45874-81e3-47d1-81db-cd6d15b09da8"
+  }
+}

--- a/project/events/2026-04-14T22:15:28.209Z__23d9e027-43c8-44c8-ac74-eb1edce75ea9.json
+++ b/project/events/2026-04-14T22:15:28.209Z__23d9e027-43c8-44c8-ac74-eb1edce75ea9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "23d9e027-43c8-44c8-ac74-eb1edce75ea9",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:15:28.209Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "c9509828-d714-49fc-9db7-40d3655d1aef"
+  }
+}

--- a/project/events/2026-04-14T22:16:38.935Z__2bdabc52-f8a1-4c7c-82a1-c4dc6c915ea2.json
+++ b/project/events/2026-04-14T22:16:38.935Z__2bdabc52-f8a1-4c7c-82a1-c4dc6c915ea2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2bdabc52-f8a1-4c7c-82a1-c4dc6c915ea2",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:16:38.935Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "6798fd87-399d-45c7-b4f7-606deb3b8ef6"
+  }
+}

--- a/project/issues/plx-3c73348a-163a-436e-8b26-0da2bca510cc.json
+++ b/project/issues/plx-3c73348a-163a-436e-8b26-0da2bca510cc.json
@@ -40,10 +40,28 @@
       "author": "derek.norrbom",
       "text": "Implementation complete in working tree: updated pyproject to tactus ^0.46.0 and lupa 2.7 (required by tactus), regenerated poetry.lock with Poetry 2.3.2 on Python 3.11, and verified with poetry check (warnings only about deprecated poetry metadata fields). Leaving task in_progress until changes are landed.",
       "created_at": "2026-04-14T21:45:54.607102Z"
+    },
+    {
+      "id": "265129eb-a419-4afb-b2af-546d2a06f556",
+      "author": "derek.norrbom",
+      "text": "User requested release-path promotion. Opened PR from develop to main for merged Tactus update work; will share URL once created.",
+      "created_at": "2026-04-14T21:52:38.918694Z"
+    },
+    {
+      "id": "ad143417-3042-4c9b-b980-1032f176d8e8",
+      "author": "derek.norrbom",
+      "text": "PR opened: https://github.com/AnthusAI/Plexus/pull/167 (develop -> main), title: chore: promote develop to main.",
+      "created_at": "2026-04-14T21:52:45.556032Z"
+    },
+    {
+      "id": "cb2289ce-b262-4327-825d-0be53201063c",
+      "author": "derek.norrbom",
+      "text": "Starting follow-up repair: create fix branch from develop and resolve current failing checks on PR #167 (develop -> main) introduced by recent develop commits.",
+      "created_at": "2026-04-14T22:14:46.988659Z"
     }
   ],
   "created_at": "2026-04-14T21:44:42.101227Z",
-  "updated_at": "2026-04-14T21:45:54.607102Z",
+  "updated_at": "2026-04-14T22:14:46.988659Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
+++ b/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
@@ -1,0 +1,37 @@
+{
+  "id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "title": "Fix develop CI regressions blocking PR #167 review",
+  "description": "",
+  "type": "sub-task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-3c73348a-163a-436e-8b26-0da2bca510cc",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "a6c45874-81e3-47d1-81db-cd6d15b09da8",
+      "author": "derek.norrbom",
+      "text": "Created fix branch from develop to resolve failing feedback_contradictions tests blocking PR #167 review.",
+      "created_at": "2026-04-14T22:14:51.984842Z"
+    },
+    {
+      "id": "c9509828-d714-49fc-9db7-40d3655d1aef",
+      "author": "derek.norrbom",
+      "text": "Patched feedback_contradictions scorecard resolution for non-UUID identifiers to use Scorecard.get_by_external_id (matching report-block conventions and test expectations). Running targeted tests now.",
+      "created_at": "2026-04-14T22:15:28.208705Z"
+    },
+    {
+      "id": "6798fd87-399d-45c7-b4f7-606deb3b8ef6",
+      "author": "derek.norrbom",
+      "text": "Reviewed history: commit 71515533 intentionally changed FeedbackContradictions scorecard lookup to get_by_name. Updated tests to mock get_by_name (not get_by_external_id) and rerunning failing tests.",
+      "created_at": "2026-04-14T22:16:38.935390Z"
+    }
+  ],
+  "created_at": "2026-04-14T22:14:47.099327Z",
+  "updated_at": "2026-04-14T22:16:38.935390Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- align `FeedbackContradictions` tests with current resolver behavior introduced in recent develop commits
- update test stubs to mock `Scorecard.get_by_name` instead of `Scorecard.get_by_external_id`
- keep source behavior unchanged (no fallback path added)

## Why
Recent changes on `develop` switched non-UUID scorecard resolution in `FeedbackContradictions` to name-based lookup. The tests still mocked external-id lookup, causing failures:
- `test_feedback_contradictions_mode_returns_contradiction_payload`
- `test_feedback_contradictions_mode_aligned_includes_dataset_payload`
- `test_feedback_contradictions_applies_max_feedback_items_cap`

## Validation
- `pytest -q plexus/reports/blocks/feedback_contradictions_test.py -k "mode_returns_contradiction_payload or mode_aligned_includes_dataset_payload or applies_max_feedback_items_cap"`
- Result: 3 passed

## Kanbus
- Parent task: `plx-3c7334`
- Sub-task: `plx-659985`
