### PR TITLE
fix: bump tactus to v0.46.0 in score-processor-lambda

### DIFF
--- a/project/events/2026-04-15T18:52:04.831Z__6c4c1447-9f4a-42b2-84de-4947ff09102a.json
+++ b/project/events/2026-04-15T18:52:04.831Z__6c4c1447-9f4a-42b2-84de-4947ff09102a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6c4c1447-9f4a-42b2-84de-4947ff09102a",
+  "issue_id": "plx-fdaf669a-1fab-4d7a-95d8-db635c717983",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-15T18:52:04.831Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "6b6b7e6e-5531-44f7-b5af-94591195e844"
+  }
+}

--- a/project/events/2026-04-15T18:56:21.156Z__79211cc7-361f-4129-aaf2-5e8253418c10.json
+++ b/project/events/2026-04-15T18:56:21.156Z__79211cc7-361f-4129-aaf2-5e8253418c10.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "79211cc7-361f-4129-aaf2-5e8253418c10",
+  "issue_id": "plx-fdaf669a-1fab-4d7a-95d8-db635c717983",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-15T18:56:21.156Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "4a7fc705-2e1f-4e4e-a2fd-24311450e598"
+  }
+}

--- a/project/events/2026-04-15T18:56:25.462Z__b49e4744-4b0f-40bb-9d70-9ffc8ac1cf5b.json
+++ b/project/events/2026-04-15T18:56:25.462Z__b49e4744-4b0f-40bb-9d70-9ffc8ac1cf5b.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "event_id": "b49e4744-4b0f-40bb-9d70-9ffc8ac1cf5b",
+  "issue_id": "plx-fdaf669a-1fab-4d7a-95d8-db635c717983",
+  "event_type": "comment_updated",
+  "occurred_at": "2026-04-15T18:56:25.462Z",
+  "actor_id": "derek",
+  "payload": {
+    "changed_fields": [
+      "text"
+    ],
+    "comment_author": "derek",
+    "comment_id": "4a7fc705-2e1f-4e4e-a2fd-24311450e598"
+  }
+}

--- a/project/issues/plx-fdaf669a-1fab-4d7a-95d8-db635c717983.json
+++ b/project/issues/plx-fdaf669a-1fab-4d7a-95d8-db635c717983.json
@@ -43,10 +43,22 @@
       "author": "derek.norrbom",
       "text": "Installed dependency-triage tooling into the active Python environment for future remediation work:\n- pipdeptree 2.31.0\n- pip-audit 2.10.0\n- pip-tools 7.5.3\n\nQuick verification:\n- pipdeptree --version\n- pip-audit --version\n- pip-compile --version\n\nNote: environment has pre-existing package metadata/constraint conflicts (reported by pipdeptree), which may affect global audit output quality but tools are installed and usable for requirements-level analysis.",
       "created_at": "2026-03-11T21:22:45.550894Z"
+    },
+    {
+      "id": "6b6b7e6e-5531-44f7-b5af-94591195e844",
+      "author": "derek",
+      "text": "Starting work for this request: bump tactus in score-processor-lambda to v0.46.0, build the lambda Docker image, and run smoke tests to verify install/runtime. I will record exact commands and results here.",
+      "created_at": "2026-04-15T18:52:04.830450028Z"
+    },
+    {
+      "id": "4a7fc705-2e1f-4e4e-a2fd-24311450e598",
+      "author": "derek",
+      "text": "Completed tactus bump and validation for score-processor-lambda.\n\nChanges:\n- Updated score-processor-lambda/requirements.txt from tactus==0.44.0 to tactus==0.46.0.\n\nValidation run:\n- make test (from score-processor-lambda) failed early because host shell lacked pytest (ModuleNotFoundError: No module named pytest).\n- Ran unit tests via project env: PYTHONPATH=score-processor-lambda poetry run pytest score-processor-lambda/tests/test_*.py -v -> 6 passed.\n- Ran container smoke path: make test-smoke (includes docker buildx build + smoke runner) -> PASS.\n- Smoke result summary: 10 passed, 0 failed and explicit version check logged tactus version matches: 0.46.0.\n\nNotes:\n- Container emitted a non-fatal CloudWatch handler warning (UnrecognizedClientException with test credentials), expected in local smoke context and did not affect test outcomes.",
+      "created_at": "2026-04-15T18:56:21.156846583Z"
     }
   ],
   "created_at": "2026-02-26T00:13:56.245115Z",
-  "updated_at": "2026-03-11T21:22:45.550894Z",
+  "updated_at": "2026-04-15T18:56:25.462758277Z",
   "closed_at": null,
   "custom": {
     "snyk_category": "dependency",

--- a/score-processor-lambda/requirements.txt
+++ b/score-processor-lambda/requirements.txt
@@ -12,7 +12,7 @@ langchain-aws==0.2.35
 langgraph-checkpoint-postgres==2.0.9
 
 # Tactus
-tactus==0.44.0
+tactus==0.46.0
 
 # AWS & Azure
 boto3


### PR DESCRIPTION
## Summary
- bump `score-processor-lambda/requirements.txt` from `tactus==0.44.0` to `tactus==0.46.0`
- include Kanbus artifacts for `plx-fdaf66` progress logging

## Validation
- `PYTHONPATH=score-processor-lambda poetry run pytest score-processor-lambda/tests/test_*.py -v` (6 passed)
- `make test-smoke` in `score-processor-lambda` (build + smoke passed, 10 passed / 0 failed)

## Notes
- local `make test` fails in host shell if global `pytest` is absent; unit validation above used project environment via Poetry
