### PR TITLE
fix(dashboard-tests): stabilize guidelines saving-state assertion

### DIFF
--- a/dashboard/components/__tests__/guidelines-functionality.test.tsx
+++ b/dashboard/components/__tests__/guidelines-functionality.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom'
 // Create a simplified component that tests just the guidelines logic
 interface GuidelinesTestComponentProps {
   guidelines: string
-  onSave?: (newGuidelines: string) => void
+  onSave?: (newGuidelines: string) => void | Promise<void>
 }
 
 function GuidelinesTestComponent({ guidelines, onSave }: GuidelinesTestComponentProps) {
@@ -25,7 +25,7 @@ function GuidelinesTestComponent({ guidelines, onSave }: GuidelinesTestComponent
     setIsSaving(true)
     try {
       await new Promise(resolve => setTimeout(resolve, 10)) // Simulate async save
-      onSave?.(editValue)
+      await onSave?.(editValue)
       setIsEditing(false)
       setHasChanges(false)
     } finally {

--- a/project/events/2026-04-14T22:17:32.720Z__02cc9286-92d8-4d7f-99b9-ec091f1a6350.json
+++ b/project/events/2026-04-14T22:17:32.720Z__02cc9286-92d8-4d7f-99b9-ec091f1a6350.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "02cc9286-92d8-4d7f-99b9-ec091f1a6350",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:17:32.720Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "f7df64ef-800b-49ce-8209-8f9502d23a32"
+  }
+}

--- a/project/events/2026-04-14T22:17:32.720Z__95597cea-f65b-458d-82a2-ae465007431d.json
+++ b/project/events/2026-04-14T22:17:32.720Z__95597cea-f65b-458d-82a2-ae465007431d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "95597cea-f65b-458d-82a2-ae465007431d",
+  "issue_id": "plx-3c73348a-163a-436e-8b26-0da2bca510cc",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:17:32.720Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "fe0a80cb-5357-4f89-806d-47d5b5d8c926"
+  }
+}

--- a/project/events/2026-04-14T22:29:06.240Z__5ee470ae-56cd-4a4b-83d1-4a0572bbf156.json
+++ b/project/events/2026-04-14T22:29:06.240Z__5ee470ae-56cd-4a4b-83d1-4a0572bbf156.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5ee470ae-56cd-4a4b-83d1-4a0572bbf156",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:29:06.240Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "85c281a6-091c-4269-b281-12d0224aec00"
+  }
+}

--- a/project/events/2026-04-14T22:29:30.268Z__39d8e169-69ae-4960-8b18-b4ac83890569.json
+++ b/project/events/2026-04-14T22:29:30.268Z__39d8e169-69ae-4960-8b18-b4ac83890569.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "39d8e169-69ae-4960-8b18-b4ac83890569",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:29:30.268Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "3b4f11e7-d91c-420b-82d7-043346603208"
+  }
+}

--- a/project/events/2026-04-14T22:29:46.734Z__65807d41-f7ec-4584-baee-40ba5f3c099f.json
+++ b/project/events/2026-04-14T22:29:46.734Z__65807d41-f7ec-4584-baee-40ba5f3c099f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "65807d41-f7ec-4584-baee-40ba5f3c099f",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:29:46.734Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "a0085c77-a5d7-4d48-9e4e-966569ba665d"
+  }
+}

--- a/project/events/2026-04-14T22:30:02.837Z__9b1bffb8-e76b-43ea-9765-ceec656416fe.json
+++ b/project/events/2026-04-14T22:30:02.837Z__9b1bffb8-e76b-43ea-9765-ceec656416fe.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9b1bffb8-e76b-43ea-9765-ceec656416fe",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:30:02.837Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "5e04d499-ed9b-46c5-a139-80ec71a50ff5"
+  }
+}

--- a/project/events/2026-04-14T22:31:24.360Z__c967c59f-78a9-44c5-a239-ed68f4bc4ad6.json
+++ b/project/events/2026-04-14T22:31:24.360Z__c967c59f-78a9-44c5-a239-ed68f4bc4ad6.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c967c59f-78a9-44c5-a239-ed68f4bc4ad6",
+  "issue_id": "plx-6599855c-d0a3-42c1-bd6c-a976ca84df84",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-14T22:31:24.360Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "41fc97ae-f1c8-4811-b5bf-b7ba22a0c13c"
+  }
+}

--- a/project/issues/plx-3c73348a-163a-436e-8b26-0da2bca510cc.json
+++ b/project/issues/plx-3c73348a-163a-436e-8b26-0da2bca510cc.json
@@ -58,10 +58,16 @@
       "author": "derek.norrbom",
       "text": "Starting follow-up repair: create fix branch from develop and resolve current failing checks on PR #167 (develop -> main) introduced by recent develop commits.",
       "created_at": "2026-04-14T22:14:46.988659Z"
+    },
+    {
+      "id": "fe0a80cb-5357-4f89-806d-47d5b5d8c926",
+      "author": "derek.norrbom",
+      "text": "Opened develop repair PR for CI regressions affecting reviewability of PR #167: https://github.com/AnthusAI/Plexus/pull/168.",
+      "created_at": "2026-04-14T22:17:32.720546Z"
     }
   ],
   "created_at": "2026-04-14T21:44:42.101227Z",
-  "updated_at": "2026-04-14T22:14:46.988659Z",
+  "updated_at": "2026-04-14T22:17:32.720546Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
+++ b/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
@@ -52,10 +52,16 @@
       "author": "derek.norrbom",
       "text": "Fixed CI failure from PR #167 Dashboard Unit Tests: in guidelines-functionality test helper, await onSave during handleSave so loading-state assertion is deterministic. Local run: npm test -- --runInBand components/__tests__/guidelines-functionality.test.tsx (pass).",
       "created_at": "2026-04-14T22:29:46.733922Z"
+    },
+    {
+      "id": "5e04d499-ed9b-46c5-a139-80ec71a50ff5",
+      "author": "derek.norrbom",
+      "text": "Pushed follow-up commits to PR #168 for Dashboard Unit Tests failure from PR #167: c58f0907 (stabilize guidelines saving-state test) and 805fe849 (Kanbus artifacts).",
+      "created_at": "2026-04-14T22:30:02.836770Z"
     }
   ],
   "created_at": "2026-04-14T22:14:47.099327Z",
-  "updated_at": "2026-04-14T22:29:46.733922Z",
+  "updated_at": "2026-04-14T22:30:02.836770Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
+++ b/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
@@ -28,10 +28,28 @@
       "author": "derek.norrbom",
       "text": "Reviewed history: commit 71515533 intentionally changed FeedbackContradictions scorecard lookup to get_by_name. Updated tests to mock get_by_name (not get_by_external_id) and rerunning failing tests.",
       "created_at": "2026-04-14T22:16:38.935390Z"
+    },
+    {
+      "id": "f7df64ef-800b-49ce-8209-8f9502d23a32",
+      "author": "derek.norrbom",
+      "text": "Implemented fix on branch fix/pr167-feedback-contradictions-develop and opened PR: https://github.com/AnthusAI/Plexus/pull/168. Change updates feedback_contradictions tests to mock Scorecard.get_by_name, matching current source behavior on develop. Targeted failing tests now pass (3/3).",
+      "created_at": "2026-04-14T22:17:32.720524Z"
+    },
+    {
+      "id": "85c281a6-091c-4269-b281-12d0224aec00",
+      "author": "derek.norrbom",
+      "text": "New CI failure reported from PR #167 unit-tests job (run 24425715051, job 71359116117). Investigating log and will patch accordingly.",
+      "created_at": "2026-04-14T22:29:06.239641Z"
+    },
+    {
+      "id": "3b4f11e7-d91c-420b-82d7-043346603208",
+      "author": "derek.norrbom",
+      "text": "Investigated run 24425715051/job 71359116117: failing test is dashboard/components/__tests__/guidelines-functionality.test.tsx (loading-state assertion). Applying deterministic test-only fix.",
+      "created_at": "2026-04-14T22:29:30.268040Z"
     }
   ],
   "created_at": "2026-04-14T22:14:47.099327Z",
-  "updated_at": "2026-04-14T22:16:38.935390Z",
+  "updated_at": "2026-04-14T22:29:30.268040Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
+++ b/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
@@ -46,10 +46,16 @@
       "author": "derek.norrbom",
       "text": "Investigated run 24425715051/job 71359116117: failing test is dashboard/components/__tests__/guidelines-functionality.test.tsx (loading-state assertion). Applying deterministic test-only fix.",
       "created_at": "2026-04-14T22:29:30.268040Z"
+    },
+    {
+      "id": "a0085c77-a5d7-4d48-9e4e-966569ba665d",
+      "author": "derek.norrbom",
+      "text": "Fixed CI failure from PR #167 Dashboard Unit Tests: in guidelines-functionality test helper, await onSave during handleSave so loading-state assertion is deterministic. Local run: npm test -- --runInBand components/__tests__/guidelines-functionality.test.tsx (pass).",
+      "created_at": "2026-04-14T22:29:46.733922Z"
     }
   ],
   "created_at": "2026-04-14T22:14:47.099327Z",
-  "updated_at": "2026-04-14T22:29:30.268040Z",
+  "updated_at": "2026-04-14T22:29:46.733922Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
+++ b/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
@@ -58,10 +58,16 @@
       "author": "derek.norrbom",
       "text": "Pushed follow-up commits to PR #168 for Dashboard Unit Tests failure from PR #167: c58f0907 (stabilize guidelines saving-state test) and 805fe849 (Kanbus artifacts).",
       "created_at": "2026-04-14T22:30:02.836770Z"
+    },
+    {
+      "id": "41fc97ae-f1c8-4811-b5bf-b7ba22a0c13c",
+      "author": "derek.norrbom",
+      "text": "PR #168 was already merged, so opened a new PR from fix/pr167-feedback-contradictions-develop to develop with post-merge follow-up commits (including c58f0907 dashboard test stabilization).",
+      "created_at": "2026-04-14T22:31:24.360318Z"
     }
   ],
   "created_at": "2026-04-14T22:14:47.099327Z",
-  "updated_at": "2026-04-14T22:30:02.836770Z",
+  "updated_at": "2026-04-14T22:31:24.360318Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
## Summary
- include follow-up fix after PR #168 merge
- stabilize dashboard guidelines loading-state unit test by awaiting async `onSave` in the test helper
- include Kanbus artifact updates generated during remediation

## Context
PR #168 was already merged into `develop`, but additional commits were pushed to this branch afterward:
- `c58f0907` fix(dashboard-tests): stabilize guidelines saving-state assertion
- Kanbus artifact commits tied to the same remediation

## Validation
- `cd dashboard && npm test -- --runInBand components/__tests__/guidelines-functionality.test.tsx`
- Result: pass (11/11)

## Kanbus
- Parent task: `plx-3c7334`
- Sub-task: `plx-659985`
