### PR TITLE
docs: align report documentation with current implementation

### DIFF
--- a/.cursor/rules/reports-feature.mdc
+++ b/.cursor/rules/reports-feature.mdc
@@ -15,12 +15,12 @@ alwaysApply: false
 - Backend:
   - Report blocks: [plexus/reports/blocks/](mdc:plexus/reports/blocks)
   - Report generation service: [plexus/reports/service.py](mdc:plexus/reports/service.py)
-  - CLI commands: [plexus/cli/commands/report/](mdc:plexus/cli/commands/report)
+  - CLI commands: [plexus/cli/report/](mdc:plexus/cli/report)
   
 - Frontend:
-  - Report components: [dashboard/components/reports/](mdc:dashboard/components/reports)
+  - Report components: [dashboard/components/ReportTask.tsx](mdc:dashboard/components/ReportTask.tsx)
   - Block rendering system: [dashboard/components/blocks/](mdc:dashboard/components/blocks)
-  - Report pages: [dashboard/app/lab/reports/](mdc:dashboard/app/lab/reports)
+  - Report pages: [dashboard/app/lab/reports-dashboard/](mdc:dashboard/app/lab/reports-dashboard)
 
 ## Creating a New Report Block
 1. Backend: Create a new Python class in `plexus/reports/blocks/` that inherits from `BaseReportBlock`
@@ -123,9 +123,9 @@ score: ExampleScore
   - Shows how to format dates and percentage values
 
 ## Testing Reports
-- Use `python -m plexus.cli.CommandLineInterface report config create --name "Test Config" --file config.md`
-- Run a report with `python -m plexus.cli.CommandLineInterface report run --config "Test Config"`
-- View reports with `python -m plexus.cli.CommandLineInterface report list` and `report show <id>`
+- Use `plexus report config create --name "Test Config" --file config.md`
+- Run a report with `plexus report run --config "Test Config"`
+- View reports with `plexus report list` and `plexus report show <id>`
 
 ## Common Patterns
 - Report blocks should follow the naming convention of their Python class

--- a/dashboard/app/documentation/advanced/cli/page.tsx
+++ b/dashboard/app/documentation/advanced/cli/page.tsx
@@ -454,8 +454,7 @@ plexus results list --account "Example Account" --limit 20`}</code>
           <h2 className="text-2xl font-semibold mb-4">Report Commands</h2>
           <p className="text-muted-foreground mb-4">
             Manage report configurations and generated reports using the following commands.
-            Remember to run commands from your project root using `python -m plexus.cli.CommandLineInterface ...`
-            if you are working on the codebase locally, to avoid conflicts with globally installed versions.
+            Use the top-level `plexus report ...` command group.
           </p>
 
           <div className="space-y-6">
@@ -464,20 +463,20 @@ plexus results list --account "Example Account" --limit 20`}</code>
               <pre className="bg-muted rounded-lg mb-4">
                 <div className="code-container p-4">
                   <code>{`# List available report configurations for your account
-python -m plexus.cli.CommandLineInterface report config list
+plexus report config list
 
 # Show details of a specific report configuration (using ID or Name)
 # Note: Uses the flexible identifier system (tries ID, then Name if it looks like UUID; otherwise Name then ID)
-python -m plexus.cli.CommandLineInterface report config show <id_or_name>
+plexus report config show <id_or_name>
 
 # Create a new report configuration from a Markdown/YAML file
-python -m plexus.cli.CommandLineInterface report config create --name "My Report Config" --file ./path/to/config.md [--description "Optional description"]
+plexus report config create --name "My Report Config" --file ./path/to/config.md [--description "Optional description"]
 
 # Delete a report configuration (prompts for confirmation)
-python -m plexus.cli.CommandLineInterface report config delete <id_or_name>
+plexus report config delete <id_or_name>
 
 # Delete a report configuration (skip confirmation prompt)
-python -m plexus.cli.CommandLineInterface report config delete <id_or_name> --yes`}</code>
+plexus report config delete <id_or_name> --yes`}</code>
                 </div>
               </pre>
             </div>
@@ -486,33 +485,31 @@ python -m plexus.cli.CommandLineInterface report config delete <id_or_name> --ye
               <h3 className="text-xl font-medium mb-2">Report Generation and Viewing Commands</h3>
               <pre className="bg-muted rounded-lg mb-4">
                 <div className="code-container p-4">
-                  <code>{`# Trigger a new report generation task based on a configuration (using ID or Name for config)
-python -m plexus.cli.CommandLineInterface report run --config <config_id_or_name> [param1=value1 param2=value2 ...]
+                  <code>{`# Trigger a new report generation run based on a configuration (using ID or Name for config)
+plexus report run --config <config_id_or_name> [param1=value1 param2=value2 ...]
 
 # List generated reports, optionally filtered by configuration (using ID or Name for config filter)
 # Shows Report ID, Name, Config ID, Task ID, and Task Status
-python -m plexus.cli.CommandLineInterface report list [--config <config_id_or_name>]
+plexus report list [--config <config_id_or_name>]
 
 # Show details of a specific generated report (using ID or Name)
 # Includes Report details, linked Task status/details, rendered output, and Report Block summary
-python -m plexus.cli.CommandLineInterface report show <report_id_or_name>
+plexus report show <report_id_or_name>
 
 # Show details of the most recently created report
-python -m plexus.cli.CommandLineInterface report last`}</code>
-                </div>
-              </pre>
-            </div>
+plexus report last
 
-            <div>
-              <h3 className="text-xl font-medium mb-2">Report Block Inspection Commands</h3>
-              <pre className="bg-muted rounded-lg mb-4">
-                <div className="code-container p-4">
-                  <code>{`# List the analysis blocks for a specific report (requires Report ID)
-python -m plexus.cli.CommandLineInterface report block list <report_id>
+# Delete one report
+plexus report delete <report_id_or_name>
 
-# Show details of a specific block within a report (requires Report ID and block position or name)
-# Displays block details, output JSON (syntax highlighted), and logs
-python -m plexus.cli.CommandLineInterface report block show <report_id> <block_position_or_name>`}</code>
+# Purge old reports
+plexus report purge --older-than 30 --limit 50
+
+# Generate action items from a feedback report
+plexus report action-items [report_id]
+
+# Verify report S3 bucket access
+plexus report check-s3`}</code>
                 </div>
               </pre>
             </div>

--- a/dashboard/app/documentation/concepts/reports/page.tsx
+++ b/dashboard/app/documentation/concepts/reports/page.tsx
@@ -47,7 +47,7 @@ time_range: last_30_days
             <li>
               <strong className="text-foreground">Report (`Report`)</strong>
               <p>
-                This represents a specific instance of a report generated from a `ReportConfiguration` at a particular time, potentially with specific runtime parameters. It stores the final rendered output (e.g., the Markdown content after processing) and links to the results of the individual analysis blocks.
+                This represents a specific instance of a report generated from a `ReportConfiguration` at a particular time, potentially with specific runtime parameters. `Report.output` stores the report template markdown, while execution results are stored in the related `ReportBlock` records.
               </p>
               <p className="mt-2">If the Configuration is the recipe, the Report is the finished cake, baked on a specific day.</p>
             </li>
@@ -57,13 +57,13 @@ time_range: last_30_days
                 These are the reusable Python components that perform the actual data fetching and analysis for specific sections within a report. Examples might include `ScorePerformanceBlock`, `FeedbackTopicAnalysisBlock`, or `SentimentTrendBlock`. When a report is generated, the system executes the Python code for each block defined in the configuration.
               </p>
               <p className="mt-2">
-                Each block generates structured data (usually JSON) containing its findings (e.g., metrics, lists of feedback, chart data) and optionally logs. This structured output is stored alongside the final report.
+                Each block generates structured data (usually JSON) containing its findings (e.g., metrics, lists of feedback, chart data) and optionally logs. Large outputs and logs may be stored as S3-backed attachments and referenced from the block record.
               </p>
             </li>
             <li>
               <strong className="text-foreground">Task Integration (`Task`)</strong>
               <p>
-                Generating a report, especially one involving multiple complex analysis blocks, can take time. Plexus leverages the existing `Task` system to manage report generation as a background job. When you request a new report, a `Task` is created to handle the process. You can monitor the report's progress (Initializing, Running Blocks, Finalizing, Completed/Failed) through the standard Task interface, ensuring consistency with other background operations like Evaluations. The `Report` record itself is directly linked to its corresponding `Task` record.
+                Report generation is tracked with the existing `Task` system. Dashboard-dispatched runs typically execute in workers, while CLI runs execute synchronously in-process, but both create and update Task records for progress/status visibility. The `Report` record itself is directly linked to its corresponding `Task` record.
               </p>
             </li>
           </ul>
@@ -77,22 +77,21 @@ time_range: last_30_days
           <ol className="list-decimal pl-6 space-y-4 text-muted-foreground">
             <li>
               <strong className="text-foreground">Define a `ReportConfiguration`</strong>
-              <p>Create a template (using Markdown and block definitions) for the type of report you need. This is often done once and then reused. You might use the CLI or eventually a UI editor.</p>
               <p>Create a template (using Markdown and block definitions) for the type of report you need. This is often done once and then reused. This can be done using the Plexus CLI, the Dashboard UI, or programmatically via the API/SDK (used by AI agents).</p>
               <pre className="bg-muted rounded-lg mt-2">
                 <div className="code-container p-4">
                   <code>{`# Example: Creating a config from a file
-python -m plexus.cli.CommandLineInterface report config create --name "Agent Prof Report" --file agent_prof_report.md`}</code>
+plexus report config create --name "Agent Prof Report" --file agent_prof_report.md`}</code>
                 </div>
               </pre>
             </li>
             <li>
               <strong className="text-foreground">Run the Report</strong>
-              <p>Trigger the generation of a new `Report` based on a chosen `ReportConfiguration`. This creates a `Task` to handle the background processing.</p>
+              <p>Trigger the generation of a new `Report` based on a chosen `ReportConfiguration`. This creates/updates a `Task` for observability; worker-dispatched and synchronous CLI execution paths both use the same core generation flow.</p>
                <pre className="bg-muted rounded-lg mt-2">
                 <div className="code-container p-4">
                   <code>{`# Example: Running the report
-python -m plexus.cli.CommandLineInterface report run --config "Agent Prof Report"`}</code>
+plexus report run --config "Agent Prof Report"`}</code>
                 </div>
               </pre>
             </li>
@@ -106,7 +105,7 @@ python -m plexus.cli.CommandLineInterface report run --config "Agent Prof Report
                <pre className="bg-muted rounded-lg mt-2">
                 <div className="code-container p-4">
                   <code>{`# Example: Viewing the latest generated report
-python -m plexus.cli.CommandLineInterface report last`}</code>
+plexus report last`}</code>
                 </div>
               </pre>
             </li>

--- a/documentation/report_block_details_s3_storage.md
+++ b/documentation/report_block_details_s3_storage.md
@@ -1,229 +1,108 @@
 # Report Block Details S3 Storage
 
-This document explains the implementation of S3 storage for report block details in Plexus.
+This document describes how report block artifacts are stored and retrieved in the current reports implementation.
 
 ## Overview
 
-Previously, all log data from report blocks was stored directly in the ReportBlock record in DynamoDB. This was limiting because:
+Report blocks can produce:
 
-1. DynamoDB has a maximum size limit for attributes
-2. Large log output couldn't be stored effectively
-3. Additional files like charts, CSV data, or other supplementary materials couldn't be attached
+- execution logs (`log.txt`)
+- block output payload artifacts (`output-<report_block_id>.json`)
+- optional block-specific attachments (CSV, HTML, images, etc.)
 
-To solve this, we've implemented S3 storage for report block details, where:
+These artifacts are stored in S3 to avoid DynamoDB item-size limits and to keep report rendering responsive.
 
-1. The ReportBlock model includes a `attachedFiles` field that contains a JSON array of file paths
-2. Each path is a string that points to the S3 key where the file is stored
-3. Files are stored in the Amplify-managed S3 bucket with a structure of `reportblocks/{report_block_id}/{filename}`
+## Storage Model
 
-## Implementation Details
+### `ReportBlock.attachedFiles`
 
-### S3 Bucket
-
-We use an Amplify-managed S3 bucket for storing report block details. This bucket is defined in `dashboard/amplify/storage/resource.ts`:
-
-```typescript
-export const reportBlockDetails = defineStorage({
-  name: 'reportBlockDetails',
-  access: (allow) => ({
-    'reportblocks/*': [
-      allow.guest.to(['read']),
-      allow.authenticated.to(['read', 'write', 'delete'])
-    ]
-  })
-});
-```
-
-### ReportBlock Model
-
-The ReportBlock model in `plexus/dashboard/api/models/report_block.py` includes an `attachedFiles` field that stores a JSON array of file paths:
-
-```python
-class ReportBlock(BaseModel):
-    # ... other fields ...
-    attachedFiles = attr.Field(null=True)  # JSON array of file paths (strings)
-```
-
-### File Upload
-
-Files are uploaded to S3 and added to the ReportBlock's `attachedFiles` field using the `add_file_to_report_block` function in `plexus/reports/s3_utils.py`:
-
-```python
-def add_file_to_report_block(report_block_id, file_name, content, content_type=None, client=None):
-    # Upload the file to S3 and get the path
-    file_path = upload_report_block_file(
-        report_block_id=report_block_id,
-        file_name=file_name,
-        content=content,
-        content_type=content_type
-    )
-    
-    # Get existing attachedFiles
-    report_block = ReportBlock.get_by_id(report_block_id, client)
-    file_paths = []
-    if report_block.attachedFiles:
-        file_paths = json.loads(report_block.attachedFiles)
-    
-    # Add the new file path
-    file_paths.append(file_path)
-    
-    # Update the report block
-    report_block.update(attachedFiles=json.dumps(file_paths), client=client)
-    
-    return file_paths
-```
-
-### Using Amplify Storage APIs
-
-In the frontend, we use the Amplify Storage APIs to get URLs for the files stored in S3:
-
-```typescript
-import { Storage } from 'aws-amplify';
-
-// Get URLs for files
-const getFileUrls = async (filePaths: string[]) => {
-  return Promise.all(
-    filePaths.map(async (path) => {
-      const url = await Storage.get(path);
-      return { path, url };
-    })
-  );
-};
-```
-
-## Important Notes
-
-1. The `attachedFiles` field should always be a JSON array of string paths
-2. When adding new file attachments, always fetch the existing `attachedFiles`, append to it, and update
-3. Never store the file content directly in the `attachedFiles` field
-4. Use the Amplify Storage APIs to work with the files in the frontend
-
-## Backend Components
-
-### S3 Storage Definition
-
-The S3 bucket is defined in Amplify:
-
-```typescript
-// dashboard/amplify/storage/resource.ts
-export const reportBlockDetails = defineStorage({
-  name: 'reportBlockDetails',
-  access: (allow) => ({
-    'reportblocks/*': [
-      allow.guest.to(['read']),
-      allow.authenticated.to(['read', 'write', 'delete'])
-    ]
-  })
-});
-```
-
-### ReportBlock Model
-
-The ReportBlock model includes a `attachedFiles` field:
-
-```typescript
-// dashboard/amplify/data/resource.ts
-ReportBlock: a
-    .model({
-        // ... other fields ...
-        attachedFiles: a.json(), // JSON array of file paths (strings)
-    })
-```
-
-### Python Utilities
-
-New utility functions to manage S3 storage:
-
-1. **`plexus/reports/s3_utils.py`**:
-   - `upload_report_block_file`: Upload a file to S3 and return file info
-   - `add_file_to_report_block`: Upload a file and update the ReportBlock record
-   - `download_report_block_file`: Download and read a file from S3
-
-2. **BaseReportBlock** enhancement:
-   - `attach_detail_file`: Method to attach a file to a report block
-
-3. **Service Integration**:
-   - Updated `service.py` to automatically store log files in S3
-
-## Frontend Components
-
-### BlockDetails Component
-
-A new React component to display and interact with files:
-
-```typescript
-// dashboard/components/reports/BlockDetails.tsx
-const BlockDetails: React.FC<BlockDetailsProps> = ({ block }) => {
-  // Renders a list of detail files with view/download buttons
-  // Fetch pre-signed URLs for accessing S3 files
-  // Displays text file content in a dialog
-}
-```
-
-### ReportTask Integration
-
-The ReportTask component has been updated to:
-1. Include `attachedFiles` in GraphQL queries
-2. Render the BlockDetails component for each report block
-
-## Usage
-
-### Automatic Log Storage
-
-Logs are automatically stored in S3 when report blocks are created. The service will:
-
-1. Create a ReportBlock record
-2. Upload the log content to S3 as `log.txt`
-3. Update the ReportBlock record with the file reference
-
-### Custom File Attachment
-
-In report block code, you can attach custom files:
-
-```python
-# Example of attaching a custom file in a report block
-async def generate(self):
-    # ... generate report block data ...
-    
-    # After getting the report block ID, attach files
-    if report_block_id:
-        self.attach_detail_file(
-            report_block_id=report_block_id,
-            file_name="data.csv",
-            content=csv_content,
-            content_type="text/csv"
-        )
-    
-    return output_data, log_summary
-```
-
-## Example JSON
-
-The `attachedFiles` field contains a JSON array like:
+- `attachedFiles` is a list of S3 keys (strings), not file contents.
+- In Amplify schema, `ReportBlock.attachedFiles` is `a.string().array()`.
+- Typical values look like:
 
 ```json
 [
   "reportblocks/01234567-89ab-cdef-0123-456789abcdef/log.txt",
-  "reportblocks/01234567-89ab-cdef-0123-456789abcdef/data.csv"
+  "reportblocks/01234567-89ab-cdef-0123-456789abcdef/output-01234567-89ab-cdef-0123-456789abcdef.json"
 ]
 ```
 
-## Configuration
+### S3 key format
 
-The S3 bucket name is determined by:
+Artifacts are written under:
 
-1. Environment variable: `AMPLIFY_STORAGE_REPORTBLOCKDETAILS_BUCKET_NAME`
-2. Default fallback: `reportblockdetails-production`
+`reportblocks/{report_block_id}/{filename}`
 
-## Testing
+The bucket comes from:
 
-The implementation includes unit tests:
-- `plexus/reports/s3_utils_test.py`
+1. `AMPLIFY_STORAGE_REPORTBLOCKDETAILS_BUCKET_NAME`
+2. default `reportblockdetails-production`
 
-## Future Enhancements
+## Backend Write Flow
 
-Potential future enhancements:
-- Support for larger binary files (images, PDFs)
-- Automatic file expiration/cleanup
-- Direct file upload from the frontend
-- Enhanced file previews for more file types 
+Primary files:
+
+- `plexus/reports/service.py`
+- `plexus/reports/s3_utils.py`
+
+During report generation:
+
+1. A `ReportBlock` record is created.
+2. The block runs and returns `output` + `log`.
+3. `log.txt` is uploaded to S3 and appended to `attachedFiles`.
+4. Output JSON may also be uploaded as `output-<id>.json`.
+5. Inline `ReportBlock.output` is compacted to a preview envelope when output is attached.
+
+Compact output envelope example:
+
+```json
+{
+  "status": "ok",
+  "output_compacted": true,
+  "preview": {
+    "summary": "..."
+  },
+  "output_attachment": "reportblocks/<block-id>/output-<block-id>.json"
+}
+```
+
+The compaction behavior is controlled by:
+
+- `REPORT_BLOCK_MAX_INLINE_OUTPUT_CHARS`
+- `REPORT_BLOCK_OUTPUT_PREVIEW_CHARS`
+- `REPORT_BLOCK_ATTACH_OUTPUT_JSON_ALWAYS`
+
+## Programmatic attachment API
+
+Use `add_file_to_report_block()` in `plexus/reports/s3_utils.py` to append attachments to an existing block.
+
+High-level behavior:
+
+1. Upload file to S3 with `upload_report_block_file()`
+2. Load current `ReportBlock`
+3. Merge into existing `attachedFiles`
+4. Persist with `report_block.update(attachedFiles=file_paths, ...)`
+
+## Frontend Read Flow
+
+Primary file:
+
+- `dashboard/components/blocks/ReportBlock.tsx`
+
+Frontend uses `aws-amplify/storage` APIs:
+
+- `downloadData()` for inline file content
+- `getUrl()` for downloadable/viewable URLs
+
+Bucket routing is based on file prefix:
+
+- `reportblocks/*` -> `reportBlockDetails`
+- `scoreresults/*` -> `scoreResultAttachments`
+
+## Diagnostics
+
+CLI command:
+
+- `plexus report check-s3`
+
+This validates list/read/write/delete permissions for the report block details bucket.

--- a/documentation/source/plexus.ScorecardReport.rst
+++ b/documentation/source/plexus.ScorecardReport.rst
@@ -1,7 +1,10 @@
-plexus.ScorecardReport module
-=============================
+Scorecard report UI component
+============================
 
-.. automodule:: plexus.ScorecardReport
-   :members:
-   :undoc-members:
-   :show-inheritance:
+`ScorecardReport` is a dashboard UI block component, not a Python module.
+
+- Component: `dashboard/components/blocks/ScorecardReport.tsx`
+- Base block renderer: `dashboard/components/blocks/ReportBlock.tsx`
+- Backend report generation: `plexus/reports/service.py`
+
+The dashboard renders scorecard-style report output from `ReportBlock` records.

--- a/documentation/source/plexus.cli.ReportingCommands.rst
+++ b/documentation/source/plexus.cli.ReportingCommands.rst
@@ -1,7 +1,35 @@
-plexus.cli.ReportingCommands module
-===================================
+Report CLI commands
+===================
 
-.. automodule:: plexus.cli.ReportingCommands
-   :members:
-   :undoc-members:
-   :show-inheritance:
+The report CLI is implemented in the ``plexus.cli.report`` package and exposed
+through the top-level ``plexus report`` command group.
+
+Primary entry points:
+
+- ``plexus.cli.report.reports`` (group registration)
+- ``plexus.cli.report.report_commands`` (run/list/show/last/delete/purge)
+- ``plexus.cli.report.config_commands`` (configuration CRUD)
+- ``plexus.cli.report.action_items`` (action item extraction from reports)
+- ``plexus.cli.shared.report`` (``check-s3`` diagnostic command)
+
+Common commands:
+
+- ``plexus report config list``
+- ``plexus report config show <id_or_name>``
+- ``plexus report config create --name "My Config" --file ./config.md``
+- ``plexus report config delete <id_or_name>``
+- ``plexus report run --config <id_or_name> [param=value ...]``
+- ``plexus report list``
+- ``plexus report show <id_or_name>``
+- ``plexus report last``
+- ``plexus report delete <id_or_name>``
+- ``plexus report purge --older-than <days> --limit <n>``
+- ``plexus report action-items [report_id]``
+- ``plexus report check-s3``
+
+Notes:
+
+- ``report run`` executes synchronously in the current process while still
+  creating a Task record for progress and observability.
+- Generated report content is split between ``Report.output`` (template
+  markdown) and ``ReportBlock`` records (block outputs/logs/artifacts).

--- a/documentation/source/plexus.rst
+++ b/documentation/source/plexus.rst
@@ -38,7 +38,6 @@ Submodules
    plexus.ScoreResult_test
    plexus.Score_test
    plexus.Scorecard
-   plexus.ScorecardReport
    plexus.ScorecardResults
    plexus.ScorecardResultsAnalysis
    plexus.ScorecardResultsAnalysis_test

--- a/scripts/create_feedback_vtm_config.sh
+++ b/scripts/create_feedback_vtm_config.sh
@@ -5,7 +5,7 @@
 set -e
 cd "$(dirname "$0")/.."
 
-python -m plexus.cli.CommandLineInterface report config create \
+plexus report config create \
   --name "Feedback Analysis + Vector Topic Memory" \
   --file feedback_and_vector_topic_memory_report.md \
   --description "Feedback analysis + Vector Topic Memory (S3 Vectors clustering)"

--- a/scripts/run_feedback_vtm_report.sh
+++ b/scripts/run_feedback_vtm_report.sh
@@ -6,7 +6,7 @@
 #   Default: scorecard=1438 (SelectQuote HCS Medium-Risk), days=10
 #
 # Prerequisite: Create the report config first (one-time):
-#   python -m plexus.cli.CommandLineInterface report config create \
+#   plexus report config create \
 #     --name "Feedback Analysis + Vector Topic Memory" \
 #     --file feedback_and_vector_topic_memory_report.md
 #
@@ -24,7 +24,7 @@ echo "Config: $CONFIG_NAME"
 echo "Scorecard: $SCORECARD | Days: $DAYS"
 echo ""
 
-python -m plexus.cli.CommandLineInterface report run \
+plexus report run \
   --config "$CONFIG_NAME" \
   scorecard="$SCORECARD" \
   days="$DAYS"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update report architecture docs to reflect current `ReportConfiguration`/`Report`/`ReportBlock` behavior and storage model
- replace stale report CLI references with the current `plexus report ...` command set
- refresh dashboard report concept/CLI docs to match current sync + task-tracked execution paths
- remove stale Sphinx references to non-existent report modules and update report-related helper scripts/examples

## Validation
- ran stale-reference scan to ensure removed outdated strings:
  - `python -m plexus.cli.CommandLineInterface report`
  - `plexus.cli.ReportingCommands`
  - `plexus.ScorecardReport`
  - legacy storage API snippets
- syntax-checked updated scripts:
  - `bash -n scripts/run_feedback_vtm_report.sh`
  - `bash -n scripts/create_feedback_vtm_config.sh`

## Notes
- change is documentation/scripts only; no runtime code paths were modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9dcaab2-6069-4455-91d8-7e32ec0df2ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9dcaab2-6069-4455-91d8-7e32ec0df2ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

