### PR TITLE
fix: restore develop CI typecheck in OptimizerMetricsChart

### DIFF
--- a/dashboard/components/OptimizerMetricsChart.tsx
+++ b/dashboard/components/OptimizerMetricsChart.tsx
@@ -442,7 +442,6 @@ export default function OptimizerMetricsChart({ iterations, datasetView: control
               yAxisId="left"
               domain={[-1, 1]}
               ticks={[-1, -0.5, 0, 0.5, 1]}
-              tick={{ fill: "hsl(var(--foreground) / 0.7)", fontSize: 11 }}
               axisLine={{ stroke: "hsl(var(--foreground) / 0.25)" }}
               tickLine={{ stroke: "hsl(var(--foreground) / 0.25)" }}
               tick={<LeftAxisTick />}
@@ -453,7 +452,6 @@ export default function OptimizerMetricsChart({ iterations, datasetView: control
               orientation="right"
               domain={[0, 100]}
               ticks={[0, 25, 50, 75, 100]}
-              tick={{ fill: "hsl(var(--foreground) / 0.7)", fontSize: 11 }}
               axisLine={{ stroke: "hsl(var(--foreground) / 0.25)" }}
               tickLine={{ stroke: "hsl(var(--foreground) / 0.25)" }}
               tick={<RightAxisTick />}

--- a/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
+++ b/project/issues/plx-6599855c-d0a3-42c1-bd6c-a976ca84df84.json
@@ -64,10 +64,22 @@
       "author": "derek.norrbom",
       "text": "PR #168 was already merged, so opened a new PR from fix/pr167-feedback-contradictions-develop to develop with post-merge follow-up commits (including c58f0907 dashboard test stabilization).",
       "created_at": "2026-04-14T22:31:24.360318Z"
+    },
+    {
+      "id": "b96ea9f6-e887-47e8-a64a-91eece6f54d4",
+      "author": "ryan",
+      "text": "Taking over to restore develop CI per current request. Next: inspect latest failing GitHub Actions runs on develop, reproduce locally, patch on dedicated branch, and verify green checks before handoff.",
+      "created_at": "2026-04-19T19:55:33.245991Z"
+    },
+    {
+      "id": "fea313e9-2759-4101-a8f2-f37b76840fd2",
+      "author": "ryan",
+      "text": "Latest develop failure reproduced from GH run 24637486425: Dashboard Unit Tests typecheck error TS17001 in dashboard/components/OptimizerMetricsChart.tsx (duplicate tick prop on YAxis). Preparing minimal patch on bugfix/develop-ci-optimizer-chart-tick-props and validating with dashboard typecheck/tests.",
+      "created_at": "2026-04-19T19:56:00.554080Z"
     }
   ],
   "created_at": "2026-04-14T22:14:47.099327Z",
-  "updated_at": "2026-04-14T22:31:24.360318Z",
+  "updated_at": "2026-04-19T19:56:00.554080Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
## Summary
- remove duplicate tick props on left/right YAxis in OptimizerMetricsChart
- keep custom tick renderers (LeftAxisTick/RightAxisTick) as the single source of tick formatting
- include Kanbus tracking update for plx-659985

## Validation
- cd dashboard && npm run ci:typecheck
- cd dashboard && npm run ci:unit

## Context
Develop branch CI failed in Dashboard Unit Tests typecheck with TS17001 (duplicate JSX attributes) on dashboard/components/OptimizerMetricsChart.tsx.
