### PR TITLE
Fix in-flight report blocks pending UI

### DIFF
--- a/dashboard/components/ReportTask.tsx
+++ b/dashboard/components/ReportTask.tsx
@@ -297,6 +297,53 @@ const ReportTask: React.FC<ReportTaskProps> = ({
     return false;
   };
 
+  const hasMeaningfulBlockOutput = (output: unknown): boolean => {
+    if (!output) return false;
+
+    if (typeof output === "string") {
+      const trimmed = output.trim();
+      return trimmed.length > 0 && trimmed !== "{}";
+    }
+
+    if (typeof output !== "object") {
+      return true;
+    }
+
+    const payload = output as Record<string, any>;
+    const keys = Object.keys(payload);
+    if (keys.length === 0) return false;
+
+    if (payload.status === "pending_execution") return false;
+
+    if (payload.output_compacted === true) {
+      return typeof payload.output_attachment === "string" && payload.output_attachment.trim().length > 0;
+    }
+
+    return true;
+  };
+
+  const isBlockPending = (
+    block: ReportBlock,
+    reportComplete: boolean,
+    taskStatus?: string
+  ): boolean => {
+    if (reportComplete) return false;
+    if (taskStatus !== "RUNNING" && taskStatus !== "PENDING") return false;
+    if (hasMeaningfulBlockOutput(block.output)) return false;
+
+    const logText = (block.log || "").toLowerCase();
+    if (
+      logText.includes("processing") ||
+      logText.includes("pending") ||
+      logText.includes("waiting") ||
+      logText.includes("queued")
+    ) {
+      return true;
+    }
+
+    return true;
+  };
+
   // Update the customCodeBlockRenderer function to handle incomplete reports better
   const customCodeBlockRenderer = ({ node, inline, className, children, ...props }: any) => {
     // If it's an inline code block, render normally
@@ -334,6 +381,7 @@ const ReportTask: React.FC<ReportTaskProps> = ({
       if (blockData) {
         // Check if the report is complete
         const complete = isReportComplete(task.status, reportBlocks);
+        const blockPending = isBlockPending(blockData, complete, task.status);
         
         // Add a unique key that includes task.id to force re-render when report data changes
         const blockKey = `${task.id}-block-${blockData.id}-${blockData.position}-${Date.now()}`;
@@ -364,7 +412,8 @@ const ReportTask: React.FC<ReportTaskProps> = ({
           config: {
             ...blockData.config,
             // Force the log UI to be shown during generation
-            showLog: !complete && !!blockData.log
+            showLog: blockPending && !!blockData.log,
+            isProcessing: blockPending,
           },
           output: blockData.output,
           log: blockData.log || undefined,
@@ -373,7 +422,7 @@ const ReportTask: React.FC<ReportTaskProps> = ({
           type: blockData.type,
           attachedFiles: attachedFiles,
           // Add a note when the block is generating
-          subtitle: !complete ? "Generating..." : undefined,
+          subtitle: blockPending ? "Generating..." : undefined,
           // Add any error or warning from the block output if available
           error: blockData.output?.error,
           warning: blockData.output?.warning,

--- a/dashboard/components/blocks/AcceptanceRate.tsx
+++ b/dashboard/components/blocks/AcceptanceRate.tsx
@@ -75,6 +75,7 @@ const AUTO_SHOW_ROWS_THRESHOLD = 200;
 const AcceptanceRate: React.FC<ReportBlockProps> = (props) => {
   const [loadedOutput, setLoadedOutput] = React.useState<AcceptanceRateData | null>(null);
   const [attachmentLoadError, setAttachmentLoadError] = React.useState<string | null>(null);
+  const isProcessing = Boolean((props.config as any)?.isProcessing);
 
   let parsedOutput: AcceptanceRateData = {};
   try {
@@ -121,6 +122,13 @@ const AcceptanceRate: React.FC<ReportBlockProps> = (props) => {
   const output = loadedOutput ?? parsedOutput;
   const summary = output.summary;
   const items = Array.isArray(output.items) ? output.items : [];
+  const isLoadingCompactedOutput =
+    Boolean(parsedOutput.output_compacted) && !loadedOutput && !attachmentLoadError;
+  const hasResolvedData =
+    Boolean(summary) ||
+    items.length > 0 ||
+    Boolean(output.error) ||
+    Boolean(output.warning);
   const [showRows, setShowRows] = React.useState(items.length <= AUTO_SHOW_ROWS_THRESHOLD);
 
   React.useEffect(() => {
@@ -141,6 +149,24 @@ const AcceptanceRate: React.FC<ReportBlockProps> = (props) => {
     props.name && !props.name.startsWith("block_")
       ? props.name
       : output.block_title || "Acceptance Rate";
+
+  if ((isProcessing || isLoadingCompactedOutput) && !hasResolvedData) {
+    return (
+      <ReportBlock
+        {...props}
+        output={output as any}
+        title={title}
+        subtitle={output.block_description}
+        error={attachmentLoadError || output.error}
+        warning={output.warning}
+        dateRange={output.date_range}
+      >
+        <div className="rounded-md bg-card p-4 text-sm text-muted-foreground">
+          Report block is processing. Metrics will appear when computation completes.
+        </div>
+      </ReportBlock>
+    );
+  }
 
   return (
     <ReportBlock

--- a/dashboard/components/blocks/AcceptanceRateTimeline.tsx
+++ b/dashboard/components/blocks/AcceptanceRateTimeline.tsx
@@ -103,6 +103,7 @@ const TimelineTooltip: React.FC<any> = ({ active, payload }) => {
 const AcceptanceRateTimeline: React.FC<ReportBlockProps> = (props) => {
   const [loadedOutput, setLoadedOutput] = React.useState<AcceptanceRateTimelineData | null>(null);
   const [attachmentLoadError, setAttachmentLoadError] = React.useState<string | null>(null);
+  const isProcessing = Boolean((props.config as any)?.isProcessing);
 
   let parsedOutput: AcceptanceRateTimelineData = {};
   try {
@@ -146,6 +147,13 @@ const AcceptanceRateTimeline: React.FC<ReportBlockProps> = (props) => {
   const points = Array.isArray(output.points) ? output.points : [];
   const summary = output.summary;
   const showBucketDetails = Boolean(output.show_bucket_details);
+  const isLoadingCompactedOutput =
+    Boolean(parsedOutput.output_compacted) && !loadedOutput && !attachmentLoadError;
+  const hasResolvedData =
+    points.length > 0 ||
+    Boolean(summary) ||
+    Boolean(output.error) ||
+    Boolean(output.warning);
   const title =
     props.name && !props.name.startsWith("block_")
       ? props.name
@@ -155,6 +163,24 @@ const AcceptanceRateTimeline: React.FC<ReportBlockProps> = (props) => {
     ...point,
     acceptance: point.score_result_acceptance_rate,
   }));
+
+  if ((isProcessing || isLoadingCompactedOutput) && !hasResolvedData) {
+    return (
+      <ReportBlock
+        {...props}
+        output={output as any}
+        title={title}
+        subtitle={output.block_description}
+        error={attachmentLoadError || output.error}
+        warning={output.warning}
+        dateRange={output.date_range}
+      >
+        <div className="rounded-md bg-card p-4 text-sm text-muted-foreground">
+          Report block is processing. Timeline metrics will appear when computation completes.
+        </div>
+      </ReportBlock>
+    );
+  }
 
   return (
     <ReportBlock

--- a/dashboard/components/blocks/AcceptanceRateTimeline.tsx
+++ b/dashboard/components/blocks/AcceptanceRateTimeline.tsx
@@ -27,6 +27,7 @@ interface AcceptanceRateTimelineData {
   report_type?: string;
   block_title?: string;
   block_description?: string;
+  show_bucket_details?: boolean;
   scorecard_name?: string;
   score_name?: string | null;
   date_range?: {
@@ -144,6 +145,7 @@ const AcceptanceRateTimeline: React.FC<ReportBlockProps> = (props) => {
   const output = loadedOutput ?? parsedOutput;
   const points = Array.isArray(output.points) ? output.points : [];
   const summary = output.summary;
+  const showBucketDetails = Boolean(output.show_bucket_details);
   const title =
     props.name && !props.name.startsWith("block_")
       ? props.name
@@ -225,6 +227,46 @@ const AcceptanceRateTimeline: React.FC<ReportBlockProps> = (props) => {
             </LineChart>
           </ChartContainer>
         </div>
+
+        {showBucketDetails && (
+          <div className="rounded-md bg-card p-3">
+            <div className="mb-2 text-sm font-medium">Bucket Metrics</div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-muted-foreground">
+                    <th className="px-2 py-1 font-medium">Bucket</th>
+                    <th className="px-2 py-1 font-medium">Window</th>
+                    <th className="px-2 py-1 font-medium">Acceptance</th>
+                    <th className="px-2 py-1 font-medium">Accepted / Total</th>
+                    <th className="px-2 py-1 font-medium">Corrected</th>
+                    <th className="px-2 py-1 font-medium">Feedback (valid/total)</th>
+                    <th className="px-2 py-1 font-medium">Value Changed</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {points.map((point) => (
+                    <tr key={`${point.bucket_index}-${point.label}`}>
+                      <td className="px-2 py-1">{point.label}</td>
+                      <td className="px-2 py-1 text-muted-foreground">
+                        {new Date(point.start).toLocaleDateString()} - {new Date(point.end).toLocaleDateString()}
+                      </td>
+                      <td className="px-2 py-1">{formatPercent(point.score_result_acceptance_rate)}</td>
+                      <td className="px-2 py-1">
+                        {point.accepted_score_results} / {point.total_score_results}
+                      </td>
+                      <td className="px-2 py-1">{point.corrected_score_results}</td>
+                      <td className="px-2 py-1">
+                        {point.feedback_items_valid}/{point.feedback_items_total}
+                      </td>
+                      <td className="px-2 py-1">{point.feedback_items_changed}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
       </div>
     </ReportBlock>
   );

--- a/dashboard/components/blocks/FeedbackAlignmentTimeline.tsx
+++ b/dashboard/components/blocks/FeedbackAlignmentTimeline.tsx
@@ -33,6 +33,7 @@ interface FeedbackAlignmentTimelineData {
   mode?: "single_score" | "all_scores";
   block_title?: string;
   block_description?: string;
+  show_bucket_details?: boolean;
   scorecard_id?: string;
   scorecard_name?: string;
   date_range?: {
@@ -45,6 +46,7 @@ interface FeedbackAlignmentTimelineData {
     timezone?: string;
     week_start?: string;
     complete_only?: boolean;
+    window_mode?: "historical_complete" | "exact_window";
   };
   overall?: AlignmentSeries;
   scores?: AlignmentSeries[];
@@ -220,7 +222,7 @@ const FeedbackAlignmentTimeline: React.FC<ReportBlockProps> = (props) => {
     return scores.find((score) => score.score_id === selectedSeries) || null;
   }, [data.overall, isSingleScoreMode, scores, selectedSeries]);
 
-  const chartData = activeSeries?.points || [];
+  const chartData = React.useMemo(() => activeSeries?.points || [], [activeSeries?.points]);
   const seriesLabel = activeSeries?.score_name || "Overall";
   const selectedSeriesLabel = selectedSeries === OVERALL_SERIES_KEY
     ? "Overall"
@@ -340,6 +342,11 @@ const FeedbackAlignmentTimeline: React.FC<ReportBlockProps> = (props) => {
   const hasRenderableAc1Points = renderableAc1Points.length > 0;
   const canDrawConnectingLine = renderableAc1Points.length > 1;
   const hasSeriesSelector = !isSingleScoreMode && scores.length > 0;
+  const showBucketDetails = Boolean(data.show_bucket_details);
+  const bucketModeCopy =
+    data.bucket_policy?.window_mode === "exact_window"
+      ? "exact-window coverage"
+      : "complete periods only";
   const accuracyGaugeSegments = React.useMemo(
     () => GaugeThresholdComputer.createSegments(GaugeThresholdComputer.computeThresholds({})),
     []
@@ -365,7 +372,7 @@ const FeedbackAlignmentTimeline: React.FC<ReportBlockProps> = (props) => {
             <div>
               <strong className="text-foreground">Buckets:</strong>{" "}
               {isLoadingCompactedOutput ? "loading..." : data.bucket_policy?.bucket_count ?? chartData.length} x{" "}
-              {data.bucket_policy?.bucket_type || "trailing_7d"} (complete periods only)
+              {data.bucket_policy?.bucket_type || "trailing_7d"} ({bucketModeCopy})
             </div>
           </div>
 
@@ -390,8 +397,8 @@ const FeedbackAlignmentTimeline: React.FC<ReportBlockProps> = (props) => {
         </div>
 
         <p className="text-sm text-muted-foreground">
-          This report shows how feedback alignment changes over complete historical buckets for the selected
-          series, using Gwet&apos;s AC1 as the primary trend metric.
+          This report shows how feedback alignment changes over time for the selected series, using
+          Gwet&apos;s AC1 as the primary trend metric.
         </p>
 
         {data.message && <p className="text-xs text-muted-foreground">{data.message}</p>}
@@ -485,70 +492,72 @@ const FeedbackAlignmentTimeline: React.FC<ReportBlockProps> = (props) => {
             <p className="mt-2 text-xs text-muted-foreground">
               Dot size indicates the number of feedback items in each bucket.
             </p>
-            <div className="mt-4 w-full space-y-3">
-              <h4 className="text-sm font-medium">Bucket Details</h4>
-              {chartData.map((point) => {
-                const hasBucketData =
-                  point.item_count > 0 && point.ac1 !== null && point.accuracy !== null;
+            {showBucketDetails && (
+              <div className="mt-4 w-full space-y-3">
+                <h4 className="text-sm font-medium">Bucket Details</h4>
+                {chartData.map((point) => {
+                  const hasBucketData =
+                    point.item_count > 0 && point.ac1 !== null && point.accuracy !== null;
 
-                return (
-                  <div
-                    key={`${seriesLabel}-${point.bucket_index}-${point.label}`}
-                    className="rounded-md bg-card p-3"
-                  >
-                    <div className="mb-3">
-                      <div className="text-sm font-medium">{point.label}</div>
-                      <div className="text-xs text-muted-foreground">
-                        {formatBucketRange(point.start, point.end)}
-                      </div>
-                      <div className="text-xs text-muted-foreground mt-1">
-                        Items: {point.item_count}
-                      </div>
-                    </div>
-
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
-                      <div className="flex justify-center">
-                        <div style={{ width: "190px" }}>
-                          <Gauge
-                            value={point.ac1 ?? undefined}
-                            title="Alignment"
-                            valueUnit=""
-                            min={AC1_MIN}
-                            max={AC1_MAX}
-                            decimalPlaces={2}
-                            segments={ac1GaugeSegments}
-                            showTicks
-                          />
+                  return (
+                    <div
+                      key={`${seriesLabel}-${point.bucket_index}-${point.label}`}
+                      className="rounded-md bg-card p-3"
+                    >
+                      <div className="mb-3">
+                        <div className="text-sm font-medium">{point.label}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatBucketRange(point.start, point.end)}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1">
+                          Items: {point.item_count}
                         </div>
                       </div>
-                      <div className="flex justify-center">
-                        <div style={{ width: "190px" }}>
-                          <Gauge
-                            value={point.accuracy ?? undefined}
-                            title="Accuracy"
-                            min={0}
-                            max={100}
-                            segments={accuracyGaugeSegments}
-                            showTicks
-                          />
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
+                        <div className="flex justify-center">
+                          <div style={{ width: "190px" }}>
+                            <Gauge
+                              value={point.ac1 ?? undefined}
+                              title="Alignment"
+                              valueUnit=""
+                              min={AC1_MIN}
+                              max={AC1_MAX}
+                              decimalPlaces={2}
+                              segments={ac1GaugeSegments}
+                              showTicks
+                            />
+                          </div>
+                        </div>
+                        <div className="flex justify-center">
+                          <div style={{ width: "190px" }}>
+                            <Gauge
+                              value={point.accuracy ?? undefined}
+                              title="Accuracy"
+                              min={0}
+                              max={100}
+                              segments={accuracyGaugeSegments}
+                              showTicks
+                            />
+                          </div>
                         </div>
                       </div>
-                    </div>
 
-                    <div className="space-y-2">
-                      <div className="text-xs text-muted-foreground">Raw Agreement</div>
-                      <RawAgreementBar agreements={point.agreements} totalItems={point.item_count} />
-                    </div>
+                      <div className="space-y-2">
+                        <div className="text-xs text-muted-foreground">Raw Agreement</div>
+                        <RawAgreementBar agreements={point.agreements} totalItems={point.item_count} />
+                      </div>
 
-                    {!hasBucketData && (
-                      <p className="mt-2 text-xs text-amber-700">
-                        No data for this bucket.
-                      </p>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+                      {!hasBucketData && (
+                        <p className="mt-2 text-xs text-amber-700">
+                          No data for this bucket.
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/dashboard/components/blocks/FeedbackAlignmentTimeline.tsx
+++ b/dashboard/components/blocks/FeedbackAlignmentTimeline.tsx
@@ -115,6 +115,7 @@ const FeedbackAlignmentTimeline: React.FC<ReportBlockProps> = (props) => {
   const [attachmentLoadError, setAttachmentLoadError] = React.useState<string | null>(null);
   const [selectedSeries, setSelectedSeries] = React.useState<string>(OVERALL_SERIES_KEY);
   const [isSeriesLoading, setIsSeriesLoading] = React.useState(false);
+  const isProcessing = Boolean((props.config as any)?.isProcessing);
 
   let parsedOutput: FeedbackAlignmentTimelineData = {};
   try {
@@ -343,6 +344,11 @@ const FeedbackAlignmentTimeline: React.FC<ReportBlockProps> = (props) => {
   const canDrawConnectingLine = renderableAc1Points.length > 1;
   const hasSeriesSelector = !isSingleScoreMode && scores.length > 0;
   const showBucketDetails = Boolean(data.show_bucket_details);
+  const hasResolvedData =
+    hasChartData ||
+    Boolean(data.message) ||
+    Boolean(data.error) ||
+    Boolean(data.warning);
   const bucketModeCopy =
     data.bucket_policy?.window_mode === "exact_window"
       ? "exact-window coverage"
@@ -406,6 +412,10 @@ const FeedbackAlignmentTimeline: React.FC<ReportBlockProps> = (props) => {
         {isLoadingCompactedOutput ? (
           <div className="rounded-md border bg-muted/20 p-4 text-sm text-muted-foreground">
             Loading bucketed alignment data...
+          </div>
+        ) : isProcessing && !hasResolvedData ? (
+          <div className="rounded-md border bg-muted/20 p-4 text-sm text-muted-foreground">
+            Report block is processing. Timeline data will appear when computation completes.
           </div>
         ) : isSeriesLoading ? (
           <div className="rounded-md bg-muted/20 p-4 text-sm text-muted-foreground">

--- a/dashboard/components/blocks/RecentFeedback.tsx
+++ b/dashboard/components/blocks/RecentFeedback.tsx
@@ -52,6 +52,7 @@ const AUTO_SHOW_ROWS_THRESHOLD = 200;
 const RecentFeedback: React.FC<ReportBlockProps> = (props) => {
   const [loadedOutput, setLoadedOutput] = React.useState<RecentFeedbackData | null>(null);
   const [attachmentLoadError, setAttachmentLoadError] = React.useState<string | null>(null);
+  const isProcessing = Boolean((props.config as any)?.isProcessing);
 
   let parsedOutput: RecentFeedbackData = {};
   try {
@@ -98,6 +99,13 @@ const RecentFeedback: React.FC<ReportBlockProps> = (props) => {
   const output = loadedOutput ?? parsedOutput;
   const summary = output.summary;
   const items = Array.isArray(output.items) ? output.items : [];
+  const isLoadingCompactedOutput =
+    Boolean(parsedOutput.output_compacted) && !loadedOutput && !attachmentLoadError;
+  const hasResolvedData =
+    Boolean(summary) ||
+    items.length > 0 ||
+    Boolean(output.error) ||
+    Boolean(output.warning);
   const [showRows, setShowRows] = React.useState(items.length <= AUTO_SHOW_ROWS_THRESHOLD);
 
   React.useEffect(() => {
@@ -116,6 +124,24 @@ const RecentFeedback: React.FC<ReportBlockProps> = (props) => {
     props.name && !props.name.startsWith("block_")
       ? props.name
       : output.block_title || "Recent Feedback";
+
+  if ((isProcessing || isLoadingCompactedOutput) && !hasResolvedData) {
+    return (
+      <ReportBlock
+        {...props}
+        output={output as any}
+        title={title}
+        subtitle={output.block_description}
+        error={attachmentLoadError || output.error}
+        warning={output.warning}
+        dateRange={output.date_range}
+      >
+        <div className="rounded-md bg-card p-4 text-sm text-muted-foreground">
+          Report block is processing. Feedback metrics will appear when computation completes.
+        </div>
+      </ReportBlock>
+    );
+  }
 
   return (
     <ReportBlock

--- a/plexus/cli/feedback/feedback_report.py
+++ b/plexus/cli/feedback/feedback_report.py
@@ -5,20 +5,24 @@ Direct feedback report commands (no report template required).
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import click
 import yaml
 
 from plexus.cli.feedback.report_runner import (
+    build_window_config,
     run_feedback_report_block,
     summarize_timeline_feedback_volume,
 )
+from plexus.cli.report.utils import resolve_account_id_for_command
 from plexus.cli.shared.client_utils import create_client
 from plexus.cli.shared.console import console
 from plexus.reports.service import (
     decode_programmatic_run_payload,
     run_programmatic_block_and_persist,
+    run_programmatic_report_and_persist,
 )
 
 
@@ -66,6 +70,14 @@ def _coerce_optional_int(value: Optional[int], name: str) -> Optional[int]:
     except (TypeError, ValueError) as exc:
         raise click.ClickException(f"'{name}' must be an integer.") from exc
     return int_value
+
+
+def _window_label(days: Optional[int], start_date: Optional[str], end_date: Optional[str]) -> str:
+    if start_date and end_date:
+        return f"{start_date} to {end_date}"
+    if days is not None:
+        return f"Last {days} days"
+    return "Default window"
 
 
 @click.group(name="report")
@@ -397,6 +409,12 @@ def contradictions(
 @click.option("--bucket-count", type=int, default=12, show_default=True)
 @click.option("--timezone", "timezone_name", default="UTC", show_default=True)
 @click.option("--week-start", type=click.Choice(["monday", "sunday"]), default="monday", show_default=True)
+@click.option(
+    "--show-bucket-details/--chart-only",
+    default=False,
+    show_default=True,
+    help="Show or hide per-bucket details below the timeline chart.",
+)
 @click.option("--days", type=int, required=False, help="Trailing window in days.")
 @click.option("--start-date", required=False, help="Inclusive start date in YYYY-MM-DD.")
 @click.option("--end-date", required=False, help="Inclusive end date in YYYY-MM-DD.")
@@ -414,6 +432,7 @@ def timeline(
     bucket_count: int,
     timezone_name: str,
     week_start: str,
+    show_bucket_details: bool,
     days: Optional[int],
     start_date: Optional[str],
     end_date: Optional[str],
@@ -443,6 +462,7 @@ def timeline(
             "bucket_count": bucket_count,
             "timezone": timezone_name,
             "week_start": week_start,
+            "show_bucket_details": show_bucket_details,
         },
     )
     _print_result(title="FeedbackAlignmentTimeline", result=result, output_format=output_format, include_log=include_log)
@@ -518,6 +538,12 @@ def volume(
 @click.option("--score", required=False, help="Optional score identifier (id or external id).")
 @click.option("--bucket-type", default="trailing_7d", show_default=True)
 @click.option("--bucket-count", type=int, default=12, show_default=True)
+@click.option(
+    "--show-bucket-details/--chart-only",
+    default=False,
+    show_default=True,
+    help="Show or hide per-bucket metrics details below the chart.",
+)
 @click.option("--days", type=int, required=False, help="Trailing window in days.")
 @click.option("--start-date", required=False, help="Inclusive start date in YYYY-MM-DD.")
 @click.option("--end-date", required=False, help="Inclusive end date in YYYY-MM-DD.")
@@ -535,6 +561,7 @@ def acceptance_rate_timeline(
     score: Optional[str],
     bucket_type: str,
     bucket_count: int,
+    show_bucket_details: bool,
     days: Optional[int],
     start_date: Optional[str],
     end_date: Optional[str],
@@ -563,9 +590,173 @@ def acceptance_rate_timeline(
         extra_config={
             "bucket_type": bucket_type,
             "bucket_count": bucket_count,
+            "show_bucket_details": show_bucket_details,
             "fetch_shard_days": fetch_shard_days,
             "fetch_shard_concurrency": fetch_shard_concurrency,
             "fetch_max_inflight_process": fetch_max_inflight_process,
         },
     )
     _print_result(title="AcceptanceRateTimeline", result=result, output_format=output_format, include_log=include_log)
+
+
+@report.command(name="overview")
+@click.option("--scorecard", required=True, help="Scorecard identifier (id, external id, or key).")
+@click.option("--score", required=True, help="Score identifier (id or external id).")
+@click.option("--days", type=int, required=False, help="Trailing window in days.")
+@click.option("--start-date", required=False, help="Inclusive start date in YYYY-MM-DD.")
+@click.option("--end-date", required=False, help="Inclusive end date in YYYY-MM-DD.")
+@click.option("--bucket-type", default="trailing_7d", show_default=True)
+@click.option("--timezone", "timezone_name", default="UTC", show_default=True)
+@click.option("--week-start", type=click.Choice(["monday", "sunday"]), default="monday", show_default=True)
+@click.option(
+    "--show-bucket-details/--chart-only",
+    default=False,
+    show_default=True,
+    help="Show or hide per-bucket details for the top timeline block.",
+)
+@click.option("--max-items", type=int, default=200, show_default=True, help="Maximum acceptance-rate item rows.")
+@click.option(
+    "--mode",
+    type=click.Choice(["contradictions", "aligned"]),
+    default="contradictions",
+    show_default=True,
+    help="Feedback contradictions block mode.",
+)
+@click.option("--max-feedback-items", type=int, default=400, show_default=True)
+@click.option("--num-topics", type=int, default=8, show_default=True)
+@click.option("--max-concurrent", type=int, default=20, show_default=True)
+@click.option("--name", "report_name", required=False, help="Optional report name override.")
+@click.option("--account", "account_identifier", default=None, help="Optional account key or id.")
+@click.option("--format", "output_format", type=click.Choice(["json", "yaml"]), default="json", show_default=True)
+def overview(
+    scorecard: str,
+    score: str,
+    days: Optional[int],
+    start_date: Optional[str],
+    end_date: Optional[str],
+    bucket_type: str,
+    timezone_name: str,
+    week_start: str,
+    show_bucket_details: bool,
+    max_items: int,
+    mode: str,
+    max_feedback_items: int,
+    num_topics: int,
+    max_concurrent: int,
+    report_name: Optional[str],
+    account_identifier: Optional[str],
+    output_format: str,
+) -> None:
+    """
+    Generate a 3-block score overview report:
+    FeedbackAlignmentTimeline, AcceptanceRate, FeedbackContradictions.
+    """
+    client = create_client()
+    if not client:
+        raise click.ClickException("Could not create dashboard client.")
+    account_id = resolve_account_id_for_command(client, account_identifier)
+
+    window_config = build_window_config(
+        days=_coerce_optional_int(days, "days"),
+        start_date=start_date,
+        end_date=end_date,
+    )
+    shared_scope: Dict[str, Any] = {
+        "scorecard": str(scorecard).strip(),
+        "score": str(score).strip(),
+        **window_config,
+    }
+
+    timeline_config: Dict[str, Any] = {
+        **shared_scope,
+        "bucket_type": bucket_type,
+        "timezone": timezone_name,
+        "week_start": week_start,
+        "show_bucket_details": show_bucket_details,
+    }
+    acceptance_config: Dict[str, Any] = {
+        **shared_scope,
+        "include_item_acceptance_rate": True,
+        "max_items": max_items,
+    }
+    contradictions_config: Dict[str, Any] = {
+        **shared_scope,
+        "mode": mode,
+        "max_feedback_items": max_feedback_items,
+        "num_topics": num_topics,
+        "max_concurrent": max_concurrent,
+    }
+
+    timestamp_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    generated_name = (
+        f"Feedback Overview | Scorecard {shared_scope['scorecard']} | "
+        f"Score {shared_scope['score']} | {_window_label(days, start_date, end_date)} | {timestamp_utc}"
+    )
+    final_report_name = str(report_name).strip() if report_name and str(report_name).strip() else generated_name
+
+    report_id, first_error = run_programmatic_report_and_persist(
+        report_name=final_report_name,
+        block_definitions=[
+            {
+                "class_name": "FeedbackAlignmentTimeline",
+                "block_name": "Feedback Alignment Timeline",
+                "config": timeline_config,
+            },
+            {
+                "class_name": "AcceptanceRate",
+                "block_name": "Acceptance Rate",
+                "config": acceptance_config,
+            },
+            {
+                "class_name": "FeedbackContradictions",
+                "block_name": "Feedback Contradictions",
+                "config": contradictions_config,
+            },
+        ],
+        account_id=account_id,
+        client=client,
+        report_parameters={
+            **shared_scope,
+            "bucket_type": bucket_type,
+            "timezone": timezone_name,
+            "week_start": week_start,
+            "show_bucket_details": show_bucket_details,
+            "acceptance_max_items": max_items,
+            "contradictions_mode": mode,
+            "max_feedback_items": max_feedback_items,
+            "num_topics": num_topics,
+            "max_concurrent": max_concurrent,
+        },
+        display_title="Feedback Overview",
+        display_subtitle=_window_label(days, start_date, end_date),
+    )
+
+    if not report_id:
+        raise click.ClickException(first_error or "Overview report generation failed.")
+
+    dashboard_url = client.generate_deep_link("/lab/reports/{reportId}", {"reportId": report_id})
+    payload = {
+        "status": "success" if not first_error else "partial_success",
+        "report_id": report_id,
+        "report_name": final_report_name,
+        "dashboard_url": dashboard_url,
+        "blocks": [
+            "FeedbackAlignmentTimeline",
+            "AcceptanceRate",
+            "FeedbackContradictions",
+        ],
+        "shared_scope": shared_scope,
+        "timeline": {
+            "bucket_type": bucket_type,
+            "timezone": timezone_name,
+            "week_start": week_start,
+            "show_bucket_details": show_bucket_details,
+        },
+    }
+    if first_error:
+        payload["error"] = first_error
+
+    if output_format == "yaml":
+        console.print(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True))
+    else:
+        console.print(json.dumps(payload, indent=2, default=str))

--- a/plexus/cli/feedback/feedback_report.py
+++ b/plexus/cli/feedback/feedback_report.py
@@ -689,8 +689,8 @@ def overview(
 
     timestamp_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     generated_name = (
-        f"Feedback Overview | Scorecard {shared_scope['scorecard']} | "
-        f"Score {shared_scope['score']} | {_window_label(days, start_date, end_date)} | {timestamp_utc}"
+        f"Scorecard {shared_scope['scorecard']} | Score {shared_scope['score']} | "
+        f"Feedback Overview | {_window_label(days, start_date, end_date)} | {timestamp_utc}"
     )
     final_report_name = str(report_name).strip() if report_name and str(report_name).strip() else generated_name
 

--- a/plexus/cli/feedback/feedback_report_test.py
+++ b/plexus/cli/feedback/feedback_report_test.py
@@ -94,3 +94,94 @@ def test_acceptance_rate_timeline_uses_default_parallel_fetch_options(mock_run_f
     assert kwargs["extra_config"]["fetch_shard_days"] == 30
     assert kwargs["extra_config"]["fetch_shard_concurrency"] == 4
     assert kwargs["extra_config"]["fetch_max_inflight_process"] == 8
+
+
+@patch("plexus.cli.feedback.feedback_report.run_feedback_report_block")
+def test_feedback_alignment_timeline_show_bucket_details_flag_pass_through(mock_run_feedback_report_block):
+    runner = CliRunner()
+    mock_run_feedback_report_block.return_value = {"status": "success", "output": {"points": []}}
+
+    result = runner.invoke(
+        report,
+        [
+            "timeline",
+            "--scorecard",
+            "1438",
+            "--days",
+            "30",
+            "--show-bucket-details",
+        ],
+    )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_run_feedback_report_block.call_args
+    assert kwargs["extra_config"]["show_bucket_details"] is True
+
+
+@patch("plexus.cli.feedback.feedback_report.run_feedback_report_block")
+def test_acceptance_rate_timeline_show_bucket_details_flag_pass_through(mock_run_feedback_report_block):
+    runner = CliRunner()
+    mock_run_feedback_report_block.return_value = {"status": "success", "output": {"points": []}}
+
+    result = runner.invoke(
+        report,
+        [
+            "acceptance-rate-timeline",
+            "--scorecard",
+            "1438",
+            "--days",
+            "30",
+            "--show-bucket-details",
+        ],
+    )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_run_feedback_report_block.call_args
+    assert kwargs["extra_config"]["show_bucket_details"] is True
+
+
+@patch("plexus.cli.feedback.feedback_report.resolve_account_id_for_command")
+@patch("plexus.cli.feedback.feedback_report.run_programmatic_report_and_persist")
+@patch("plexus.cli.feedback.feedback_report.create_client")
+def test_overview_builds_three_blocks_in_required_order_with_shared_window(
+    mock_create_client,
+    mock_run_programmatic_report_and_persist,
+    mock_resolve_account_id_for_command,
+):
+    runner = CliRunner()
+    mock_client = MagicMock()
+    mock_client.generate_deep_link.return_value = "https://app.plexus.ai/lab/reports/report-123"
+    mock_create_client.return_value = mock_client
+    mock_resolve_account_id_for_command.return_value = "acct-1"
+    mock_run_programmatic_report_and_persist.return_value = ("report-123", None)
+
+    result = runner.invoke(
+        report,
+        [
+            "overview",
+            "--scorecard",
+            "1438",
+            "--score",
+            "45813",
+            "--days",
+            "90",
+            "--show-bucket-details",
+        ],
+    )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_run_programmatic_report_and_persist.call_args
+    block_definitions = kwargs["block_definitions"]
+    assert [block["class_name"] for block in block_definitions] == [
+        "FeedbackAlignmentTimeline",
+        "AcceptanceRate",
+        "FeedbackContradictions",
+    ]
+
+    for block in block_definitions:
+        assert block["config"]["scorecard"] == "1438"
+        assert block["config"]["score"] == "45813"
+        assert block["config"]["days"] == 90
+
+    assert block_definitions[0]["config"]["show_bucket_details"] is True
+    assert block_definitions[1]["config"]["include_item_acceptance_rate"] is True

--- a/plexus/reports/blocks/acceptance_rate_timeline.py
+++ b/plexus/reports/blocks/acceptance_rate_timeline.py
@@ -32,6 +32,19 @@ class AcceptanceRateTimeline(FeedbackRatesBase):
         "trailing_30d": 30,
     }
 
+    @staticmethod
+    def _parse_bool(value: Any, *, default: bool = False) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        value_str = str(value).strip().lower()
+        if value_str in {"1", "true", "yes", "y", "on"}:
+            return True
+        if value_str in {"0", "false", "no", "n", "off"}:
+            return False
+        return default
+
     async def generate(self) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
         self.log_messages = []
         try:
@@ -43,6 +56,12 @@ class AcceptanceRateTimeline(FeedbackRatesBase):
             bucket_type = str(self._get_param("bucket_type") or "trailing_7d").strip().lower()
             bucket_count_raw = self._get_param("bucket_count")
             bucket_count = int(bucket_count_raw) if bucket_count_raw is not None else 12
+            show_bucket_details_raw = (
+                self.config.get("show_bucket_details")
+                if isinstance(self.config, dict) and "show_bucket_details" in self.config
+                else self._get_param("show_bucket_details")
+            )
+            show_bucket_details = self._parse_bool(show_bucket_details_raw, default=False)
 
             if bucket_type not in self.TRAILING_BUCKET_DAYS:
                 supported = sorted(self.TRAILING_BUCKET_DAYS.keys())
@@ -141,6 +160,7 @@ class AcceptanceRateTimeline(FeedbackRatesBase):
                 "scorecard_name": scorecard.name,
                 "score_id": resolved_score_id,
                 "score_name": resolved_score_name,
+                "show_bucket_details": show_bucket_details,
                 "bucket_policy": {
                     "bucket_type": bucket_type,
                     "bucket_count": bucket_count,

--- a/plexus/reports/blocks/acceptance_rate_timeline_test.py
+++ b/plexus/reports/blocks/acceptance_rate_timeline_test.py
@@ -22,6 +22,7 @@ async def test_acceptance_rate_timeline_buckets_and_counts(mock_api_client):
             "end_date": "2026-04-15",
             "bucket_type": "trailing_7d",
             "bucket_count": 2,
+            "show_bucket_details": True,
         },
         params={"account_id": "acct-1"},
         api_client=mock_api_client,
@@ -84,6 +85,7 @@ async def test_acceptance_rate_timeline_buckets_and_counts(mock_api_client):
         output, _ = await block.generate()
 
     assert output["report_type"] == "acceptance_rate_timeline"
+    assert output["show_bucket_details"] is True
     points = output["points"]
     assert len(points) == 2
 

--- a/plexus/reports/blocks/feedback_alignment_timeline.py
+++ b/plexus/reports/blocks/feedback_alignment_timeline.py
@@ -31,11 +31,14 @@ class FeedbackAlignmentTimeline(BaseReportBlock):
     - scorecard only: all scores on the scorecard
     - scorecard + score/score_id: single-score mode
 
-    Bucket policy supports trailing complete windows and calendar-aligned complete windows.
+    Bucket policy supports:
+    - complete historical buckets (default when no explicit window is provided)
+    - exact-window buckets (when days or start_date/end_date is provided)
     """
 
     DEFAULT_NAME = "Feedback Alignment Timeline"
-    DEFAULT_DESCRIPTION = "Alignment metrics over complete historical time buckets"
+    DEFAULT_DESCRIPTION = "Alignment metrics over time"
+    DEFAULT_DAYS = 30
 
     TRAILING_BUCKET_DAYS: Dict[str, int] = {
         "trailing_1d": 1,
@@ -50,33 +53,26 @@ class FeedbackAlignmentTimeline(BaseReportBlock):
         self.log_messages = []
 
         try:
-            scorecard_identifier = self.config.get("scorecard")
+            scorecard_identifier = self._get_param("scorecard")
             if not scorecard_identifier:
                 raise ValueError("'scorecard' is required in block configuration.")
 
-            score_identifier = (
-                self.config.get("score_id")
-                or self.config.get("score")
-                or self.params.get("score_id")
-                or self.params.get("score")
-                or self.params.get("param_score_id")
-                or self.params.get("param_score")
-            )
+            score_identifier = self._get_param("score_id") or self._get_param("score")
             if score_identifier is not None:
                 score_identifier = str(score_identifier).strip() or None
 
-            bucket_type = str(self.config.get("bucket_type", "trailing_7d")).strip().lower()
-            bucket_count = int(self.config.get("bucket_count", 12))
-            timezone_name = str(self.config.get("timezone", "UTC")).strip()
-            week_start = str(self.config.get("week_start", "monday")).strip().lower()
+            bucket_type = str(self._get_param("bucket_type") or "trailing_7d").strip().lower()
+            requested_bucket_count = self._get_param("bucket_count")
+            bucket_count = int(requested_bucket_count) if requested_bucket_count is not None else 12
+            timezone_name = str(self._get_param("timezone") or "UTC").strip()
+            week_start = str(self._get_param("week_start") or "monday").strip().lower()
+            show_bucket_details = self._parse_bool(self._get_param("show_bucket_details"), default=False)
 
             if bucket_type not in self.TRAILING_BUCKET_DAYS and bucket_type not in self.CALENDAR_BUCKET_TYPES:
                 supported = sorted(list(self.TRAILING_BUCKET_DAYS.keys()) + list(self.CALENDAR_BUCKET_TYPES))
                 raise ValueError(
                     f"Unsupported bucket_type '{bucket_type}'. Supported values: {supported}"
                 )
-            if bucket_count <= 0:
-                raise ValueError("'bucket_count' must be a positive integer.")
             if week_start not in self.WEEK_START_INDEX:
                 raise ValueError("'week_start' must be either 'monday' or 'sunday'.")
 
@@ -85,27 +81,71 @@ class FeedbackAlignmentTimeline(BaseReportBlock):
             except Exception as exc:
                 raise ValueError(f"Invalid timezone '{timezone_name}': {exc}") from exc
 
-            now_local = self._now_utc().astimezone(tzinfo)
-            buckets = self._build_buckets(
-                now_local=now_local,
-                bucket_type=bucket_type,
-                bucket_count=bucket_count,
-                week_start=week_start,
-            )
+            has_explicit_window = self._has_explicit_window()
+            if has_explicit_window:
+                window_start_utc, window_end_utc = self._resolve_window_utc()
+                window_start_local = window_start_utc.astimezone(tzinfo)
+                window_end_local = window_end_utc.astimezone(tzinfo)
+                if window_end_local <= window_start_local:
+                    raise ValueError("Resolved time window must have end > start.")
+
+                buckets = self._build_exact_window_buckets(
+                    start_local=window_start_local,
+                    end_local=window_end_local,
+                    bucket_type=bucket_type,
+                    week_start=week_start,
+                )
+                window_mode = "exact_window"
+                complete_only = False
+                if requested_bucket_count is not None:
+                    self._log(
+                        "Ignoring 'bucket_count' because an explicit window was provided (days/start_date/end_date).",
+                        level="INFO",
+                    )
+                range_start_utc = window_start_utc
+                # Feedback item query uses inclusive bounds.
+                range_end_query_utc = window_end_utc
+                date_range_end_utc = window_end_utc
+            else:
+                if bucket_count <= 0:
+                    raise ValueError("'bucket_count' must be a positive integer.")
+                now_local = self._now_utc().astimezone(tzinfo)
+                buckets = self._build_buckets(
+                    now_local=now_local,
+                    bucket_type=bucket_type,
+                    bucket_count=bucket_count,
+                    week_start=week_start,
+                )
+                window_mode = "historical_complete"
+                complete_only = True
+                range_start_utc = buckets[0].start_local.astimezone(timezone.utc)
+                # Query end is inclusive; subtract 1 microsecond to remain in the last bucket.
+                range_end_query_utc = (
+                    buckets[-1].end_local.astimezone(timezone.utc) - timedelta(microseconds=1)
+                )
+                date_range_end_utc = buckets[-1].end_local.astimezone(timezone.utc)
+
             if not buckets:
                 raise ValueError("No time buckets were generated.")
 
-            range_start_utc = buckets[0].start_local.astimezone(timezone.utc)
-            # Query end is inclusive in FeedbackItem utility query; subtract 1 microsecond to stay inside last bucket.
-            range_end_query_utc = (
-                buckets[-1].end_local.astimezone(timezone.utc) - timedelta(microseconds=1)
-            )
-
+            effective_bucket_count = len(buckets)
             scorecard = await self._resolve_scorecard(str(scorecard_identifier))
             scores_to_analyze = await self._resolve_scores_for_mode(
                 scorecard_id=scorecard.id,
                 score_identifier=score_identifier,
             )
+
+            bucket_policy = {
+                "bucket_type": bucket_type,
+                "bucket_count": effective_bucket_count,
+                "requested_bucket_count": bucket_count,
+                "bucket_count_ignored": bool(has_explicit_window and requested_bucket_count is not None),
+                "timezone": timezone_name,
+                "week_start": week_start,
+                "complete_only": complete_only,
+                "window_mode": window_mode,
+            }
+
             if not scores_to_analyze:
                 return {
                     "mode": "single_score" if score_identifier else "all_scores",
@@ -113,22 +153,22 @@ class FeedbackAlignmentTimeline(BaseReportBlock):
                     "block_description": self.DEFAULT_DESCRIPTION,
                     "scorecard_id": scorecard.id,
                     "scorecard_name": scorecard.name,
-                    "bucket_policy": {
-                        "bucket_type": bucket_type,
-                        "bucket_count": bucket_count,
-                        "timezone": timezone_name,
-                        "week_start": week_start,
-                        "complete_only": True,
-                    },
+                    "show_bucket_details": show_bucket_details,
+                    "bucket_policy": bucket_policy,
                     "buckets": self._serialize_buckets(buckets),
                     "overall": {"score_id": "overall", "score_name": "Overall", "points": []},
                     "scores": [],
                     "message": "No scores found for the requested scope.",
+                    "date_range": {
+                        "start": range_start_utc.isoformat(),
+                        "end": date_range_end_utc.isoformat(),
+                    },
                 }, self._get_log_string()
 
             self._log(
                 f"Running FeedbackAlignmentTimeline for scorecard '{scorecard.name}' "
-                f"with {len(scores_to_analyze)} score(s), bucket_type={bucket_type}, bucket_count={bucket_count}"
+                f"with {len(scores_to_analyze)} score(s), bucket_type={bucket_type}, "
+                f"bucket_count={effective_bucket_count}, window_mode={window_mode}"
             )
 
             overall_bucket_items: List[List[FeedbackItem]] = [[] for _ in buckets]
@@ -186,13 +226,8 @@ class FeedbackAlignmentTimeline(BaseReportBlock):
                 "block_description": self.DEFAULT_DESCRIPTION,
                 "scorecard_id": scorecard.id,
                 "scorecard_name": scorecard.name,
-                "bucket_policy": {
-                    "bucket_type": bucket_type,
-                    "bucket_count": bucket_count,
-                    "timezone": timezone_name,
-                    "week_start": week_start,
-                    "complete_only": True,
-                },
+                "show_bucket_details": show_bucket_details,
+                "bucket_policy": bucket_policy,
                 "buckets": self._serialize_buckets(buckets),
                 "overall": {
                     "score_id": "overall",
@@ -201,17 +236,17 @@ class FeedbackAlignmentTimeline(BaseReportBlock):
                 },
                 "scores": score_series,
                 "date_range": {
-                    "start": buckets[0].start_local.astimezone(timezone.utc).isoformat(),
-                    "end": buckets[-1].end_local.astimezone(timezone.utc).isoformat(),
+                    "start": range_start_utc.isoformat(),
+                    "end": date_range_end_utc.isoformat(),
                 },
                 "total_feedback_items_retrieved": total_feedback_items_retrieved,
                 "message": (
                     f"Processed {len(score_series)} score(s) across "
-                    f"{len(buckets)} complete bucket(s)."
+                    f"{len(buckets)} bucket(s) in {window_mode} mode."
                 ),
             }
 
-            # In single-score mode, "overall" and selected score should represent the same series.
+            # In single-score mode, "overall" and selected score represent the same series.
             if mode == "single_score" and score_series:
                 output["overall"] = {
                     "score_id": score_series[0]["score_id"],
@@ -226,6 +261,82 @@ class FeedbackAlignmentTimeline(BaseReportBlock):
 
     def _now_utc(self) -> datetime:
         return datetime.now(timezone.utc)
+
+    def _get_param(self, name: str) -> Any:
+        if name in self.config and self.config.get(name) is not None:
+            return self.config.get(name)
+        if name in self.params and self.params.get(name) is not None:
+            return self.params.get(name)
+        param_name = f"param_{name}"
+        if param_name in self.params and self.params.get(param_name) is not None:
+            return self.params.get(param_name)
+        return None
+
+    def _parse_bool(self, value: Any, *, default: bool = False) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        value_str = str(value).strip().lower()
+        if value_str in {"1", "true", "yes", "y", "on"}:
+            return True
+        if value_str in {"0", "false", "no", "n", "off"}:
+            return False
+        return default
+
+    def _has_explicit_window(self) -> bool:
+        return any(
+            self._get_param(name) is not None
+            for name in ("days", "start_date", "end_date")
+        )
+
+    def _parse_dt(self, value: Any, *, is_end: bool) -> datetime:
+        value_str = str(value).strip()
+        date_only = (
+            len(value_str) == 10
+            and value_str[4] == "-"
+            and value_str[7] == "-"
+        )
+        try:
+            dt = datetime.fromisoformat(value_str)
+            if date_only:
+                if is_end:
+                    dt = dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+                else:
+                    dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        except Exception:
+            dt = datetime.strptime(value_str, "%Y-%m-%d")
+            if is_end:
+                dt = dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+            else:
+                dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    def _resolve_window_utc(self) -> Tuple[datetime, datetime]:
+        start_date_raw = self._get_param("start_date")
+        end_date_raw = self._get_param("end_date")
+        days_raw = self._get_param("days")
+
+        if (start_date_raw and not end_date_raw) or (end_date_raw and not start_date_raw):
+            raise ValueError("Both 'start_date' and 'end_date' are required when specifying explicit date windows.")
+        if days_raw is not None and start_date_raw and end_date_raw:
+            raise ValueError("Use either 'days' or 'start_date'+'end_date', not both.")
+
+        if start_date_raw and end_date_raw:
+            start_date = self._parse_dt(start_date_raw, is_end=False)
+            end_date = self._parse_dt(end_date_raw, is_end=True)
+        else:
+            days = int(days_raw) if days_raw is not None else self.DEFAULT_DAYS
+            if days <= 0:
+                raise ValueError("'days' must be a positive integer.")
+            end_date = self._now_utc()
+            start_date = end_date - timedelta(days=days)
+
+        if end_date <= start_date:
+            raise ValueError("'end_date' must be after 'start_date'.")
+        return start_date, end_date
 
     async def _resolve_scorecard(self, scorecard_identifier: str) -> Scorecard:
         scorecard = None
@@ -469,6 +580,102 @@ class FeedbackAlignmentTimeline(BaseReportBlock):
             return buckets
 
         raise ValueError(f"Unhandled bucket_type '{bucket_type}'.")
+
+    def _build_exact_window_buckets(
+        self,
+        *,
+        start_local: datetime,
+        end_local: datetime,
+        bucket_type: str,
+        week_start: str,
+    ) -> List[_TimeBucket]:
+        if start_local.tzinfo is None:
+            start_local = start_local.replace(tzinfo=timezone.utc)
+        if end_local.tzinfo is None:
+            end_local = end_local.replace(tzinfo=timezone.utc)
+
+        if end_local <= start_local:
+            return []
+
+        if bucket_type in self.TRAILING_BUCKET_DAYS:
+            duration = timedelta(days=self.TRAILING_BUCKET_DAYS[bucket_type])
+            buckets: List[_TimeBucket] = []
+            current_start = start_local
+            while current_start < end_local:
+                current_end = min(current_start + duration, end_local)
+                buckets.append(
+                    _TimeBucket(
+                        start_local=current_start,
+                        end_local=current_end,
+                        label=current_start.strftime("%Y-%m-%d"),
+                    )
+                )
+                current_start = current_end
+            return buckets
+
+        period_start = self._calendar_period_start(start_local, bucket_type, week_start)
+        buckets = []
+        while period_start < end_local:
+            period_end = self._advance_calendar_period(period_start, bucket_type)
+            clipped_start = max(period_start, start_local)
+            clipped_end = min(period_end, end_local)
+            if clipped_start < clipped_end:
+                buckets.append(
+                    _TimeBucket(
+                        start_local=clipped_start,
+                        end_local=clipped_end,
+                        label=self._calendar_period_label(period_start, bucket_type),
+                    )
+                )
+            period_start = period_end
+
+        return buckets
+
+    def _calendar_period_start(
+        self,
+        value: datetime,
+        bucket_type: str,
+        week_start: str,
+    ) -> datetime:
+        day_start = value.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        if bucket_type == "calendar_day":
+            return day_start
+
+        if bucket_type == "calendar_week":
+            week_start_index = self.WEEK_START_INDEX[week_start]
+            offset = (day_start.weekday() - week_start_index) % 7
+            return day_start - timedelta(days=offset)
+
+        if bucket_type == "calendar_biweek":
+            week_start_index = self.WEEK_START_INDEX[week_start]
+            offset = (day_start.weekday() - week_start_index) % 7
+            current_week_start = day_start - timedelta(days=offset)
+            epoch_day = 5 if week_start == "monday" else 4
+            epoch = day_start.replace(year=1970, month=1, day=epoch_day)
+            weeks_since_epoch = int((current_week_start - epoch).days // 7)
+            return epoch + timedelta(weeks=(weeks_since_epoch // 2) * 2)
+
+        if bucket_type == "calendar_month":
+            return day_start.replace(day=1)
+
+        raise ValueError(f"Unsupported calendar bucket type '{bucket_type}'.")
+
+    def _advance_calendar_period(self, period_start: datetime, bucket_type: str) -> datetime:
+        if bucket_type == "calendar_day":
+            return period_start + timedelta(days=1)
+        if bucket_type == "calendar_week":
+            return period_start + timedelta(days=7)
+        if bucket_type == "calendar_biweek":
+            return period_start + timedelta(days=14)
+        if bucket_type == "calendar_month":
+            return self._shift_months(period_start, 1)
+        raise ValueError(f"Unsupported calendar bucket type '{bucket_type}'.")
+
+    def _calendar_period_label(self, period_start: datetime, bucket_type: str) -> str:
+        if bucket_type == "calendar_month":
+            return period_start.strftime("%Y-%m")
+        return period_start.strftime("%Y-%m-%d")
 
     def _shift_months(self, value: datetime, months: int) -> datetime:
         month_index = (value.month - 1) + months

--- a/plexus/reports/blocks/feedback_alignment_timeline_test.py
+++ b/plexus/reports/blocks/feedback_alignment_timeline_test.py
@@ -102,6 +102,44 @@ async def test_generate_single_score_mode(mock_api_client):
     assert len(output["scores"][0]["points"]) == 2
     assert output["scores"][0]["points"][0]["item_count"] == 1
     assert output["scores"][0]["points"][1]["item_count"] == 1
+    assert output["show_bucket_details"] is False
+
+
+@pytest.mark.asyncio
+async def test_generate_exact_window_ignores_bucket_count_and_sets_show_details(mock_api_client):
+    block = FeedbackAlignmentTimeline(
+        config={
+            "scorecard": "sc-1",
+            "score": "score-ext-1",
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-19",
+            "bucket_type": "calendar_week",
+            "bucket_count": 1,
+            "timezone": "UTC",
+            "show_bucket_details": True,
+        },
+        params={"account_id": "acct-1"},
+        api_client=mock_api_client,
+    )
+
+    scorecard = MagicMock(id="sc-1", name="Test Scorecard")
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(
+            block,
+            "_resolve_scores_for_mode",
+            new=AsyncMock(return_value=[{"score_id": "score-1", "score_name": "Score 1"}]),
+        ),
+        patch.object(block, "_fetch_feedback_items_for_score", new=AsyncMock(return_value=[])),
+    ):
+        output, _ = await block.generate()
+
+    assert output["show_bucket_details"] is True
+    assert output["bucket_policy"]["window_mode"] == "exact_window"
+    assert output["bucket_policy"]["bucket_count_ignored"] is True
+    assert output["bucket_policy"]["bucket_count"] == 3
+    assert output["date_range"]["start"].startswith("2026-04-01T00:00:00")
+    assert output["date_range"]["end"].startswith("2026-04-19T23:59:59")
 
 
 @pytest.mark.asyncio

--- a/plexus/reports/service.py
+++ b/plexus/reports/service.py
@@ -1055,6 +1055,178 @@ def _persist_block_result(
     logger.info("Cached block result as Report %s (block %s)", report.id, rb.id)
 
 
+def _build_programmatic_report_markdown(
+    block_definitions: List[Dict[str, Any]],
+) -> str:
+    """
+    Build the markdown block template for a programmatic multi-block report.
+    """
+    rendered_blocks: List[str] = []
+    for block in block_definitions:
+        class_name = str(block.get("class_name") or "").strip()
+        if not class_name:
+            continue
+        block_name = str(block.get("block_name") or _humanize_block_class(class_name)).strip()
+        block_config = block.get("config") if isinstance(block.get("config"), dict) else {}
+        block_yaml = yaml.dump(block_config, default_flow_style=False).strip()
+        if block_yaml:
+            block_body = f"class: {class_name}\n{block_yaml}"
+        else:
+            block_body = f"class: {class_name}"
+        rendered_blocks.append(
+            f'```block name="{block_name}"\n{block_body}\n```'
+        )
+    return "\n\n".join(rendered_blocks)
+
+
+def run_programmatic_report_and_persist(
+    *,
+    report_name: str,
+    block_definitions: List[Dict[str, Any]],
+    account_id: str,
+    client: PlexusDashboardClient,
+    report_parameters: Optional[Dict[str, Any]] = None,
+    display_title: Optional[str] = None,
+    display_subtitle: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Run multiple report blocks and persist them as a single Report with ordered ReportBlocks.
+    """
+    if not report_name or not str(report_name).strip():
+        raise ValueError("'report_name' is required.")
+    if not block_definitions:
+        raise ValueError("'block_definitions' must contain at least one block.")
+
+    normalized_blocks: List[Dict[str, Any]] = []
+    for idx, raw in enumerate(block_definitions):
+        if not isinstance(raw, dict):
+            raise ValueError(f"Invalid block definition at index {idx}: expected object.")
+        class_name = str(raw.get("class_name") or "").strip()
+        if not class_name:
+            raise ValueError(f"Invalid block definition at index {idx}: 'class_name' is required.")
+        block_name = str(raw.get("block_name") or _humanize_block_class(class_name)).strip()
+        config = raw.get("config")
+        if config is None:
+            config = {}
+        if not isinstance(config, dict):
+            raise ValueError(f"Invalid block definition at index {idx}: 'config' must be an object.")
+        normalized_blocks.append(
+            {
+                "class_name": class_name,
+                "block_name": block_name,
+                "config": config,
+                "position": idx,
+            }
+        )
+
+    config_id = _get_programmatic_config_id(account_id, client)
+    task = Task.create(
+        client=client,
+        type="ProgrammaticReport",
+        target=str(report_name).strip(),
+        command="run_programmatic_report_and_persist",
+        accountId=account_id,
+        status="COMPLETED",
+        dispatchStatus="COMPLETED",
+    )
+
+    parameters = dict(report_parameters or {})
+    if display_title:
+        parameters["_display_title"] = display_title
+    if display_subtitle:
+        parameters["_display_subtitle"] = display_subtitle
+
+    report = Report.create(
+        client=client,
+        accountId=account_id,
+        taskId=task.id,
+        name=str(report_name).strip(),
+        reportConfigurationId=config_id,
+        parameters=parameters,
+    )
+    report.update(output=_build_programmatic_report_markdown(normalized_blocks))
+
+    report_params = {"account_id": account_id}
+    first_error_message: Optional[str] = None
+
+    for block in normalized_blocks:
+        block_class_name = block["class_name"]
+        block_display_name = block["block_name"]
+        block_config = block["config"]
+        position = int(block["position"])
+
+        report_block = ReportBlock.create(
+            client=client,
+            reportId=report.id,
+            position=position,
+            type=block_class_name,
+            name=block_display_name,
+            output="{}",
+            log="Processing...",
+        )
+
+        output_json, log_string, resolved_dataset_id = _instantiate_and_run_block(
+            block_def=block,
+            report_params=report_params,
+            api_client=client,
+            report_block_id=report_block.id,
+        )
+
+        if output_json is None:
+            if first_error_message is None:
+                first_error_message = log_string or f"Block {block_display_name} failed."
+            output_payload: Any = {
+                "error": log_string or f"Block {block_display_name} failed.",
+                "block_class": block_class_name,
+            }
+        else:
+            output_payload = output_json
+
+        db_block_state = ReportBlock.get_by_id(report_block.id, client)
+        if not db_block_state:
+            raise RuntimeError(f"Could not re-fetch ReportBlock {report_block.id} after execution.")
+
+        existing_details_files_list: List[str] = []
+        attached_files = db_block_state.attachedFiles
+        if attached_files:
+            if not isinstance(attached_files, list):
+                raise RuntimeError(
+                    f"ReportBlock {report_block.id} attachedFiles must be a list, got {type(attached_files).__name__}."
+                )
+            existing_details_files_list = list(attached_files)
+
+        final_log_message, existing_details_files_list, _ = _persist_log_artifact_if_present(
+            report_block_id=report_block.id,
+            log_output=log_string,
+            existing_details_files_list=existing_details_files_list,
+            log_prefix="[programmatic-report]",
+        )
+        compact_output_json, existing_details_files_list, _ = _persist_output_artifact_and_compact(
+            report_block_id=report_block.id,
+            output_payload=output_payload,
+            existing_details_files_list=existing_details_files_list,
+            log_prefix="[programmatic-report]",
+        )
+
+        update_input: Dict[str, Any] = {
+            "id": report_block.id,
+            "output": compact_output_json,
+            "log": final_log_message,
+            "attachedFiles": existing_details_files_list,
+        }
+        if resolved_dataset_id:
+            update_input["dataSetId"] = resolved_dataset_id
+
+        mutation = """
+        mutation UpdateReportBlock($input: UpdateReportBlockInput!) {
+            updateReportBlock(input: $input) { id output log attachedFiles dataSetId }
+        }
+        """
+        client.execute(mutation, {"input": update_input})
+
+    return report.id, first_error_message
+
+
 def _fetch_first_block_output(report_id: str, client: PlexusDashboardClient) -> Optional[Any]:
     """Fetch block data from the first ReportBlock of a report.
 

--- a/plexus/reports/service.py
+++ b/plexus/reports/service.py
@@ -540,7 +540,7 @@ def _build_default_cache_key(block_class: str, block_config: Dict[str, Any]) -> 
     Build a deterministic but readable cache key for programmatic blocks.
     """
     block_title = _humanize_block_class(block_class)
-    parts: List[str] = [block_title]
+    parts: List[str] = []
 
     scorecard = str(block_config.get("scorecard") or "").strip()
     score = str(block_config.get("score") or block_config.get("score_id") or "").strip()
@@ -555,6 +555,7 @@ def _build_default_cache_key(block_class: str, block_config: Dict[str, Any]) -> 
         parts.append(f"Scorecard {scorecard}")
     if score:
         parts.append(f"Score {score}")
+    parts.append(block_title)
 
     if start_date and end_date:
         parts.append(f"{start_date} to {end_date}")
@@ -618,13 +619,14 @@ def _derive_programmatic_display_strings(
         score_name = output_data.get("score_name") or None
         scope = output_data.get("scope") or None
 
-    title_parts: List[str] = [block_title]
+    title_parts: List[str] = []
     if scorecard_name:
         title_parts.append(str(scorecard_name).strip())
     if score_name:
         title_parts.append(str(score_name).strip())
     elif scope == "scorecard_all_scores":
         title_parts.append("All Scores")
+    title_parts.append(block_title)
 
     title = " - ".join([part for part in title_parts if part])
 

--- a/plexus/reports/tests/test_feedback_overview_template_fixture.py
+++ b/plexus/reports/tests/test_feedback_overview_template_fixture.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+from plexus.reports.parameter_utils import render_configuration_with_parameters
+from plexus.reports.service import _parse_report_configuration
+
+
+FIXTURE_PATH = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "reports" / "feedback_score_overview_template.md"
+
+
+def test_feedback_overview_template_days_window_renders_three_blocks_with_shared_scope() -> None:
+    template = FIXTURE_PATH.read_text()
+    rendered = render_configuration_with_parameters(
+        template,
+        {
+            "scorecard": "1438",
+            "score": "45813",
+            "days": 90,
+            "start_date": "",
+            "end_date": "",
+            "bucket_type": "trailing_7d",
+            "timezone": "UTC",
+            "week_start": "monday",
+            "show_bucket_details": False,
+            "max_items": 200,
+            "mode": "contradictions",
+            "max_feedback_items": 400,
+            "num_topics": 8,
+            "max_concurrent": 20,
+        },
+    )
+
+    blocks = _parse_report_configuration(rendered)
+    assert [block["class_name"] for block in blocks] == [
+        "FeedbackAlignmentTimeline",
+        "AcceptanceRate",
+        "FeedbackContradictions",
+    ]
+
+    for block in blocks:
+        assert block["config"]["scorecard"] == 1438
+        assert block["config"]["score"] == 45813
+        assert block["config"]["days"] == 90
+        assert "start_date" not in block["config"]
+        assert "end_date" not in block["config"]
+
+
+def test_feedback_overview_template_explicit_window_overrides_days() -> None:
+    template = FIXTURE_PATH.read_text()
+    rendered = render_configuration_with_parameters(
+        template,
+        {
+            "scorecard": "1438",
+            "score": "45813",
+            "days": "",
+            "start_date": "2026-01-01",
+            "end_date": "2026-03-31",
+            "bucket_type": "calendar_month",
+            "timezone": "UTC",
+            "week_start": "monday",
+            "show_bucket_details": True,
+            "max_items": 200,
+            "mode": "contradictions",
+            "max_feedback_items": 400,
+            "num_topics": 8,
+            "max_concurrent": 20,
+        },
+    )
+
+    blocks = _parse_report_configuration(rendered)
+    assert len(blocks) == 3
+
+    for block in blocks:
+        assert str(block["config"]["start_date"]) == "2026-01-01"
+        assert str(block["config"]["end_date"]) == "2026-03-31"
+        assert "days" not in block["config"]

--- a/plexus/tests/fixtures/reports/feedback_score_overview_template.md
+++ b/plexus/tests/fixtures/reports/feedback_score_overview_template.md
@@ -1,0 +1,144 @@
+parameters:
+  - name: scorecard
+    label: Scorecard
+    type: scorecard_select
+    required: true
+  - name: score
+    label: Score
+    type: score_select
+    required: true
+    depends_on: scorecard
+  - name: days
+    label: Trailing Days
+    type: number
+    required: false
+    default: 90
+  - name: start_date
+    label: Start Date
+    type: text
+    required: false
+    default: ""
+  - name: end_date
+    label: End Date
+    type: text
+    required: false
+    default: ""
+  - name: bucket_type
+    label: Timeline Bucket Type
+    type: select
+    required: true
+    default: trailing_7d
+    options:
+      - value: trailing_1d
+        label: Trailing 1 Day
+      - value: trailing_7d
+        label: Trailing 7 Day
+      - value: trailing_14d
+        label: Trailing 14 Day
+      - value: trailing_30d
+        label: Trailing 30 Day
+      - value: calendar_day
+        label: Calendar Day
+      - value: calendar_week
+        label: Calendar Week
+      - value: calendar_biweek
+        label: Calendar Biweek
+      - value: calendar_month
+        label: Calendar Month
+  - name: timezone
+    label: Timezone
+    type: text
+    required: true
+    default: UTC
+  - name: week_start
+    label: Week Start
+    type: select
+    required: true
+    default: monday
+    options:
+      - value: monday
+        label: Monday
+      - value: sunday
+        label: Sunday
+  - name: show_bucket_details
+    label: Show Bucket Details
+    type: boolean
+    required: true
+    default: false
+  - name: max_items
+    label: Acceptance Max Items
+    type: number
+    required: true
+    default: 200
+  - name: mode
+    label: Contradictions Mode
+    type: select
+    required: true
+    default: contradictions
+    options:
+      - value: contradictions
+        label: Contradictions
+      - value: aligned
+        label: Aligned
+  - name: max_feedback_items
+    label: Contradictions Max Feedback Items
+    type: number
+    required: true
+    default: 400
+  - name: num_topics
+    label: Contradictions Topic Count
+    type: number
+    required: true
+    default: 8
+  - name: max_concurrent
+    label: Contradictions Max Concurrent
+    type: number
+    required: true
+    default: 20
+---
+
+```block name="Feedback Alignment Timeline"
+class: FeedbackAlignmentTimeline
+scorecard: {{ scorecard }}
+score: {{ score }}
+{% if start_date and end_date %}
+start_date: {{ start_date }}
+end_date: {{ end_date }}
+{% elif days %}
+days: {{ days }}
+{% endif %}
+bucket_type: {{ bucket_type }}
+timezone: {{ timezone }}
+week_start: {{ week_start }}
+show_bucket_details: {{ show_bucket_details }}
+```
+
+```block name="Acceptance Rate"
+class: AcceptanceRate
+scorecard: {{ scorecard }}
+score: {{ score }}
+{% if start_date and end_date %}
+start_date: {{ start_date }}
+end_date: {{ end_date }}
+{% elif days %}
+days: {{ days }}
+{% endif %}
+include_item_acceptance_rate: true
+max_items: {{ max_items }}
+```
+
+```block name="Feedback Contradictions"
+class: FeedbackContradictions
+scorecard: {{ scorecard }}
+score: {{ score }}
+{% if start_date and end_date %}
+start_date: {{ start_date }}
+end_date: {{ end_date }}
+{% elif days %}
+days: {{ days }}
+{% endif %}
+mode: {{ mode }}
+max_feedback_items: {{ max_feedback_items }}
+num_topics: {{ num_topics }}
+max_concurrent: {{ max_concurrent }}
+```


### PR DESCRIPTION
- Prevents report blocks from rendering misleading zero metrics while output is still pending\n- Passes per-block processing state from ReportTask into feedback blocks\n- Applies to AcceptanceRate, AcceptanceRateTimeline, FeedbackAlignmentTimeline, RecentFeedback\n\nKanbus: plx-cd3451