### PR TITLE
feat: finalize optimizer model cost attribution and UI breakdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,16 @@ This workflow uses a chain of skills and agents:
 - **Validate First**: Always run an evaluation or prediction test before declaring a task complete.
 - **Check Documentation**: Use `get_plexus_documentation` if you are unsure about formats.
 
+## Direct CLI Policy (Critical)
+
+- **Procedures and reports must be executed directly via CLI** (`plexus procedure ...`, `plexus report ...`) during development/debugging.
+- **Do not use dispatcher state as evidence** that a direct CLI procedure/report is running or healthy.
+- **Do not diagnose procedure/report crashes from task status alone**. Use process-level evidence first:
+  1. Live process check (`ps`/PID)
+  2. Direct CLI stdout/stderr logs
+  3. Then dashboard task/procedure records for corroboration
+- If a direct CLI run exits unexpectedly, capture and report the exact exception/traceback from that CLI run before proposing fixes.
+
 ## Debugging Procedures
 
 ### LLM Debug Mode (`PLEXUS_DEBUG_LLM`)

--- a/MCP/tools/evaluation/evaluations.py
+++ b/MCP/tools/evaluation/evaluations.py
@@ -781,6 +781,7 @@ def register_evaluation_tools(mcp: FastMCP):
                         "baselineEvaluationId": eval_info.get('baseline_evaluation_id'),
                         "currentBaselineEvaluationId": eval_info.get('current_baseline_evaluation_id'),
                         "cost": eval_info.get('cost'),
+                        "cost_details": eval_info.get('cost_details'),
                         "started_at": eval_info.get('started_at'),
                         "created_at": eval_info.get('created_at'),
                         "updated_at": eval_info.get('updated_at'),
@@ -1000,6 +1001,7 @@ def register_evaluation_tools(mcp: FastMCP):
                 'total_items': eval_info.get('total_items'),
                 'processed_items': eval_info.get('processed_items'),
                 'cost': eval_info.get('cost'),
+                'cost_details': eval_info.get('cost_details'),
                 'accuracy': eval_info.get('accuracy'),
                 'metrics': eval_info.get('metrics'),
                 'confusionMatrix': eval_info.get('confusion_matrix'),  # snake_case in source
@@ -1122,6 +1124,7 @@ def register_evaluation_tools(mcp: FastMCP):
                     "baselineEvaluationId": eval_info.get("baseline_evaluation_id"),
                     "currentBaselineEvaluationId": eval_info.get("current_baseline_evaluation_id"),
                     "cost": eval_info.get("cost"),
+                    "cost_details": eval_info.get("cost_details"),
                     "started_at": eval_info.get("started_at"),
                     "created_at": eval_info.get("created_at"),
                     "updated_at": eval_info.get("updated_at"),

--- a/dashboard/amplify/data/resource.ts
+++ b/dashboard/amplify/data/resource.ts
@@ -230,6 +230,7 @@ const schema = a.schema({
             inferences: a.integer(),
             accuracy: a.float().required(),
             cost: a.float(),
+            costDetails: a.json(),
             createdAt: a.datetime().required(),
             updatedAt: a.datetime().required(),
             status: a.string().required(),

--- a/dashboard/components/ProcedureTask.tsx
+++ b/dashboard/components/ProcedureTask.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useTransition } from 'react'
+import React, { useCallback, useState, useEffect, useMemo, useTransition } from 'react'
 import { Task, TaskHeader, TaskContent } from '@/components/Task'
 import { BaseTaskData } from '@/types/base'
 import { Card, CardContent } from '@/components/ui/card'
@@ -621,6 +621,68 @@ export default function ProcedureTask({
   const overallTotal = Number(costTotals?.overall?.total ?? (evaluationTotal + inferenceTotal))
   const evaluationEntryCount = Array.isArray(evaluationCosts?.entries) ? evaluationCosts.entries.length : 0
   const inferenceEntryCount = Array.isArray(inferenceCosts?.entries) ? inferenceCosts.entries.length : 0
+  const evaluationBreakdownRows = Array.isArray(evaluationCosts?.breakdown)
+    ? evaluationCosts.breakdown
+    : (evaluationCosts?.breakdown && typeof evaluationCosts.breakdown === 'object'
+      ? Object.values(evaluationCosts.breakdown)
+      : [])
+  const inferenceBreakdownRows = Array.isArray(inferenceCosts?.breakdown)
+    ? inferenceCosts.breakdown
+    : (inferenceCosts?.breakdown && typeof inferenceCosts.breakdown === 'object'
+      ? Object.values(inferenceCosts.breakdown)
+      : [])
+  const modelCostRows = useMemo(() => {
+    const index = new Map<string, {
+      provider: string | null
+      model: string | null
+      evalSpent: number
+      evalReused: number
+      optimizer: number
+      totalReferenced: number
+    }>()
+
+    const upsert = (provider: string | null, model: string | null) => {
+      const key = `${provider ?? ''}|${model ?? ''}`
+      const existing = index.get(key)
+      if (existing) return existing
+      const created = {
+        provider,
+        model,
+        evalSpent: 0,
+        evalReused: 0,
+        optimizer: 0,
+        totalReferenced: 0,
+      }
+      index.set(key, created)
+      return created
+    }
+
+    for (const row of evaluationBreakdownRows as any[]) {
+      if (!row || typeof row !== 'object') continue
+      const target = upsert(
+        typeof row.provider === 'string' ? row.provider : null,
+        typeof row.model === 'string' ? row.model : null,
+      )
+      const spent = Number(row.spent_usd ?? 0)
+      const reused = Number(row.reused_usd ?? 0)
+      const referenced = Number(row.referenced_usd ?? (spent + reused))
+      target.evalSpent += spent
+      target.evalReused += reused
+      target.totalReferenced += referenced
+    }
+    for (const row of inferenceBreakdownRows as any[]) {
+      if (!row || typeof row !== 'object') continue
+      const target = upsert(
+        typeof row.provider === 'string' ? row.provider : null,
+        typeof row.model === 'string' ? row.model : null,
+      )
+      const optimizer = Number(row.spent_usd ?? row.referenced_usd ?? 0)
+      target.optimizer += optimizer
+      target.totalReferenced += optimizer
+    }
+
+    return Array.from(index.values()).sort((a, b) => b.totalReferenced - a.totalReferenced)
+  }, [evaluationBreakdownRows, inferenceBreakdownRows])
 
   // ---- Shared helpers for creating a Task and dispatching a procedure run ----
   const createTaskWithStages = async (procedureId: string, runParameters?: ParameterValue) => {
@@ -1215,6 +1277,35 @@ export default function ProcedureTask({
                   </div>
                 </div>
               </div>
+              {modelCostRows.length > 0 && (
+                <div className="mt-3 overflow-x-auto">
+                  <table className="w-full text-xs">
+                    <thead className="text-muted-foreground/70">
+                      <tr>
+                        <th className="py-1 text-left font-medium">Provider / Model</th>
+                        <th className="py-1 text-right font-medium">Eval spent</th>
+                        <th className="py-1 text-right font-medium">Eval reused</th>
+                        <th className="py-1 text-right font-medium">Optimizer</th>
+                        <th className="py-1 text-right font-medium">Total referenced</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {modelCostRows.map((row, idx) => (
+                        <tr key={`${row.provider ?? 'none'}|${row.model ?? 'none'}|${idx}`} className="border-t border-border/40">
+                          <td className="py-1 pr-2">
+                            <span className="text-foreground/90">{row.provider || 'unknown'}</span>
+                            <span className="text-muted-foreground"> / {row.model || 'unknown'}</span>
+                          </td>
+                          <td className="py-1 text-right tabular-nums">{formatCurrency(row.evalSpent)}</td>
+                          <td className="py-1 text-right tabular-nums text-emerald-700 dark:text-emerald-400">{formatCurrency(row.evalReused)}</td>
+                          <td className="py-1 text-right tabular-nums">{formatCurrency(row.optimizer)}</td>
+                          <td className="py-1 text-right font-medium tabular-nums">{formatCurrency(row.totalReferenced)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
             </div>
           )}
 

--- a/dashboard/components/procedures-dashboard.tsx
+++ b/dashboard/components/procedures-dashboard.tsx
@@ -25,6 +25,19 @@ type ProcedureWithTask = Procedure & {
   task?: Task | null
 }
 
+const getProcedureStartTimeMs = (procedure: ProcedureWithTask): number => {
+  const startCandidate =
+    procedure.task?.startedAt ||
+    procedure.task?.createdAt ||
+    procedure.createdAt ||
+    procedure.updatedAt
+  const timestamp = startCandidate ? new Date(startCandidate).getTime() : 0
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+const sortProceduresByStartTime = (procedures: ProcedureWithTask[]): ProcedureWithTask[] =>
+  [...procedures].sort((a, b) => getProcedureStartTimeMs(b) - getProcedureStartTimeMs(a))
+
 let amplifyClient: ReturnType<typeof generateClient<Schema>> | null = null
 const getAmplifyClient = () => (amplifyClient ??= generateClient<Schema>())
 
@@ -308,12 +321,8 @@ function ProceduresDashboard({ initialSelectedProcedureId }: ProceduresDashboard
         console.log('Most recent 5 procedures by API order:', recentProcedures)
       }
       
-      // Sort procedures in reverse chronological order (newest first)
-      const sortedData = data?.sort((a: Procedure, b: Procedure) => {
-        const dateA = new Date(a.updatedAt || a.createdAt)
-        const dateB = new Date(b.updatedAt || b.createdAt)
-        return dateB.getTime() - dateA.getTime()
-      }) || []
+      // Order by actual run start time instead of update time.
+      const sortedData = sortProceduresByStartTime(data || [])
       
       // Always replace with the first page — loadProcedures is a full reset
       setProcedures(sortedData)
@@ -386,7 +395,7 @@ function ProceduresDashboard({ initialSelectedProcedureId }: ProceduresDashboard
         task: taskMap.get(procedure.id) ?? null
       }))
 
-      setProcedures(prev => [...prev, ...merged])
+      setProcedures(prev => sortProceduresByStartTime([...prev, ...merged]))
       setNextToken(newNextToken)
       setHasMore(!!newNextToken)
     } catch (err) {
@@ -420,8 +429,8 @@ function ProceduresDashboard({ initialSelectedProcedureId }: ProceduresDashboard
               console.log(`Updating procedure ${metadata.procedure_id} with task data:`, data);
               
               // Update the procedures list with new task data, preserving stages
-              setProcedures(prevProcedures => 
-                prevProcedures.map(procedure => {
+              setProcedures(prevProcedures =>
+                sortProceduresByStartTime(prevProcedures.map(procedure => {
                   if (procedure.id === metadata.procedure_id) {
                     // Merge new task data with existing task, preserving stages
                     const updatedTask = procedure.task 
@@ -430,7 +439,7 @@ function ProceduresDashboard({ initialSelectedProcedureId }: ProceduresDashboard
                     return { ...procedure, task: updatedTask };
                   }
                   return procedure;
-                })
+                }))
               );
             }
           } catch (error) {
@@ -449,8 +458,8 @@ function ProceduresDashboard({ initialSelectedProcedureId }: ProceduresDashboard
         
         if (data?.taskId) {
           // Update the procedures list with new stage data
-          setProcedures(prevProcedures => 
-            prevProcedures.map((procedure: ProcedureWithTask) => {
+          setProcedures(prevProcedures =>
+            sortProceduresByStartTime(prevProcedures.map((procedure: ProcedureWithTask) => {
               if (procedure.task?.id === data.taskId) {
                 console.log(`Updating procedure ${procedure.id} stages with:`, data);
                 
@@ -484,7 +493,7 @@ function ProceduresDashboard({ initialSelectedProcedureId }: ProceduresDashboard
                 return { ...procedure, task: updatedTask };
               }
               return procedure;
-            })
+            }))
           );
         }
       },
@@ -514,7 +523,7 @@ function ProceduresDashboard({ initialSelectedProcedureId }: ProceduresDashboard
           if (!procedure || procedure.accountId !== accountId) return;
           setProcedures(prev => {
             if (prev.some(p => p.id === procedure.id)) return prev;
-            return [{ ...procedure, task: null }, ...prev];
+            return sortProceduresByStartTime([{ ...procedure, task: null }, ...prev]);
           });
         },
         error: (error: Error) => console.error('Error in create procedure subscription:', error)
@@ -532,7 +541,9 @@ function ProceduresDashboard({ initialSelectedProcedureId }: ProceduresDashboard
           const updated = data?.onUpdateProcedure;
           if (!updated || updated.accountId !== accountId) return;
           setProcedures(prev =>
-            prev.map(p => p.id === updated.id ? { ...p, ...updated } : p)
+            sortProceduresByStartTime(
+              prev.map(p => p.id === updated.id ? { ...p, ...updated } : p)
+            )
           );
         },
         error: (error: Error) => console.error('Error in update procedure subscription:', error)

--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -37,6 +37,7 @@ import {
   MessageSquare,
   PanelLeftOpen,
   PanelLeftClose,
+  ChevronDownIcon,
   MoreHorizontal,
   Trash2,
   AlertCircle,
@@ -838,6 +839,28 @@ type MessageCostMetadata = {
   summary?: MessageCostSummary
 }
 
+const hasMeaningfulCostSummary = (summary: MessageCostSummary | null | undefined): boolean => {
+  if (!summary || typeof summary !== 'object') {
+    return false
+  }
+  const totalUsd = typeof summary.total_usd === 'number' ? summary.total_usd : 0
+  const llmCalls = typeof summary.llm_calls === 'number' ? summary.llm_calls : 0
+  const promptTokens = typeof summary.prompt_tokens === 'number' ? summary.prompt_tokens : 0
+  const completionTokens = typeof summary.completion_tokens === 'number' ? summary.completion_tokens : 0
+  const totalTokens = typeof summary.total_tokens === 'number' ? summary.total_tokens : 0
+  const cachedTokens = typeof summary.cached_tokens === 'number' ? summary.cached_tokens : 0
+  const hasBreakdown = Array.isArray(summary.breakdown) && summary.breakdown.length > 0
+  return (
+    totalUsd > 0
+    || llmCalls > 0
+    || promptTokens > 0
+    || completionTokens > 0
+    || totalTokens > 0
+    || cachedTokens > 0
+    || hasBreakdown
+  )
+}
+
 const getMessageCostMetadata = (message: ChatMessage): MessageCostMetadata | null => {
   const metadata = message.metadata
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
@@ -893,8 +916,12 @@ const MemoizedMessageRow = React.memo(function MessageRow({
   const showToolNameBadge = Boolean(message.toolName) && !toolViewModel
   const costMetadata = getMessageCostMetadata(message)
   const costSummary = costMetadata?.summary
+  const hasCostSummary = hasMeaningfulCostSummary(costSummary)
   const costTotal = typeof costSummary?.total_usd === 'number' ? costSummary.total_usd : undefined
-  const costBadgeLabel = costMetadata
+  const showInlineCostBadge = !(
+    message.role === 'ASSISTANT' && message.messageType === 'MESSAGE'
+  )
+  const costBadgeLabel = costMetadata && hasCostSummary && showInlineCostBadge
     ? `${costMetadata.billing_mode === 'reused' ? 'Reused' : 'Spent'} ${formatUsd(costTotal)}`
     : null
   const showMetadataBadges = showMessageTypeBadge || showToolNameBadge || Boolean(costBadgeLabel)
@@ -975,12 +1002,15 @@ const MemoizedMessageRow = React.memo(function MessageRow({
                   )}
                 </ToolContent>
               </Tool>
-              {costMetadata && costSummary && (
-                <details className="rounded border border-border/40 p-2 text-xs">
-                  <summary className="cursor-pointer text-muted-foreground">
-                    Cost details
+              {costMetadata && costSummary && hasCostSummary && (
+                <details className="group rounded-md bg-card/60 text-xs">
+                  <summary className="list-none cursor-pointer rounded-md px-3 py-2 text-left text-xs font-medium text-foreground hover:bg-muted/50 [&::-webkit-details-marker]:hidden">
+                    <span className="flex items-center justify-between gap-2">
+                      <span>{`${costMetadata.billing_mode === 'reused' ? 'Reused' : 'Spent'} ${formatUsd(costSummary.total_usd)}`}</span>
+                      <ChevronDownIcon className="size-4 shrink-0 transition-transform group-open:rotate-180" />
+                    </span>
                   </summary>
-                  <div className="mt-2 space-y-1 tabular-nums">
+                  <div className="space-y-1 px-3 pb-3 tabular-nums">
                     <div>Total: {formatUsd(costSummary.total_usd)}</div>
                     <div>LLM calls: {costSummary.llm_calls ?? 0}</div>
                     <div>Tokens: {costSummary.total_tokens ?? 0}</div>
@@ -1013,12 +1043,15 @@ const MemoizedMessageRow = React.memo(function MessageRow({
           ) : (
             <div className="text-sm space-y-2">
               <CollapsibleText content={message.content} />
-              {costMetadata && costSummary && (
-                <details className="rounded border border-border/40 p-2 text-xs">
-                  <summary className="cursor-pointer text-muted-foreground">
-                    Cost details
+              {costMetadata && costSummary && hasCostSummary && (
+                <details className="group rounded-md bg-card/60 text-xs">
+                  <summary className="list-none cursor-pointer rounded-md px-3 py-2 text-left text-xs font-medium text-foreground hover:bg-muted/50 [&::-webkit-details-marker]:hidden">
+                    <span className="flex items-center justify-between gap-2">
+                      <span>{`${costMetadata.billing_mode === 'reused' ? 'Reused' : 'Spent'} ${formatUsd(costSummary.total_usd)}`}</span>
+                      <ChevronDownIcon className="size-4 shrink-0 transition-transform group-open:rotate-180" />
+                    </span>
                   </summary>
-                  <div className="mt-2 space-y-1 tabular-nums">
+                  <div className="space-y-1 px-3 pb-3 tabular-nums">
                     <div>Total: {formatUsd(costSummary.total_usd)}</div>
                     <div>LLM calls: {costSummary.llm_calls ?? 0}</div>
                     <div>Prompt tokens: {costSummary.prompt_tokens ?? 0}</div>

--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -820,6 +820,38 @@ const getRowFromMessage = (message: ChatMessage): ConversationRow => {
   }
 }
 
+type MessageCostSummary = {
+  schema_version?: number
+  total_usd?: number
+  llm_calls?: number
+  prompt_tokens?: number
+  completion_tokens?: number
+  total_tokens?: number
+  cached_tokens?: number
+  breakdown?: Array<Record<string, unknown>>
+}
+
+type MessageCostMetadata = {
+  kind?: string
+  billing_mode?: string
+  live?: boolean
+  summary?: MessageCostSummary
+}
+
+const getMessageCostMetadata = (message: ChatMessage): MessageCostMetadata | null => {
+  const metadata = message.metadata
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null
+  }
+  const cost = (metadata as Record<string, unknown>).cost
+  if (!cost || typeof cost !== 'object' || Array.isArray(cost)) {
+    return null
+  }
+  return cost as MessageCostMetadata
+}
+
+const formatUsd = (value: number | undefined): string => `$${(value || 0).toFixed(4)}`
+
 // Props passed into each virtualized row
 interface MessageRowProps {
   row: ConversationRow
@@ -859,7 +891,13 @@ const MemoizedMessageRow = React.memo(function MessageRow({
   const messageTypeLabel = getMessageTypeLabel(message)
   const showMessageTypeBadge = shouldShowMessageTypeBadge(message)
   const showToolNameBadge = Boolean(message.toolName) && !toolViewModel
-  const showMetadataBadges = showMessageTypeBadge || showToolNameBadge
+  const costMetadata = getMessageCostMetadata(message)
+  const costSummary = costMetadata?.summary
+  const costTotal = typeof costSummary?.total_usd === 'number' ? costSummary.total_usd : undefined
+  const costBadgeLabel = costMetadata
+    ? `${costMetadata.billing_mode === 'reused' ? 'Reused' : 'Spent'} ${formatUsd(costTotal)}`
+    : null
+  const showMetadataBadges = showMessageTypeBadge || showToolNameBadge || Boolean(costBadgeLabel)
 
   return (
     <Message
@@ -885,55 +923,129 @@ const MemoizedMessageRow = React.memo(function MessageRow({
                   {message.toolName}
                 </Badge>
               )}
+              {costBadgeLabel && (
+                <Badge variant="pill" className="text-xs px-1.5 py-0 font-normal bg-info text-primary-foreground">
+                  {costBadgeLabel}
+                </Badge>
+              )}
             </div>
           )}
 
           {toolViewModel ? (
-            <Tool
-              defaultOpen={
-                EVALUATION_TOOL_NAMES.has(toolViewModel.toolName) ||
-                toolViewModel.state === 'output-error'
-              }
-            >
-              <ToolHeader
-                toolType={toolViewModel.type}
-                state={toolViewModel.state}
-                toolName={toolViewModel.toolName}
-              />
-              <ToolContent>
-                {(message.messageType === 'TOOL_CALL' || message.messageType === 'TOOL_RESPONSE') && toolViewModel.input !== undefined && (
-                  <ToolInput input={toolViewModel.input} />
-                )}
-                {(message.messageType === 'TOOL_RESPONSE' || (message.messageType === 'TOOL_CALL' && toolViewModel.output !== undefined)) && (
-                  EVALUATION_TOOL_NAMES.has(toolViewModel.toolName) && toolViewModel.state !== 'output-error' && toolViewModel.output != null ? (
-                    <React.Suspense fallback={
-                      <div className="rounded-md bg-card p-3">
-                        <div className="h-4 w-40 animate-pulse rounded bg-muted mb-2" />
-                        <div className="h-3 w-full animate-pulse rounded bg-muted/80" />
-                      </div>
-                    }>
-                      <EvaluationToolOutput toolOutput={toolViewModel.output} />
-                    </React.Suspense>
-                  ) : (
-                    <ToolOutput
-                      errorText={toolViewModel.errorText}
-                      output={
-                        <div className="font-mono whitespace-pre-wrap break-words">
-                          {toolViewModel.output === undefined || toolViewModel.output === null
-                            ? 'No output'
-                            : typeof toolViewModel.output === 'string'
-                              ? toolViewModel.output
-                              : formatJsonWithNewlines(toolViewModel.output)}
+            <div className="space-y-2">
+              <Tool
+                defaultOpen={
+                  EVALUATION_TOOL_NAMES.has(toolViewModel.toolName) ||
+                  toolViewModel.state === 'output-error'
+                }
+              >
+                <ToolHeader
+                  toolType={toolViewModel.type}
+                  state={toolViewModel.state}
+                  toolName={toolViewModel.toolName}
+                />
+                <ToolContent>
+                  {(message.messageType === 'TOOL_CALL' || message.messageType === 'TOOL_RESPONSE') && toolViewModel.input !== undefined && (
+                    <ToolInput input={toolViewModel.input} />
+                  )}
+                  {(message.messageType === 'TOOL_RESPONSE' || (message.messageType === 'TOOL_CALL' && toolViewModel.output !== undefined)) && (
+                    EVALUATION_TOOL_NAMES.has(toolViewModel.toolName) && toolViewModel.state !== 'output-error' && toolViewModel.output != null ? (
+                      <React.Suspense fallback={
+                        <div className="rounded-md bg-card p-3">
+                          <div className="h-4 w-40 animate-pulse rounded bg-muted mb-2" />
+                          <div className="h-3 w-full animate-pulse rounded bg-muted/80" />
                         </div>
-                      }
-                    />
-                  )
-                )}
-              </ToolContent>
-            </Tool>
+                      }>
+                        <EvaluationToolOutput toolOutput={toolViewModel.output} />
+                      </React.Suspense>
+                    ) : (
+                      <ToolOutput
+                        errorText={toolViewModel.errorText}
+                        output={
+                          <div className="font-mono whitespace-pre-wrap break-words">
+                            {toolViewModel.output === undefined || toolViewModel.output === null
+                              ? 'No output'
+                              : typeof toolViewModel.output === 'string'
+                                ? toolViewModel.output
+                                : formatJsonWithNewlines(toolViewModel.output)}
+                          </div>
+                        }
+                      />
+                    )
+                  )}
+                </ToolContent>
+              </Tool>
+              {costMetadata && costSummary && (
+                <details className="rounded border border-border/40 p-2 text-xs">
+                  <summary className="cursor-pointer text-muted-foreground">
+                    Cost details
+                  </summary>
+                  <div className="mt-2 space-y-1 tabular-nums">
+                    <div>Total: {formatUsd(costSummary.total_usd)}</div>
+                    <div>LLM calls: {costSummary.llm_calls ?? 0}</div>
+                    <div>Tokens: {costSummary.total_tokens ?? 0}</div>
+                    {Array.isArray(costSummary.breakdown) && costSummary.breakdown.length > 0 && (
+                      <table className="w-full mt-2">
+                        <thead className="text-muted-foreground/70">
+                          <tr>
+                            <th className="text-left font-medium">Model</th>
+                            <th className="text-right font-medium">Spent</th>
+                            <th className="text-right font-medium">Reused</th>
+                            <th className="text-right font-medium">Tokens</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {costSummary.breakdown.map((row: any, idx: number) => (
+                            <tr key={`${row.provider ?? 'none'}|${row.model ?? 'none'}|${idx}`}>
+                              <td className="py-0.5 pr-2">{row.provider || 'unknown'} / {row.model || 'unknown'}</td>
+                              <td className="py-0.5 text-right">{formatUsd(Number(row.spent_usd ?? 0))}</td>
+                              <td className="py-0.5 text-right">{formatUsd(Number(row.reused_usd ?? 0))}</td>
+                              <td className="py-0.5 text-right">{Number(row.total_tokens ?? 0)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    )}
+                  </div>
+                </details>
+              )}
+            </div>
           ) : (
-            <div className="text-sm">
+            <div className="text-sm space-y-2">
               <CollapsibleText content={message.content} />
+              {costMetadata && costSummary && (
+                <details className="rounded border border-border/40 p-2 text-xs">
+                  <summary className="cursor-pointer text-muted-foreground">
+                    Cost details
+                  </summary>
+                  <div className="mt-2 space-y-1 tabular-nums">
+                    <div>Total: {formatUsd(costSummary.total_usd)}</div>
+                    <div>LLM calls: {costSummary.llm_calls ?? 0}</div>
+                    <div>Prompt tokens: {costSummary.prompt_tokens ?? 0}</div>
+                    <div>Completion tokens: {costSummary.completion_tokens ?? 0}</div>
+                    {Array.isArray(costSummary.breakdown) && costSummary.breakdown.length > 0 && (
+                      <table className="w-full mt-2">
+                        <thead className="text-muted-foreground/70">
+                          <tr>
+                            <th className="text-left font-medium">Model</th>
+                            <th className="text-right font-medium">Spent</th>
+                            <th className="text-right font-medium">Tokens</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {costSummary.breakdown.map((row: any, idx: number) => (
+                            <tr key={`${row.provider ?? 'none'}|${row.model ?? 'none'}|${idx}`}>
+                              <td className="py-0.5 pr-2">{row.provider || 'unknown'} / {row.model || 'unknown'}</td>
+                              <td className="py-0.5 text-right">{formatUsd(Number(row.referenced_usd ?? row.spent_usd ?? 0))}</td>
+                              <td className="py-0.5 text-right">{Number(row.total_tokens ?? 0)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    )}
+                  </div>
+                </details>
+              )}
             </div>
           )}
 

--- a/dashboard/features/evaluations/components/EvaluationCard.tsx
+++ b/dashboard/features/evaluations/components/EvaluationCard.tsx
@@ -98,6 +98,7 @@ export const EvaluationCard = React.memo(({
     startedAt: evaluation.startedAt || undefined,
     errorMessage: evaluation.errorMessage || undefined,
     errorDetails: evaluation.errorDetails || null,
+    parameters: (evaluation as any).parameters ?? null,
     dataSetId: (evaluation as any).dataSetId ?? null,
     scoreResults: evaluation.scoreResults as any, // Pass the transformed score results with itemIdentifiers
     task: taskData

--- a/dashboard/features/evaluations/hooks/useEvaluationData.ts
+++ b/dashboard/features/evaluations/hooks/useEvaluationData.ts
@@ -39,6 +39,34 @@ const getStageItemsFromAny = (stages: any): TaskStageType[] => {
   return [] as TaskStageType[];
 };
 
+const formatSubscriptionError = (error: unknown) => {
+  const source = error as any;
+  const graphQLErrors = source?.errors ?? source?.graphQLErrors ?? null;
+  const networkError = source?.networkError ?? null;
+  const message =
+    (typeof source?.message === 'string' && source.message) ||
+    (Array.isArray(graphQLErrors) && graphQLErrors.length > 0 ? String(graphQLErrors[0]?.message || '') : '') ||
+    '';
+
+  let raw: string | null = null;
+  try {
+    if (error == null) raw = null;
+    else if (typeof error === 'string') raw = error;
+    else raw = JSON.stringify(error, Object.getOwnPropertyNames(error as object));
+  } catch {
+    raw = String(error);
+  }
+
+  return {
+    name: source?.name ?? null,
+    message: message || null,
+    graphQLErrors,
+    networkError,
+    raw,
+    isEmpty: !message && !graphQLErrors && !networkError && (raw === '{}' || raw === null),
+  };
+};
+
 // Add type for score result
 type ScoreResult = {
   id: string;
@@ -1042,7 +1070,10 @@ export function useEvaluationData({
                 existingEval.status !== transformedEvaluation.status ||
                 existingEval.accuracy !== transformedEvaluation.accuracy ||
                 existingEval.processedItems !== transformedEvaluation.processedItems ||
-                existingEval.totalItems !== transformedEvaluation.totalItems;
+                existingEval.totalItems !== transformedEvaluation.totalItems ||
+                existingEval.parameters !== transformedEvaluation.parameters ||
+                existingEval.cost !== transformedEvaluation.cost ||
+                existingEval.taskId !== transformedEvaluation.taskId;
 
               if (!isMeaningfulUpdate) {
                 console.log(`STAGE_TRACE: Skipping non-meaningful update for eval ${transformedEvaluation.id}`);
@@ -1065,6 +1096,8 @@ export function useEvaluationData({
                   // Preserve existing score results and scorecard/score names when updating evaluation
                   const updatedEval: ProcessedEvaluation = {
                     ...transformedEvaluation,
+                    // Preserve prior parameter payload when a partial update omits it.
+                    parameters: transformedEvaluation.parameters ?? e.parameters,
                     scoreResults: e.scoreResults || transformedEvaluation.scoreResults,
                     scorecard: transformedEvaluation.scorecard || e.scorecard,
                     score: transformedEvaluation.score || e.score,
@@ -1223,7 +1256,12 @@ export function useEvaluationData({
         }
       },
       error: (error: Error) => {
-        console.error('Error in evaluation update subscription:', error);
+        const details = formatSubscriptionError(error);
+        if (details.isEmpty) {
+          console.warn('Evaluation update subscription emitted an empty error payload (likely transient transport reconnect).', details);
+          return;
+        }
+        console.error('Error in evaluation update subscription:', details);
       }
     });
     subscriptions.push(evaluationUpdateSubscription);
@@ -1238,7 +1276,12 @@ export function useEvaluationData({
         }
       },
       error: (error: Error) => {
-        console.error('Error in task update subscription:', error);
+        const details = formatSubscriptionError(error);
+        if (details.isEmpty) {
+          console.warn('Task update subscription emitted an empty error payload (likely transient transport reconnect).', details);
+          return;
+        }
+        console.error('Error in task update subscription:', details);
       }
     });
     subscriptions.push(taskSubscription);
@@ -1262,7 +1305,12 @@ export function useEvaluationData({
         }
       },
       error: (error: Error) => {
-console.error('STAGE_TRACE: Error in task stage update subscription:', error.message);
+        const details = formatSubscriptionError(error);
+        if (details.isEmpty) {
+          console.warn('Task stage update subscription emitted an empty error payload (likely transient transport reconnect).', details);
+          return;
+        }
+        console.error('STAGE_TRACE: Error in task stage update subscription:', details);
       }
     });
     subscriptions.push(stageSubscription);

--- a/dashboard/features/evaluations/hooks/useEvaluationSubscriptions.ts
+++ b/dashboard/features/evaluations/hooks/useEvaluationSubscriptions.ts
@@ -8,6 +8,34 @@ import {
   TASK_STAGE_UPDATE_SUBSCRIPTION 
 } from '../graphql/queries'
 
+const formatSubscriptionError = (error: unknown) => {
+  const source = error as any
+  const graphQLErrors = source?.errors ?? source?.graphQLErrors ?? null
+  const networkError = source?.networkError ?? null
+  const message =
+    (typeof source?.message === 'string' && source.message) ||
+    (Array.isArray(graphQLErrors) && graphQLErrors.length > 0 ? String(graphQLErrors[0]?.message || '') : '') ||
+    ''
+
+  let raw: string | null = null
+  try {
+    if (error == null) raw = null
+    else if (typeof error === 'string') raw = error
+    else raw = JSON.stringify(error, Object.getOwnPropertyNames(error as object))
+  } catch {
+    raw = String(error)
+  }
+
+  return {
+    name: source?.name ?? null,
+    message: message || null,
+    graphQLErrors,
+    networkError,
+    raw,
+    isEmpty: !message && !graphQLErrors && !networkError && (raw === '{}' || raw === null),
+  }
+}
+
 interface UseEvaluationSubscriptionsProps {
   accountId: string | null
   onEvaluationUpdate: (evaluation: Schema['Evaluation']['type']) => void
@@ -40,7 +68,12 @@ export function useEvaluationSubscriptions({
         }
       },
       error: (error: Error) => {
-        console.error('Error in evaluation update subscription:', error)
+        const details = formatSubscriptionError(error)
+        if (details.isEmpty) {
+          console.warn('Evaluation update subscription emitted an empty error payload (likely transient transport reconnect).', details)
+          return
+        }
+        console.error('Error in evaluation update subscription:', details)
       }
     })
     subscriptions.push(evaluationSub)
@@ -60,7 +93,12 @@ export function useEvaluationSubscriptions({
         }
       },
       error: (error: Error) => {
-        console.error('Error in task update subscription:', error)
+        const details = formatSubscriptionError(error)
+        if (details.isEmpty) {
+          console.warn('Task update subscription emitted an empty error payload (likely transient transport reconnect).', details)
+          return
+        }
+        console.error('Error in task update subscription:', details)
       }
     })
     subscriptions.push(taskSub)
@@ -79,7 +117,12 @@ export function useEvaluationSubscriptions({
         }
       },
       error: (error: Error) => {
-        console.error('Error in task stage update subscription:', error)
+        const details = formatSubscriptionError(error)
+        if (details.isEmpty) {
+          console.warn('Task stage update subscription emitted an empty error payload (likely transient transport reconnect).', details)
+          return
+        }
+        console.error('Error in task stage update subscription:', details)
       }
     })
     subscriptions.push(stageSub)

--- a/dashboard/utils/data-operations.ts
+++ b/dashboard/utils/data-operations.ts
@@ -1059,6 +1059,7 @@ export type Evaluation = {
   totalItems?: number | null;
   inferences?: number | null;
   cost?: number | null;
+  costDetails?: any;
   status?: string | null;
   elapsedSeconds?: number | null;
   estimatedRemainingSeconds?: number | null;

--- a/dashboard/utils/transformers.ts
+++ b/dashboard/utils/transformers.ts
@@ -217,6 +217,7 @@ export async function processTask(task: AmplifyTask): Promise<ProcessedTask> {
         inferences: Number(evaluationData.data?.inferences) || 0,
         accuracy: typeof evaluationData.data?.accuracy === 'number' ? evaluationData.data.accuracy : 0,
         cost: evaluationData.data?.cost ?? null,
+        costDetails: evaluationData.data?.costDetails ?? null,
         status: evaluationData.data?.status || 'PENDING',
         startedAt: evaluationData.data?.startedAt,
         elapsedSeconds: evaluationData.data?.elapsedSeconds ?? null,

--- a/plexus/Evaluation.py
+++ b/plexus/Evaluation.py
@@ -7,7 +7,7 @@ import pandas as pd
 import time
 import traceback
 from datetime import datetime, timezone, timedelta
-from typing import List, Optional
+from typing import List, Optional, Dict, Any, Tuple
 import asyncio
 from tenacity import retry, stop_after_attempt, wait_exponential
 from requests.exceptions import Timeout, RequestException
@@ -92,6 +92,80 @@ class Evaluation:
     The Evaluation class is commonly used during model development to measure performance
     and during production to monitor for accuracy drift.
     """
+
+    @staticmethod
+    def build_cost_details_from_expenses(expenses: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Build a compact provider/model cost summary from scorecard expenses."""
+        if not isinstance(expenses, dict):
+            return {
+                "schema_version": 1,
+                "total_usd": 0.0,
+                "llm_calls": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cached_tokens": 0,
+                "breakdown": [],
+            }
+
+        grouped: Dict[Tuple[Optional[str], Optional[str]], Dict[str, Any]] = {}
+        components = expenses.get("components")
+        if isinstance(components, list):
+            for component in components:
+                if not isinstance(component, dict):
+                    continue
+                if component.get("type") != "api_call":
+                    continue
+                provider_raw = component.get("provider")
+                model_raw = component.get("model")
+                provider = str(provider_raw) if isinstance(provider_raw, str) and provider_raw else None
+                model = str(model_raw) if isinstance(model_raw, str) and model_raw else None
+                key = (provider, model)
+                row = grouped.setdefault(
+                    key,
+                    {
+                        "provider": provider,
+                        "model": model,
+                        "spent_usd": 0.0,
+                        "reused_usd": 0.0,
+                        "referenced_usd": 0.0,
+                        "llm_calls": 0,
+                        "evaluation_runs": 0,
+                        "prompt_tokens": 0,
+                        "completion_tokens": 0,
+                        "total_tokens": 0,
+                        "cached_tokens": 0,
+                    },
+                )
+                usd = float(component.get("usd") or 0.0)
+                prompt_tokens = int(component.get("prompt_tokens") or 0)
+                completion_tokens = int(component.get("completion_tokens") or 0)
+                cached_tokens = int(component.get("cached_tokens") or 0)
+                row["spent_usd"] += usd
+                row["referenced_usd"] += usd
+                row["llm_calls"] += 1
+                row["prompt_tokens"] += prompt_tokens
+                row["completion_tokens"] += completion_tokens
+                row["total_tokens"] += prompt_tokens + completion_tokens
+                row["cached_tokens"] += cached_tokens
+
+        breakdown = list(grouped.values())
+        breakdown.sort(key=lambda item: item.get("referenced_usd", 0), reverse=True)
+
+        prompt_tokens = int(expenses.get("prompt_tokens") or 0)
+        completion_tokens = int(expenses.get("completion_tokens") or 0)
+        cached_tokens = int(expenses.get("cached_tokens") or 0)
+        total_tokens = prompt_tokens + completion_tokens
+        return {
+            "schema_version": 1,
+            "total_usd": float(expenses.get("total_cost") or 0.0),
+            "llm_calls": int(expenses.get("llm_calls") or expenses.get("api_calls") or 0),
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "cached_tokens": cached_tokens,
+            "breakdown": breakdown,
+        }
 
     def __init__(self, *,
         scorecard_name: str,
@@ -1580,6 +1654,7 @@ class Evaluation:
                 total_cost = expenses.get('total_cost', 0)
                 if total_cost > 0:
                     update_input["cost"] = float(total_cost)
+                update_input["costDetails"] = self.build_cost_details_from_expenses(expenses)
         except Exception as e:
             logging.debug(f"Could not get accumulated costs: {e}")
         
@@ -2806,6 +2881,7 @@ Total cost:       ${expenses['total_cost']:.6f}
                 'total_items': evaluation.totalItems,
                 'processed_items': evaluation.processedItems,
                 'cost': evaluation.cost,
+                'cost_details': evaluation.costDetails,
                 'elapsed_seconds': evaluation.elapsedSeconds,
                 'estimated_remaining_seconds': evaluation.estimatedRemainingSeconds,
                 'started_at': evaluation.startedAt.isoformat() if evaluation.startedAt else None,
@@ -5444,3 +5520,76 @@ class AccuracyEvaluation(Evaluation):
             use_cache=True,  # Use cached YAML files when available (supports --yaml mode)
             yaml_only=False  # Allow API calls if needed
         )
+    @staticmethod
+    def build_cost_details_from_expenses(expenses: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Build a compact provider/model cost summary from scorecard expenses."""
+        if not isinstance(expenses, dict):
+            return {
+                "schema_version": 1,
+                "total_usd": 0.0,
+                "llm_calls": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cached_tokens": 0,
+                "breakdown": [],
+            }
+
+        grouped: Dict[Tuple[Optional[str], Optional[str]], Dict[str, Any]] = {}
+        components = expenses.get("components")
+        if isinstance(components, list):
+            for component in components:
+                if not isinstance(component, dict):
+                    continue
+                if component.get("type") != "api_call":
+                    continue
+                provider_raw = component.get("provider")
+                model_raw = component.get("model")
+                provider = str(provider_raw) if isinstance(provider_raw, str) and provider_raw else None
+                model = str(model_raw) if isinstance(model_raw, str) and model_raw else None
+                key = (provider, model)
+                row = grouped.setdefault(
+                    key,
+                    {
+                        "provider": provider,
+                        "model": model,
+                        "spent_usd": 0.0,
+                        "reused_usd": 0.0,
+                        "referenced_usd": 0.0,
+                        "llm_calls": 0,
+                        "evaluation_runs": 0,
+                        "prompt_tokens": 0,
+                        "completion_tokens": 0,
+                        "total_tokens": 0,
+                        "cached_tokens": 0,
+                    },
+                )
+                usd = float(component.get("usd") or 0.0)
+                prompt_tokens = int(component.get("prompt_tokens") or 0)
+                completion_tokens = int(component.get("completion_tokens") or 0)
+                cached_tokens = int(component.get("cached_tokens") or 0)
+                row["spent_usd"] += usd
+                row["referenced_usd"] += usd
+                row["llm_calls"] += 1
+                row["prompt_tokens"] += prompt_tokens
+                row["completion_tokens"] += completion_tokens
+                row["total_tokens"] += prompt_tokens + completion_tokens
+                row["cached_tokens"] += cached_tokens
+
+        breakdown = list(grouped.values())
+        breakdown.sort(key=lambda item: item.get("referenced_usd", 0), reverse=True)
+
+        prompt_tokens = int(expenses.get("prompt_tokens") or 0)
+        completion_tokens = int(expenses.get("completion_tokens") or 0)
+        cached_tokens = int(expenses.get("cached_tokens") or 0)
+        total_tokens = prompt_tokens + completion_tokens
+        return {
+            "schema_version": 1,
+            "total_usd": float(expenses.get("total_cost") or 0.0),
+            "llm_calls": int(expenses.get("llm_calls") or expenses.get("api_calls") or 0),
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "cached_tokens": cached_tokens,
+            "breakdown": breakdown,
+        }

--- a/plexus/Evaluation.py
+++ b/plexus/Evaluation.py
@@ -143,7 +143,7 @@ class Evaluation:
                 cached_tokens = int(component.get("cached_tokens") or 0)
                 row["spent_usd"] += usd
                 row["referenced_usd"] += usd
-                row["llm_calls"] += 1
+                row["llm_calls"] += int(component.get("llm_calls") or 1)
                 row["prompt_tokens"] += prompt_tokens
                 row["completion_tokens"] += completion_tokens
                 row["total_tokens"] += prompt_tokens + completion_tokens
@@ -1598,6 +1598,27 @@ class Evaluation:
         }
         """
 
+    @staticmethod
+    def _coerce_parameters_dict(raw_parameters: Any) -> Optional[Dict[str, Any]]:
+        if isinstance(raw_parameters, dict):
+            return dict(raw_parameters)
+        if isinstance(raw_parameters, str):
+            try:
+                parsed = json.loads(raw_parameters)
+                if isinstance(parsed, dict):
+                    return parsed
+            except Exception:
+                return None
+        return None
+
+    def _get_existing_parameters_for_update(self) -> Dict[str, Any]:
+        local = self._coerce_parameters_dict(getattr(self, "parameters", None))
+        if isinstance(local, dict):
+            return local
+        # Keep progress updates fast and side-effect free: do not make network reads
+        # in this hot path. If local parameters are unavailable, skip merge.
+        return {}
+
     def _get_update_variables(self, metrics, status):
         """Get the variables for the update mutation"""
         elapsed_seconds = int((datetime.now(timezone.utc) - self.started_at).total_seconds())
@@ -1654,7 +1675,22 @@ class Evaluation:
                 total_cost = expenses.get('total_cost', 0)
                 if total_cost > 0:
                     update_input["cost"] = float(total_cost)
-                update_input["costDetails"] = self.build_cost_details_from_expenses(expenses)
+                if status == "COMPLETED":
+                    cost_details = self.build_cost_details_from_expenses(expenses)
+                    existing_parameters = self._get_existing_parameters_for_update()
+                    if existing_parameters:
+                        metadata = existing_parameters.get("metadata")
+                        if not isinstance(metadata, dict):
+                            metadata = {}
+                        metadata["cost_details"] = cost_details
+                        existing_parameters["metadata"] = metadata
+                        update_input["parameters"] = json.dumps(existing_parameters)
+                        self.parameters = existing_parameters
+                    else:
+                        self.logging.debug(
+                            "Skipping cost_details parameter write for evaluation %s because local parameters are unavailable",
+                            getattr(self, "experiment_id", None),
+                        )
         except Exception as e:
             logging.debug(f"Could not get accumulated costs: {e}")
         
@@ -2859,6 +2895,14 @@ Total cost:       ${expenses['total_cost']:.6f}
                     logging.warning(f"Could not parse dataset class distribution: {e}")
                     dataset_class_distribution = evaluation.datasetClassDistribution
             
+            cost_details = getattr(evaluation, "costDetails", None)
+            if not isinstance(cost_details, dict) and isinstance(parameters, dict):
+                metadata = parameters.get("metadata")
+                if isinstance(metadata, dict):
+                    metadata_cost_details = metadata.get("cost_details")
+                    if isinstance(metadata_cost_details, dict):
+                        cost_details = metadata_cost_details
+
             result = {
                 'id': evaluation.id,
                 'type': evaluation.type,
@@ -2881,7 +2925,7 @@ Total cost:       ${expenses['total_cost']:.6f}
                 'total_items': evaluation.totalItems,
                 'processed_items': evaluation.processedItems,
                 'cost': evaluation.cost,
-                'cost_details': evaluation.costDetails,
+                'cost_details': cost_details,
                 'elapsed_seconds': evaluation.elapsedSeconds,
                 'estimated_remaining_seconds': evaluation.estimatedRemainingSeconds,
                 'started_at': evaluation.startedAt.isoformat() if evaluation.startedAt else None,
@@ -5570,7 +5614,7 @@ class AccuracyEvaluation(Evaluation):
                 cached_tokens = int(component.get("cached_tokens") or 0)
                 row["spent_usd"] += usd
                 row["referenced_usd"] += usd
-                row["llm_calls"] += 1
+                row["llm_calls"] += int(component.get("llm_calls") or 1)
                 row["prompt_tokens"] += prompt_tokens
                 row["completion_tokens"] += completion_tokens
                 row["total_tokens"] += prompt_tokens + completion_tokens

--- a/plexus/Scorecard.py
+++ b/plexus/Scorecard.py
@@ -89,6 +89,7 @@ class Scorecard:
         self.total_cost = Decimal("0.0")
         self.scorecard_total_cost = Decimal("0.0")
         self.cost_per_text = Decimal("0.0")
+        self.cost_components = []
         # Track how many texts have been processed by this scorecard instance
         self.number_of_texts_processed = 0
 
@@ -707,6 +708,8 @@ class Scorecard:
                 self.cost_per_text += Decimal(
                     str(score_total_cost.get("cost_per_text", 0))
                 )
+                if isinstance(score_total_cost.get("components"), list):
+                    self.cost_components.extend(score_total_cost.get("components"))
 
                 # Log CloudWatch metrics for this individual score
                 total_tokens = score_total_cost.get(
@@ -1290,6 +1293,7 @@ class Scorecard:
             "output_cost": self.output_cost,
             "total_cost": self.total_cost,
             "cost_per_text": cost_per_text,
+            "components": self.cost_components,
         }
 
     def get_model_name(self, name=None, id=None, key=None):

--- a/plexus/cli/procedure/lua_dsl/runtime.py
+++ b/plexus/cli/procedure/lua_dsl/runtime.py
@@ -311,7 +311,7 @@ class LuaDSLRuntime:
                     pass
             if chat_recorder and chat_recorder.session_id:
                 try:
-                    await chat_recorder.end_session(status='COMPLETED')
+                    await chat_recorder.end_session(status='FAILED')
                 except Exception as e:
                     logger.warning(f"Failed to end chat session: {e}")
 
@@ -347,7 +347,7 @@ class LuaDSLRuntime:
                     pass
             if chat_recorder and chat_recorder.session_id:
                 try:
-                    await chat_recorder.end_session(status='COMPLETED')
+                    await chat_recorder.end_session(status='FAILED')
                 except Exception as e:
                     logger.warning(f"Failed to end chat session: {e}")
 
@@ -383,7 +383,7 @@ class LuaDSLRuntime:
                     pass
             if chat_recorder and chat_recorder.session_id:
                 try:
-                    await chat_recorder.end_session(status='COMPLETED')
+                    await chat_recorder.end_session(status='FAILED')
                 except Exception as e:
                     logger.warning(f"Failed to end chat session: {e}")
 

--- a/plexus/cli/procedure/lua_dsl/test_runtime_failure_session_status.py
+++ b/plexus/cli/procedure/lua_dsl/test_runtime_failure_session_status.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from plexus.cli.procedure.lua_dsl.lua_sandbox import LuaSandboxError
+from plexus.cli.procedure.lua_dsl.runtime import LuaDSLRuntime
+
+
+class _DummyPrimitive:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def flush_recordings(self):
+        return None
+
+    async def save(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_runtime_marks_chat_session_failed_when_execution_errors(monkeypatch):
+    recorder = AsyncMock()
+    recorder.start_session.return_value = "sess-1"
+    recorder.session_id = "sess-1"
+
+    monkeypatch.setattr(
+        "plexus.cli.procedure.chat_recorder.ProcedureChatRecorder",
+        lambda *_args, **_kwargs: recorder,
+    )
+    monkeypatch.setattr(
+        "plexus.cli.procedure.lua_dsl.runtime.ProcedureYAMLParser.parse",
+        lambda _yaml: {
+            "name": "Test Procedure",
+            "version": "1.0.0",
+            "outputs": {},
+            "hitl": {},
+            "stages": [],
+            "agents": {
+                "worker": {
+                    "system_prompt": "sys",
+                    "initial_message": "hello",
+                    "tools": [],
+                }
+            },
+            "workflow": "return {}",
+        },
+    )
+    monkeypatch.setattr(
+        "plexus.dashboard.api.models.procedure.Procedure.get_by_id",
+        lambda *_args, **_kwargs: SimpleNamespace(accountId="acct-1"),
+    )
+    monkeypatch.setattr(
+        "plexus.cli.procedure.lua_dsl.runtime.LocalExecutionContext",
+        lambda **_kwargs: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        "plexus.cli.procedure.lua_dsl.runtime.LuaDSLRuntime._initialize_primitives",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "plexus.cli.procedure.lua_dsl.runtime.LuaDSLRuntime._setup_agents",
+        AsyncMock(side_effect=LuaSandboxError("synthetic runtime failure")),
+    )
+
+    for symbol in (
+        "HumanPrimitive",
+        "SystemPrimitive",
+        "StepPrimitive",
+        "CheckpointPrimitive",
+        "LogPrimitive",
+        "SessionPrimitive",
+        "StagePrimitive",
+        "JsonPrimitive",
+        "RetryPrimitive",
+        "FilePrimitive",
+        "ProcedurePrimitive",
+    ):
+        monkeypatch.setattr(f"plexus.cli.procedure.lua_dsl.runtime.{symbol}", _DummyPrimitive)
+
+    runtime = LuaDSLRuntime(
+        procedure_id="proc-123",
+        client=SimpleNamespace(),
+        mcp_server=None,
+        openai_api_key="test-key",
+    )
+
+    result = await runtime.execute("ignored")
+
+    assert result["success"] is False
+    assert "Lua execution error" in result["error"]
+    recorder.end_session.assert_awaited_once_with(status="FAILED")

--- a/plexus/cli/procedure/procedure_executor.py
+++ b/plexus/cli/procedure/procedure_executor.py
@@ -129,6 +129,7 @@ def _persist_inference_costs_to_state(storage: Any, procedure_id: str, cost_even
         inference_total = 0.0
         by_agent: Dict[str, float] = {}
         by_model: Dict[str, float] = {}
+        grouped_breakdown: Dict[str, Dict[str, Any]] = {}
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
@@ -145,11 +146,51 @@ def _persist_inference_costs_to_state(storage: Any, procedure_id: str, cost_even
             if isinstance(model_name, str) and model_name:
                 by_model[model_name] = by_model.get(model_name, 0.0) + entry_cost
 
+            provider_name = entry.get("provider")
+            provider_key = provider_name if isinstance(provider_name, str) and provider_name else ""
+            model_key = model_name if isinstance(model_name, str) and model_name else ""
+            breakdown_key = f"{provider_key}|{model_key}"
+            row = grouped_breakdown.get(breakdown_key)
+            if row is None:
+                row = {
+                    "provider": provider_key or None,
+                    "model": model_key or None,
+                    "spent_usd": 0.0,
+                    "reused_usd": 0.0,
+                    "referenced_usd": 0.0,
+                    "llm_calls": 0,
+                    "evaluation_runs": 0,
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                    "cached_tokens": 0,
+                }
+                grouped_breakdown[breakdown_key] = row
+
+            prompt_tokens = _to_int(entry.get("prompt_tokens")) or 0
+            completion_tokens = _to_int(entry.get("completion_tokens")) or 0
+            total_tokens = _to_int(entry.get("total_tokens"))
+            if total_tokens is None:
+                total_tokens = prompt_tokens + completion_tokens
+            row["spent_usd"] += entry_cost
+            row["referenced_usd"] += entry_cost
+            row["llm_calls"] += 1
+            row["prompt_tokens"] += prompt_tokens
+            row["completion_tokens"] += completion_tokens
+            row["total_tokens"] += total_tokens
+            if entry.get("cache_hit") is True:
+                row["cached_tokens"] += total_tokens
+
         inference["entries"] = entries
         inference["seen_signatures"] = seen_signatures
         inference["total"] = inference_total
         inference["by_agent"] = by_agent
         inference["by_model"] = by_model
+        inference["breakdown"] = sorted(
+            grouped_breakdown.values(),
+            key=lambda item: float(item.get("referenced_usd", 0.0)),
+            reverse=True,
+        )
         costs["inference"] = inference
 
         evaluation = costs.get("evaluation") or {}

--- a/plexus/cli/procedure/procedure_executor.py
+++ b/plexus/cli/procedure/procedure_executor.py
@@ -421,7 +421,8 @@ class _PlexusTraceLogBridge:
                     self._on_cost_event(event)
                 except Exception as exc:
                     logger.warning("Failed processing incremental cost event: %s", exc)
-            return
+            # Also forward cost events to the trace sink so assistant/tool chat
+            # messages can receive live per-turn cost metadata updates.
 
         try:
             self._events.put_nowait(event)

--- a/plexus/cli/procedure/procedures.py
+++ b/plexus/cli/procedure/procedures.py
@@ -704,9 +704,14 @@ def run(procedure_id: Optional[str], yaml_file: Optional[str], max_iterations: O
         status = result.get('status', 'unknown')
         status_color = {
             'completed': 'green',
+            'COMPLETED': 'green',
             'running': 'yellow', 
+            'RUNNING': 'yellow',
+            'WAITING_FOR_HUMAN': 'yellow',
             'initiated': 'blue',
-            'error': 'red'
+            'error': 'red',
+            'FAILED': 'red',
+            'failed': 'red',
         }.get(status, 'white')
         
         console.print(f"[{status_color}]✓ {result.get('message', 'Procedure run completed')}[/{status_color}]")
@@ -1324,7 +1329,17 @@ def continue_(procedure_id: str, additional_cycles: int, hint: Optional[str], ou
         console.print(_json.dumps(result, indent=2, default=str))
     else:
         status = result.get('status', 'unknown')
-        color = {'completed': 'green', 'running': 'yellow', 'initiated': 'blue', 'error': 'red'}.get(status, 'white')
+        color = {
+            'completed': 'green',
+            'COMPLETED': 'green',
+            'running': 'yellow',
+            'RUNNING': 'yellow',
+            'WAITING_FOR_HUMAN': 'yellow',
+            'initiated': 'blue',
+            'error': 'red',
+            'FAILED': 'red',
+            'failed': 'red',
+        }.get(status, 'white')
         console.print(f"[{color}]{result.get('message', 'Continuation dispatched')}[/{color}]")
         console.print(f"Procedure: {procedure_id} | Task: {result.get('task_id', 'N/A')}")
 
@@ -1401,7 +1416,17 @@ def branch(source_id: str, cycle: int, additional_cycles: int, hint: Optional[st
         console.print(_json.dumps({**info, **result}, indent=2, default=str))
     else:
         status = result.get('status', 'unknown')
-        color = {'completed': 'green', 'running': 'yellow', 'initiated': 'blue', 'error': 'red'}.get(status, 'white')
+        color = {
+            'completed': 'green',
+            'COMPLETED': 'green',
+            'running': 'yellow',
+            'RUNNING': 'yellow',
+            'WAITING_FOR_HUMAN': 'yellow',
+            'initiated': 'blue',
+            'error': 'red',
+            'FAILED': 'red',
+            'failed': 'red',
+        }.get(status, 'white')
         console.print(f"[{color}]{result.get('message', 'Branch dispatched')}[/{color}]")
         console.print(f"Branch procedure: {target_id} | Task: {result.get('task_id', 'N/A')}")
 

--- a/plexus/cli/procedure/tactus_adapters/storage.py
+++ b/plexus/cli/procedure/tactus_adapters/storage.py
@@ -170,6 +170,33 @@ class PlexusStorageAdapter:
         self._metadata_cache: Optional[ProcedureMetadata] = None
         logger.info(f"PlexusStorageAdapter initialized for procedure {procedure_id}")
 
+    def _fetch_raw_procedure_metadata(self, procedure_id: str) -> Dict[str, Any]:
+        """Fetch the current raw Procedure.metadata envelope for merge-safe writes."""
+        if self._is_builtin:
+            return {}
+
+        query = """
+        query GetProcedure($id: ID!) {
+            getProcedure(id: $id) {
+                id
+                metadata
+            }
+        }
+        """
+
+        response = self.client.execute(query, {'id': procedure_id})
+        procedure_data = response.get('getProcedure') or {}
+        raw_metadata = procedure_data.get('metadata') or {}
+        if isinstance(raw_metadata, str):
+            try:
+                raw_metadata = json.loads(raw_metadata)
+            except Exception:
+                logger.warning("Procedure metadata was not valid JSON during merge; defaulting to empty object")
+                raw_metadata = {}
+        if not isinstance(raw_metadata, dict):
+            return {}
+        return raw_metadata
+
     def load_procedure_metadata(self, procedure_id: str) -> ProcedureMetadata:
         """
         Load procedure metadata from Plexus via GraphQL.
@@ -304,13 +331,15 @@ class PlexusStorageAdapter:
                     entry['run_id'] = checkpoint.run_id
                 checkpoints_dict[name] = entry
 
-        # Build metadata JSON
-        metadata_json = {
+        # Build metadata JSON. Preserve any unrelated top-level keys already on
+        # the Procedure record (for example runtime/last_failure telemetry).
+        metadata_json = self._fetch_raw_procedure_metadata(metadata.procedure_id)
+        metadata_json.update({
             'checkpoints': checkpoints_dict,
             'state': metadata.state,
             'lua_state': metadata.lua_state,
             'replay_index': metadata.replay_index
-        }
+        })
 
         # Update via GraphQL mutation
         mutation = """

--- a/plexus/cli/procedure/tactus_adapters/trace.py
+++ b/plexus/cli/procedure/tactus_adapters/trace.py
@@ -6,7 +6,7 @@ import logging
 import inspect
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +54,202 @@ class PlexusTraceSink:
         self._backend_execution_started_at: str = datetime.now(timezone.utc).isoformat()
         self._backend_runtime_execute_started_at: Optional[str] = None
         self._session_context: Optional[Dict[str, Any]] = None
+        self._agent_cost_summaries: Dict[str, Dict[str, Any]] = {}
+        self._message_metadata_cache: Dict[str, Dict[str, Any]] = {}
+
+    def _empty_cost_summary(self) -> Dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "total_usd": 0.0,
+            "llm_calls": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "cached_tokens": 0,
+            "breakdown": [],
+        }
+
+    def _merge_cost_row(self, summary: Dict[str, Any], row: Dict[str, Any], *, reused: bool) -> None:
+        provider = row.get("provider")
+        model = row.get("model")
+        key = f"{provider or ''}|{model or ''}"
+        index = summary.setdefault("_index", {})
+        breakdown = summary.setdefault("breakdown", [])
+        target = index.get(key)
+        if not isinstance(target, dict):
+            target = {
+                "provider": provider,
+                "model": model,
+                "spent_usd": 0.0,
+                "reused_usd": 0.0,
+                "referenced_usd": 0.0,
+                "llm_calls": 0,
+                "evaluation_runs": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cached_tokens": 0,
+            }
+            index[key] = target
+            breakdown.append(target)
+
+        spent = float(row.get("spent_usd") or 0.0)
+        reused_amount = float(row.get("reused_usd") or 0.0)
+        referenced = float(row.get("referenced_usd") or (spent + reused_amount))
+        target["spent_usd"] += 0.0 if reused else spent
+        target["reused_usd"] += referenced if reused else reused_amount
+        target["referenced_usd"] += referenced
+        target["llm_calls"] += int(row.get("llm_calls") or 0)
+        target["evaluation_runs"] += int(row.get("evaluation_runs") or 0)
+        target["prompt_tokens"] += int(row.get("prompt_tokens") or 0)
+        target["completion_tokens"] += int(row.get("completion_tokens") or 0)
+        target["total_tokens"] += int(row.get("total_tokens") or 0)
+        target["cached_tokens"] += int(row.get("cached_tokens") or 0)
+
+    def _finalize_summary(self, summary: Dict[str, Any]) -> Dict[str, Any]:
+        out = dict(summary)
+        breakdown = out.get("breakdown") or []
+        if isinstance(breakdown, list):
+            breakdown.sort(key=lambda item: float(item.get("referenced_usd", 0.0)), reverse=True)
+        out.pop("_index", None)
+        return out
+
+    def _summary_from_cost_event(self, event: Any) -> Dict[str, Any]:
+        prompt_tokens = int(_event_field(event, "prompt_tokens", default=0) or 0)
+        completion_tokens = int(_event_field(event, "completion_tokens", default=0) or 0)
+        total_tokens = int(_event_field(event, "total_tokens", default=prompt_tokens + completion_tokens) or 0)
+        total_cost = float(_event_field(event, "total_cost", "cost", default=0.0) or 0.0)
+        provider = _event_field(event, "provider")
+        model = _event_field(event, "model")
+        summary = self._empty_cost_summary()
+        summary["total_usd"] = total_cost
+        summary["llm_calls"] = 1
+        summary["prompt_tokens"] = prompt_tokens
+        summary["completion_tokens"] = completion_tokens
+        summary["total_tokens"] = total_tokens
+        summary["cached_tokens"] = total_tokens if _event_field(event, "cache_hit", default=False) else 0
+        self._merge_cost_row(
+            summary,
+            {
+                "provider": provider if isinstance(provider, str) and provider else None,
+                "model": model if isinstance(model, str) and model else None,
+                "spent_usd": total_cost,
+                "reused_usd": 0.0,
+                "referenced_usd": total_cost,
+                "llm_calls": 1,
+                "evaluation_runs": 0,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+                "cached_tokens": summary["cached_tokens"],
+            },
+            reused=False,
+        )
+        return summary
+
+    def _merge_cost_summaries(self, current: Optional[Dict[str, Any]], incoming: Optional[Dict[str, Any]], *, reused: bool = False) -> Dict[str, Any]:
+        merged = self._empty_cost_summary() if not isinstance(current, dict) else dict(current)
+        if "_index" not in merged:
+            merged["_index"] = {}
+            for row in merged.get("breakdown", []) or []:
+                if isinstance(row, dict):
+                    key = f"{row.get('provider') or ''}|{row.get('model') or ''}"
+                    merged["_index"][key] = row
+
+        incoming_summary = incoming if isinstance(incoming, dict) else self._empty_cost_summary()
+        merged["total_usd"] = float(merged.get("total_usd", 0.0) or 0.0) + float(incoming_summary.get("total_usd", 0.0) or 0.0)
+        merged["llm_calls"] = int(merged.get("llm_calls", 0) or 0) + int(incoming_summary.get("llm_calls", 0) or 0)
+        merged["prompt_tokens"] = int(merged.get("prompt_tokens", 0) or 0) + int(incoming_summary.get("prompt_tokens", 0) or 0)
+        merged["completion_tokens"] = int(merged.get("completion_tokens", 0) or 0) + int(incoming_summary.get("completion_tokens", 0) or 0)
+        merged["total_tokens"] = int(merged.get("total_tokens", 0) or 0) + int(incoming_summary.get("total_tokens", 0) or 0)
+        merged["cached_tokens"] = int(merged.get("cached_tokens", 0) or 0) + int(incoming_summary.get("cached_tokens", 0) or 0)
+
+        for row in incoming_summary.get("breakdown", []) or []:
+            if isinstance(row, dict):
+                self._merge_cost_row(merged, row, reused=reused)
+        return merged
+
+    def _tool_cost_summary(self, tool_result: Any) -> Tuple[Optional[Dict[str, Any]], str]:
+        if not isinstance(tool_result, dict):
+            return None, "spent"
+        billing_mode = "reused" if tool_result.get("_from_cache") is True else "spent"
+        cost_details = tool_result.get("cost_details")
+        if isinstance(cost_details, dict):
+            summary = self._empty_cost_summary()
+            summary["total_usd"] = float(cost_details.get("total_usd", tool_result.get("cost", 0.0)) or 0.0)
+            summary["llm_calls"] = int(cost_details.get("llm_calls", 0) or 0)
+            summary["prompt_tokens"] = int(cost_details.get("prompt_tokens", 0) or 0)
+            summary["completion_tokens"] = int(cost_details.get("completion_tokens", 0) or 0)
+            summary["total_tokens"] = int(cost_details.get("total_tokens", 0) or 0)
+            summary["cached_tokens"] = int(cost_details.get("cached_tokens", 0) or 0)
+            for row in cost_details.get("breakdown", []) or []:
+                if isinstance(row, dict):
+                    self._merge_cost_row(summary, row, reused=(billing_mode == "reused"))
+            return summary, billing_mode
+
+        if tool_result.get("cost") is None:
+            return None, billing_mode
+
+        total_cost = float(tool_result.get("cost") or 0.0)
+        summary = self._empty_cost_summary()
+        summary["total_usd"] = total_cost
+        summary["llm_calls"] = 0
+        self._merge_cost_row(
+            summary,
+            {
+                "provider": None,
+                "model": None,
+                "spent_usd": total_cost,
+                "reused_usd": 0.0,
+                "referenced_usd": total_cost,
+                "llm_calls": 0,
+                "evaluation_runs": 1,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cached_tokens": 0,
+            },
+            reused=(billing_mode == "reused"),
+        )
+        return summary, billing_mode
+
+    def _merged_metadata(self, message_id: str, patch: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        patch_data = patch if isinstance(patch, dict) else {}
+        current = self._message_metadata_cache.get(message_id, {})
+        merged = dict(current) if isinstance(current, dict) else {}
+        merged.update(patch_data)
+        self._message_metadata_cache[message_id] = merged
+        return merged if merged else None
+
+    def _agent_cost_metadata(self, agent_name: str, *, live: bool) -> Optional[Dict[str, Any]]:
+        summary = self._agent_cost_summaries.get(agent_name)
+        if not isinstance(summary, dict):
+            return None
+        return {
+            "cost": {
+                "kind": "assistant_inference",
+                "billing_mode": "spent",
+                "live": live,
+                "summary": self._finalize_summary(summary),
+            }
+        }
+
+    async def _record_cost_event(self, event: Any) -> None:
+        agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+        increment = self._summary_from_cost_event(event)
+        merged_summary = self._merge_cost_summaries(self._agent_cost_summaries.get(agent_name), increment)
+        self._agent_cost_summaries[agent_name] = merged_summary
+        message_id = self._active_stream_message_ids.get(agent_name)
+        if message_id:
+            metadata = self._merged_metadata(
+                message_id,
+                self._agent_cost_metadata(agent_name, live=True),
+            )
+            await self.chat_recorder.update_message(
+                message_id=message_id,
+                metadata=metadata,
+                human_interaction="CHAT_ASSISTANT",
+            )
 
     async def start_session(self, context: Optional[Dict[str, Any]] = None) -> Optional[str]:
         if isinstance(context, dict):
@@ -227,7 +423,7 @@ class PlexusTraceSink:
                 return message_id
 
             # Build metadata only when we're about to persist (avoids expensive timing calls on every chunk)
-            metadata = {
+            metadata_patch = {
                 "streaming": {
                     "state": "streaming",
                     "agent_name": agent_name,
@@ -235,6 +431,10 @@ class PlexusTraceSink:
                     "timings": self._build_stream_timing_metadata(agent_name),
                 }
             }
+            cost_patch = self._agent_cost_metadata(agent_name, live=True)
+            if cost_patch:
+                metadata_patch.update(cost_patch)
+            metadata = self._merged_metadata(message_id, metadata_patch)
 
             updated = await self.chat_recorder.update_message(
                 message_id=message_id,
@@ -261,6 +461,9 @@ class PlexusTraceSink:
                     "timings": self._build_stream_timing_metadata(agent_name),
                 }
             }
+            cost_patch = self._agent_cost_metadata(agent_name, live=True)
+            if cost_patch:
+                metadata.update(cost_patch)
             message_id = await self.chat_recorder.record_message(
                 role="ASSISTANT",
                 content=accumulated_text,
@@ -271,6 +474,7 @@ class PlexusTraceSink:
             if not message_id:
                 logger.warning("Failed creating streamed assistant message for %s", agent_name)
                 return None
+            self._message_metadata_cache[message_id] = metadata
             self._active_stream_message_ids[agent_name] = message_id
             self._active_stream_last_persisted_texts[agent_name] = accumulated_text
             self._active_stream_last_persisted_at[agent_name] = time.monotonic()
@@ -289,7 +493,7 @@ class PlexusTraceSink:
 
         self._active_stream_last_persisted_texts.pop(agent_name, None)
         self._active_stream_last_persisted_at.pop(agent_name, None)
-        metadata = {
+        metadata_patch = {
             "streaming": {
                 "state": "complete",
                 "agent_name": agent_name,
@@ -297,6 +501,10 @@ class PlexusTraceSink:
                 "timings": self._build_stream_timing_metadata(agent_name),
             }
         }
+        cost_patch = self._agent_cost_metadata(agent_name, live=False)
+        if cost_patch:
+            metadata_patch.update(cost_patch)
+        metadata = self._merged_metadata(message_id, metadata_patch)
         await self.chat_recorder.update_message(
             message_id=message_id,
             content=final_text or None,
@@ -333,7 +541,10 @@ class PlexusTraceSink:
         event_kind = str(raw_kind or "").strip().upper()
         event_type = str(_event_field(event, "event_type", default="") or "").strip().lower()
 
-        if event_type in {"log", "cost", "execution_summary"}:
+        if event_type in {"log", "execution_summary"}:
+            return None
+        if event_type == "cost":
+            await self._record_cost_event(event)
             return None
 
         # ToolCallStartedEvent: tool is about to run — write a pending TOOL_CALL record
@@ -364,10 +575,15 @@ class PlexusTraceSink:
             stage = str(_event_field(event, "stage", default="") or "").strip().lower()
             if stage == "completed":
                 agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
-                return await self._finalize_stream_for_agent(
+                result = await self._finalize_stream_for_agent(
                     agent_name=agent_name,
                     timestamp=_event_field(event, "timestamp"),
                 )
+                self._agent_cost_summaries.pop(agent_name, None)
+                return result
+            if stage == "started":
+                agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+                self._agent_cost_summaries[agent_name] = self._empty_cost_summary()
             return None
 
         message_type = "MESSAGE"
@@ -420,6 +636,13 @@ class PlexusTraceSink:
         hi_str = str(human_interaction or "INTERNAL")
 
         tool_name = _event_field(event, "tool_name")
+        message_metadata = _event_field(event, "metadata")
+        if role == "ASSISTANT" and message_type == "MESSAGE":
+            agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+            cost_patch = self._agent_cost_metadata(agent_name, live=True)
+            if isinstance(cost_patch, dict):
+                message_metadata = dict(message_metadata) if isinstance(message_metadata, dict) else {}
+                message_metadata.update(cost_patch)
 
         # Tactus emits a single ToolCallEvent (event_type="tool_call") that carries
         # BOTH tool_args (parameters) and tool_result (response).
@@ -428,6 +651,17 @@ class PlexusTraceSink:
         if event_kind == "TOOL_CALL":
             tool_parameters = _event_field(event, "tool_parameters", "tool_args")
             tool_result = _event_field(event, "tool_response", "tool_result")
+            tool_cost_summary, tool_billing_mode = self._tool_cost_summary(tool_result)
+            tool_metadata_patch = None
+            if isinstance(tool_cost_summary, dict):
+                tool_metadata_patch = {
+                    "cost": {
+                        "kind": "tool_execution",
+                        "billing_mode": tool_billing_mode,
+                        "live": False,
+                        "summary": self._finalize_summary(tool_cost_summary),
+                    }
+                }
 
             # Check if we have an in-progress record to update
             in_progress_id = None
@@ -438,13 +672,19 @@ class PlexusTraceSink:
 
             if in_progress_id:
                 # Update the existing in-progress record with the result
+                merged_metadata = self._merged_metadata(in_progress_id, tool_metadata_patch)
                 await self.chat_recorder.update_message(
                     message_id=in_progress_id,
                     tool_response=tool_result,
+                    metadata=merged_metadata,
                 )
                 return in_progress_id
             else:
                 # No in-progress record (e.g., replayed or short-lived tool) — create new
+                metadata = message_metadata
+                if isinstance(tool_metadata_patch, dict):
+                    metadata = dict(metadata) if isinstance(metadata, dict) else {}
+                    metadata.update(tool_metadata_patch)
                 call_id = await self.chat_recorder.record_message(
                     role=role,
                     content=content_text,
@@ -453,8 +693,10 @@ class PlexusTraceSink:
                     tool_parameters=tool_parameters,
                     tool_response=tool_result,
                     human_interaction=hi_str,
-                    metadata=_event_field(event, "metadata"),
+                    metadata=metadata,
                 )
+                if call_id and isinstance(metadata, dict):
+                    self._message_metadata_cache[call_id] = metadata
                 return call_id
 
         # For explicit TOOL_RESPONSE events (non-Tactus paths), link via parentMessageId.
@@ -477,8 +719,10 @@ class PlexusTraceSink:
             tool_response=_event_field(event, "tool_response", "tool_result"),
             parent_message_id=parent_message_id,
             human_interaction=hi_str,
-            metadata=_event_field(event, "metadata"),
+            metadata=message_metadata,
         )
+        if message_id and isinstance(message_metadata, dict):
+            self._message_metadata_cache[message_id] = message_metadata
 
         if event_kind == "TOOL_CALL" and message_id and tool_name:
             key = str(tool_name)

--- a/plexus/cli/procedure/tactus_adapters/trace.py
+++ b/plexus/cli/procedure/tactus_adapters/trace.py
@@ -56,6 +56,17 @@ class PlexusTraceSink:
         self._session_context: Optional[Dict[str, Any]] = None
         self._agent_cost_summaries: Dict[str, Dict[str, Any]] = {}
         self._message_metadata_cache: Dict[str, Dict[str, Any]] = {}
+        self._active_turn_agent_name: Optional[str] = None
+        self._recent_assistant_message_ids: Dict[str, Tuple[str, float]] = {}
+        self._recent_finalized_message_ids: Dict[str, Tuple[str, float]] = {}
+
+    def _resolve_agent_name(self, event: Any, *, default: str = "assistant") -> str:
+        explicit = _event_field(event, "agent_name")
+        if isinstance(explicit, str) and explicit.strip():
+            return explicit.strip()
+        if isinstance(self._active_turn_agent_name, str) and self._active_turn_agent_name.strip():
+            return self._active_turn_agent_name.strip()
+        return default
 
     def _empty_cost_summary(self) -> Dict[str, Any]:
         return {
@@ -225,25 +236,43 @@ class PlexusTraceSink:
         summary = self._agent_cost_summaries.get(agent_name)
         if not isinstance(summary, dict):
             return None
+        finalized = self._finalize_summary(summary)
+        if (
+            float(finalized.get("total_usd", 0.0) or 0.0) <= 0.0
+            and int(finalized.get("llm_calls", 0) or 0) <= 0
+            and not (finalized.get("breakdown") or [])
+        ):
+            return None
         return {
             "cost": {
                 "kind": "assistant_inference",
                 "billing_mode": "spent",
                 "live": live,
-                "summary": self._finalize_summary(summary),
+                "summary": finalized,
             }
         }
 
     async def _record_cost_event(self, event: Any) -> None:
-        agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+        agent_name = self._resolve_agent_name(event)
         increment = self._summary_from_cost_event(event)
         merged_summary = self._merge_cost_summaries(self._agent_cost_summaries.get(agent_name), increment)
         self._agent_cost_summaries[agent_name] = merged_summary
         message_id = self._active_stream_message_ids.get(agent_name)
+        live = True
+        if not message_id:
+            recent = self._recent_assistant_message_ids.get(agent_name)
+            if recent and (time.monotonic() - recent[1]) <= 30:
+                message_id = recent[0]
+                live = False
+            if not message_id:
+                finalized = self._recent_finalized_message_ids.get(agent_name)
+                if finalized and (time.monotonic() - finalized[1]) <= 30:
+                    message_id = finalized[0]
+                    live = False
         if message_id:
             metadata = self._merged_metadata(
                 message_id,
-                self._agent_cost_metadata(agent_name, live=True),
+                self._agent_cost_metadata(agent_name, live=live),
             )
             await self.chat_recorder.update_message(
                 message_id=message_id,
@@ -376,7 +405,7 @@ class PlexusTraceSink:
         return bool(self.session_id)
 
     async def _record_stream_chunk(self, event: Any) -> Optional[str]:
-        agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+        agent_name = self._resolve_agent_name(event)
         chunk_text = str(_event_field(event, "chunk_text", default="") or "")
         accumulated_text = str(_event_field(event, "accumulated_text", default="") or "")
         if not accumulated_text:
@@ -513,9 +542,11 @@ class PlexusTraceSink:
         )
 
         normalized = final_text.strip()
+        now_mono = time.monotonic()
         if normalized:
             self.assistant_message_texts.append(normalized)
-            self._recent_finalized_streams[agent_name] = (normalized, time.monotonic())
+            self._recent_finalized_streams[agent_name] = (normalized, now_mono)
+        self._recent_finalized_message_ids[agent_name] = (message_id, now_mono)
 
         self._active_stream_chunk_counts.pop(agent_name, None)
         self._active_stream_first_chunk_received_at.pop(agent_name, None)
@@ -574,15 +605,19 @@ class PlexusTraceSink:
         if event_type == "agent_turn":
             stage = str(_event_field(event, "stage", default="") or "").strip().lower()
             if stage == "completed":
-                agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+                agent_name = self._resolve_agent_name(event)
                 result = await self._finalize_stream_for_agent(
                     agent_name=agent_name,
                     timestamp=_event_field(event, "timestamp"),
                 )
-                self._agent_cost_summaries.pop(agent_name, None)
+                # Keep summary available briefly because CostEvent can arrive
+                # after AgentTurnEvent(completed) in some runtimes.
+                if self._active_turn_agent_name == agent_name:
+                    self._active_turn_agent_name = None
                 return result
             if stage == "started":
-                agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+                agent_name = self._resolve_agent_name(event)
+                self._active_turn_agent_name = agent_name
                 self._agent_cost_summaries[agent_name] = self._empty_cost_summary()
             return None
 
@@ -620,7 +655,7 @@ class PlexusTraceSink:
             return None
 
         if role == "ASSISTANT" and message_type == "MESSAGE":
-            agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+            agent_name = self._resolve_agent_name(event)
             recent_stream = self._recent_finalized_streams.get(agent_name)
             if recent_stream:
                 streamed_text, finalized_at = recent_stream
@@ -638,7 +673,7 @@ class PlexusTraceSink:
         tool_name = _event_field(event, "tool_name")
         message_metadata = _event_field(event, "metadata")
         if role == "ASSISTANT" and message_type == "MESSAGE":
-            agent_name = str(_event_field(event, "agent_name", default="assistant") or "assistant")
+            agent_name = self._resolve_agent_name(event)
             cost_patch = self._agent_cost_metadata(agent_name, live=True)
             if isinstance(cost_patch, dict):
                 message_metadata = dict(message_metadata) if isinstance(message_metadata, dict) else {}
@@ -723,6 +758,9 @@ class PlexusTraceSink:
         )
         if message_id and isinstance(message_metadata, dict):
             self._message_metadata_cache[message_id] = message_metadata
+        if message_id and role == "ASSISTANT" and message_type == "MESSAGE":
+            agent_name = self._resolve_agent_name(event)
+            self._recent_assistant_message_ids[agent_name] = (message_id, time.monotonic())
 
         if event_kind == "TOOL_CALL" and message_id and tool_name:
             key = str(tool_name)

--- a/plexus/cli/procedure/test_procedure_executor_compat.py
+++ b/plexus/cli/procedure/test_procedure_executor_compat.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 from plexus.cli.procedure.mcp_transport import create_procedure_mcp_server
-from plexus.cli.procedure.procedure_executor import _execute_tactus
+from plexus.cli.procedure.procedure_executor import _PlexusTraceLogBridge, _execute_tactus
 
 
 class _FakeRuntime:
@@ -194,6 +194,47 @@ class _RuntimeWithCostEvents:
             )
         )
         return {"success": True, "response": "cost event emitted"}
+
+
+class _CollectingTraceSink:
+    def __init__(self):
+        self.events = []
+
+    async def record(self, event):
+        self.events.append(event)
+        return None
+
+    async def flush(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_trace_bridge_forwards_cost_events_to_trace_sink():
+    from tactus.protocols.models import CostEvent
+
+    sink = _CollectingTraceSink()
+    cost_events = []
+    bridge = _PlexusTraceLogBridge(sink, on_cost_event=lambda e: cost_events.append(e))
+    event = CostEvent(
+        agent_name="optimizer",
+        model="gpt-5.4",
+        provider="openai",
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+        prompt_cost=0.001,
+        completion_cost=0.001,
+        total_cost=0.002,
+    )
+
+    bridge.log(event)
+    await bridge.flush()
+    await bridge.close()
+
+    assert len(cost_events) == 1
+    assert len(bridge.cost_events) == 1
+    assert len(sink.events) == 1
+    assert getattr(sink.events[0], "event_type", None) == "cost"
 
 
 @pytest.mark.asyncio

--- a/plexus/cli/procedure/test_procedure_executor_compat.py
+++ b/plexus/cli/procedure/test_procedure_executor_compat.py
@@ -886,6 +886,11 @@ async def test_execute_tactus_persists_inference_costs_from_cost_events(monkeypa
     assert costs["inference"]["total"] == pytest.approx(0.003)
     assert len(costs["inference"]["entries"]) == 1
     assert costs["inference"]["entries"][0]["agent_name"] == "optimizer"
+    assert isinstance(costs["inference"]["breakdown"], list)
+    assert len(costs["inference"]["breakdown"]) == 1
+    assert costs["inference"]["breakdown"][0]["provider"] == "openai"
+    assert costs["inference"]["breakdown"][0]["model"] == "gpt-5.2"
+    assert costs["inference"]["breakdown"][0]["spent_usd"] == pytest.approx(0.003)
     assert costs["totals"]["overall"]["incurred"] == pytest.approx(0.003)
 
 

--- a/plexus/cli/procedure/test_storage_metadata_preservation.py
+++ b/plexus/cli/procedure/test_storage_metadata_preservation.py
@@ -1,0 +1,75 @@
+import json
+
+from tactus.protocols.models import ProcedureMetadata
+
+from plexus.cli.procedure.tactus_adapters.storage import PlexusStorageAdapter
+
+
+class _FakeS3Client:
+    def __init__(self):
+        self.objects = {}
+
+    def put_object(self, Bucket, Key, Body, ContentType):
+        self.objects[(Bucket, Key)] = {
+            "Body": Body,
+            "ContentType": ContentType,
+        }
+
+
+class _FakeClient:
+    def __init__(self):
+        self.raw_metadata = {
+            "runtime": {"pid": 12345, "host": "devbox", "started_at": "2026-04-20T00:00:00Z"},
+            "last_failure": {"kind": "signal", "signal": "SIGTERM"},
+            "custom": {"keep": True},
+        }
+        self.saved_metadata = None
+
+    def execute(self, query, variables):
+        if "getProcedure(id: $id)" in query:
+            return {
+                "getProcedure": {
+                    "id": variables["id"],
+                    "metadata": json.dumps(self.raw_metadata),
+                    "status": "RUNNING",
+                    "waitingOnMessageId": None,
+                }
+            }
+        if "updateProcedure(input:" in query:
+            self.saved_metadata = json.loads(variables["metadata"])
+            return {
+                "updateProcedure": {
+                    "id": variables["id"],
+                    "metadata": variables["metadata"],
+                }
+            }
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+def test_save_procedure_metadata_preserves_runtime_and_failure_fields(monkeypatch):
+    fake_client = _FakeClient()
+    fake_s3 = _FakeS3Client()
+
+    monkeypatch.setattr("plexus.cli.procedure.tactus_adapters.storage.boto3.client", lambda _name: fake_s3)
+
+    storage = PlexusStorageAdapter(fake_client, "proc-123")
+    metadata = ProcedureMetadata(
+        procedure_id="proc-123",
+        execution_log=[],
+        replay_index=7,
+        state={"iterations": [{"iteration": 1}]},
+        lua_state={"cursor": 2},
+        status="RUNNING",
+        waiting_on_message_id=None,
+    )
+
+    storage.save_procedure_metadata("proc-123", metadata)
+
+    assert fake_client.saved_metadata is not None
+    assert fake_client.saved_metadata["runtime"] == fake_client.raw_metadata["runtime"]
+    assert fake_client.saved_metadata["last_failure"] == fake_client.raw_metadata["last_failure"]
+    assert fake_client.saved_metadata["custom"] == fake_client.raw_metadata["custom"]
+    assert fake_client.saved_metadata["replay_index"] == 7
+    assert fake_client.saved_metadata["state"]["_s3_key"].endswith("/state.json")
+    assert fake_client.saved_metadata["lua_state"]["_s3_key"].endswith("/lua_state.json")
+    assert fake_client.saved_metadata["checkpoints"]["_s3_key"].endswith("/checkpoints.json")

--- a/plexus/cli/procedure/test_trace_sink.py
+++ b/plexus/cli/procedure/test_trace_sink.py
@@ -253,3 +253,104 @@ async def test_trace_sink_stream_metadata_contains_latency_markers():
     assert timings.get("backend_runtime_execute_started_at") == "2026-03-28T01:00:01+00:00"
     assert timings.get("first_chunk_received_at") == "2026-03-28T01:00:02+00:00"
     assert timings.get("chunk_count") == 1
+
+
+@pytest.mark.asyncio
+async def test_trace_sink_cost_events_attach_to_streamed_assistant_message():
+    recorder = AsyncMock()
+    recorder.start_session.return_value = "sess-1"
+    recorder.record_message.return_value = "msg-stream-1"
+    recorder.update_message.return_value = True
+
+    sink = PlexusTraceSink(recorder)
+    await sink.start_session()
+    await sink.record({"event_type": "agent_turn", "agent_name": "assistant", "stage": "started"})
+    await sink.record(
+        {
+            "event_type": "cost",
+            "agent_name": "assistant",
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "total_cost": 0.0025,
+        }
+    )
+    await sink.record(
+        {
+            "event_type": "agent_stream_chunk",
+            "agent_name": "assistant",
+            "chunk_text": "Hi",
+            "accumulated_text": "Hi",
+        }
+    )
+    await sink.record({"event_type": "agent_turn", "agent_name": "assistant", "stage": "completed"})
+
+    final_update_call = recorder.update_message.await_args_list[-1]
+    metadata = final_update_call.kwargs.get("metadata")
+    assert isinstance(metadata, dict)
+    cost = metadata.get("cost")
+    assert isinstance(cost, dict)
+    assert cost.get("kind") == "assistant_inference"
+    assert cost.get("live") is False
+    summary = cost.get("summary")
+    assert isinstance(summary, dict)
+    assert summary.get("total_usd") == pytest.approx(0.0025)
+    assert isinstance(summary.get("breakdown"), list)
+    assert summary["breakdown"][0]["model"] == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_trace_sink_tool_call_message_includes_tool_cost_metadata():
+    recorder = AsyncMock()
+    recorder.start_session.return_value = "sess-1"
+    recorder.record_message.return_value = "msg-tool-1"
+
+    sink = PlexusTraceSink(recorder)
+    await sink.start_session()
+
+    event = {
+        "event_type": "tool_call",
+        "agent_name": "assistant",
+        "tool_name": "plexus_evaluation_run",
+        "tool_args": {"evaluation_type": "accuracy"},
+        "tool_result": {
+            "_from_cache": True,
+            "cost": 0.42,
+            "cost_details": {
+                "schema_version": 1,
+                "total_usd": 0.42,
+                "llm_calls": 1,
+                "prompt_tokens": 200,
+                "completion_tokens": 10,
+                "total_tokens": 210,
+                "cached_tokens": 0,
+                "breakdown": [
+                    {
+                        "provider": "openai",
+                        "model": "gpt-4o-mini",
+                        "spent_usd": 0.42,
+                        "reused_usd": 0.0,
+                        "referenced_usd": 0.42,
+                        "llm_calls": 1,
+                        "evaluation_runs": 1,
+                        "prompt_tokens": 200,
+                        "completion_tokens": 10,
+                        "total_tokens": 210,
+                        "cached_tokens": 0,
+                    }
+                ],
+            },
+        },
+    }
+    await sink.record(event)
+
+    call_kwargs = recorder.record_message.await_args.kwargs
+    metadata = call_kwargs.get("metadata")
+    assert isinstance(metadata, dict)
+    cost = metadata.get("cost")
+    assert isinstance(cost, dict)
+    assert cost.get("kind") == "tool_execution"
+    assert cost.get("billing_mode") == "reused"
+    assert cost.get("live") is False

--- a/plexus/cli/procedure/test_trace_sink.py
+++ b/plexus/cli/procedure/test_trace_sink.py
@@ -354,3 +354,73 @@ async def test_trace_sink_tool_call_message_includes_tool_cost_metadata():
     assert cost.get("kind") == "tool_execution"
     assert cost.get("billing_mode") == "reused"
     assert cost.get("live") is False
+
+
+@pytest.mark.asyncio
+async def test_trace_sink_does_not_attach_zero_cost_placeholder_to_assistant_message():
+    recorder = AsyncMock()
+    recorder.start_session.return_value = "sess-1"
+    recorder.record_message.return_value = "msg-assistant-1"
+    recorder.update_message.return_value = True
+
+    sink = PlexusTraceSink(recorder)
+    await sink.start_session()
+
+    await sink.record({"event_type": "agent_turn", "agent_name": "code_editor", "stage": "started"})
+    await sink.record(
+        {
+            "role": "ASSISTANT",
+            "content": "Compliance-bias clarification for ambiguous cost language",
+            # Deliberately omit agent_name to exercise active-turn fallback.
+        }
+    )
+
+    record_kwargs = recorder.record_message.await_args.kwargs
+    metadata = record_kwargs.get("metadata")
+    assert not isinstance(metadata, dict) or "cost" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_trace_sink_late_cost_event_updates_recent_assistant_message():
+    recorder = AsyncMock()
+    recorder.start_session.return_value = "sess-1"
+    recorder.record_message.return_value = "msg-assistant-1"
+    recorder.update_message.return_value = True
+
+    sink = PlexusTraceSink(recorder)
+    await sink.start_session()
+
+    await sink.record({"event_type": "agent_turn", "agent_name": "code_editor", "stage": "started"})
+    await sink.record(
+        {
+            "role": "ASSISTANT",
+            "content": "Hypothesis text",
+            # Deliberately omit agent_name to exercise active-turn fallback.
+        }
+    )
+    await sink.record({"event_type": "agent_turn", "agent_name": "code_editor", "stage": "completed"})
+    await sink.record(
+        {
+            "event_type": "cost",
+            "agent_name": "code_editor",
+            "provider": "openai",
+            "model": "gpt-5.4",
+            "prompt_tokens": 100,
+            "completion_tokens": 25,
+            "total_tokens": 125,
+            "total_cost": 0.0125,
+        }
+    )
+
+    update_kwargs = recorder.update_message.await_args.kwargs
+    assert update_kwargs.get("message_id") == "msg-assistant-1"
+    metadata = update_kwargs.get("metadata")
+    assert isinstance(metadata, dict)
+    cost = metadata.get("cost")
+    assert isinstance(cost, dict)
+    assert cost.get("kind") == "assistant_inference"
+    assert cost.get("live") is False
+    summary = cost.get("summary")
+    assert isinstance(summary, dict)
+    assert summary.get("total_usd") == pytest.approx(0.0125)
+    assert summary.get("llm_calls") == 1

--- a/plexus/cli/shared/experiment_runner.py
+++ b/plexus/cli/shared/experiment_runner.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 from datetime import datetime, timezone, timedelta
 import socket
 import os
+import signal
+import threading
+import traceback
 from typing import Optional, Tuple, Dict, Any
 import logging
 import json
 import yaml
+import click
 
 from plexus.cli.shared.task_progress_tracker import TaskProgressTracker
 from plexus.cli.shared.stage_configurations import get_procedure_stage_configs
@@ -18,9 +22,148 @@ from plexus.cli.procedure.builtin_procedures import is_builtin_procedure_id
 logger = logging.getLogger(__name__)
 
 
+class ProcedureRunTermination(BaseException):
+    """Raised when the direct CLI procedure process receives a termination signal."""
+
+    def __init__(self, signum: int):
+        self.signum = int(signum)
+        try:
+            self.signal_name = signal.Signals(signum).name
+        except Exception:
+            self.signal_name = f"SIG{signum}"
+        super().__init__(f"Procedure run interrupted by {self.signal_name}")
+
+
 def _to_json_safe(value: Any) -> Any:
     """Convert arbitrary values into JSON-safe structures."""
     return json.loads(json.dumps(value, default=str))
+
+
+def _parse_json_dict(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        except Exception:
+            return {}
+    return {}
+
+
+def _json_dumps(value: Dict[str, Any]) -> str:
+    return json.dumps(_to_json_safe(value), default=str)
+
+
+def _build_runtime_identity(command: Optional[str]) -> Dict[str, Any]:
+    return {
+        "pid": os.getpid(),
+        "host": socket.gethostname(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "command": command or "",
+    }
+
+
+def _load_procedure_metadata(client: PlexusDashboardClient, procedure_id: str) -> Optional[Dict[str, Any]]:
+    query = """
+    query GetProcedureTelemetry($id: ID!) {
+        getProcedure(id: $id) {
+            id
+            metadata
+            waitingOnMessageId
+        }
+    }
+    """
+    try:
+        result = client.execute(query, {"id": procedure_id})
+    except Exception as exc:
+        logger.warning("Could not load procedure metadata for %s: %s", procedure_id, exc)
+        return None
+
+    procedure = result.get("getProcedure") or {}
+    return _parse_json_dict(procedure.get("metadata"))
+
+
+def _update_procedure_status_and_metadata(
+    client: PlexusDashboardClient,
+    procedure_id: str,
+    *,
+    status: Optional[str] = None,
+    metadata_patch: Optional[Dict[str, Any]] = None,
+    remove_metadata_keys: Optional[list[str]] = None,
+) -> None:
+    metadata = _load_procedure_metadata(client, procedure_id)
+    update_input: Dict[str, Any] = {"id": procedure_id}
+    if status is not None:
+        update_input["status"] = status
+    if metadata is not None:
+        if remove_metadata_keys:
+            for key in remove_metadata_keys:
+                metadata.pop(key, None)
+        if metadata_patch:
+            metadata.update(_to_json_safe(metadata_patch))
+        update_input["metadata"] = _json_dumps(metadata)
+    elif metadata_patch or remove_metadata_keys:
+        logger.warning(
+            "Skipping procedure metadata merge for %s because current metadata could not be loaded",
+            procedure_id,
+        )
+
+    mutation = """
+    mutation UpdateProcedureTelemetry($input: UpdateProcedureInput!) {
+        updateProcedure(input: $input) {
+            id
+            status
+            metadata
+            waitingOnMessageId
+            updatedAt
+        }
+    }
+    """
+    client.execute(mutation, {"input": update_input})
+
+
+def _merge_task_metadata(task: Task, patch: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    metadata = _parse_json_dict(task.metadata)
+    if patch:
+        metadata.update(_to_json_safe(patch))
+    return metadata
+
+
+def _current_task_phase(task: Optional[Task]) -> Optional[str]:
+    if not task:
+        return None
+
+    try:
+        stages = list(task.get_stages())
+    except Exception as exc:
+        logger.debug("Could not load task stages for %s: %s", getattr(task, "id", None), exc)
+        return None
+
+    current_stage_id = getattr(task, "currentStageId", None)
+    if current_stage_id:
+        stage = next((item for item in stages if item.id == current_stage_id), None)
+        if stage and getattr(stage, "name", None):
+            return str(stage.name)
+
+    running_stage = next((item for item in stages if getattr(item, "status", None) == "RUNNING"), None)
+    if running_stage and getattr(running_stage, "name", None):
+        return str(running_stage.name)
+
+    pending_stage = next((item for item in stages if getattr(item, "status", None) == "PENDING"), None)
+    if pending_stage and getattr(pending_stage, "name", None):
+        return str(pending_stage.name)
+
+    return None
+
+
+def _system_exit_is_failure(code: Any) -> bool:
+    if code is None:
+        return False
+    if isinstance(code, int):
+        return code != 0
+    return True
 
 
 def _extract_run_parameters_from_procedure_yaml(procedure_yaml: Optional[str]) -> Dict[str, Any]:
@@ -398,12 +541,152 @@ async def run_experiment_with_task_tracking(
         'message': 'Task tracking initialized'
     }
 
+    runtime_identity = _build_runtime_identity(
+        task.command if task and getattr(task, "command", None) else f"procedure run {procedure_id}"
+    )
+    task_ref = tracker.task if tracker and tracker.task else task
+    failure_finalized = False
+    installed_signal_handlers: Dict[int, Any] = {}
+
+    def _install_signal_guards() -> None:
+        if threading.current_thread() is not threading.main_thread():
+            return
+
+        def _raise_termination(signum, _frame):
+            raise ProcedureRunTermination(signum)
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                installed_signal_handlers[sig] = signal.getsignal(sig)
+                signal.signal(sig, _raise_termination)
+            except Exception as exc:
+                logger.debug("Could not install signal handler for %s: %s", sig, exc)
+
+    def _restore_signal_guards() -> None:
+        for sig, previous in installed_signal_handlers.items():
+            try:
+                signal.signal(sig, previous)
+            except Exception as exc:
+                logger.debug("Could not restore signal handler for %s: %s", sig, exc)
+        installed_signal_handlers.clear()
+
+    def _mark_run_started() -> None:
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if task_ref:
+            task_metadata = _merge_task_metadata(task_ref, {"runtime": runtime_identity})
+            task_ref.update(
+                accountId=task_ref.accountId,
+                type=task_ref.type,
+                status="RUNNING",
+                target=task_ref.target,
+                command=task_ref.command,
+                metadata=_json_dumps(task_metadata),
+                startedAt=now_iso,
+                updatedAt=now_iso,
+                errorMessage=None,
+                errorDetails=None,
+            )
+
+        if not is_builtin_procedure_id(procedure_id):
+            _update_procedure_status_and_metadata(
+                client,
+                procedure_id,
+                status="RUNNING",
+                metadata_patch={"runtime": runtime_identity},
+                remove_metadata_keys=["last_failure"],
+            )
+
+    def _finalize_failed(
+        *,
+        kind: str,
+        message: str,
+        signal_name: Optional[str] = None,
+        exception_type: Optional[str] = None,
+        traceback_text: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        nonlocal failure_finalized
+        if failure_finalized:
+            return {}
+        failure_finalized = True
+
+        from plexus.cli.procedure.procedure_executor import _fail_all_task_stages
+
+        terminated_at = datetime.now(timezone.utc).isoformat()
+        phase = _current_task_phase(task_ref)
+        failure_payload = {
+            "kind": kind,
+            "signal": signal_name,
+            "exception_type": exception_type,
+            "message": str(message),
+            "phase": phase,
+            "terminated_at": terminated_at,
+            "pid": runtime_identity.get("pid"),
+            "host": runtime_identity.get("host"),
+            "traceback": traceback_text,
+        }
+
+        if task_ref:
+            try:
+                _fail_all_task_stages(client, task_ref.id, str(message))
+            except Exception as stage_exc:
+                logger.warning("Could not fail task stages for %s: %s", task_ref.id, stage_exc, exc_info=True)
+
+            try:
+                task_metadata = _merge_task_metadata(task_ref, {"runtime": runtime_identity})
+                task_ref.update(
+                    accountId=task_ref.accountId,
+                    type=task_ref.type,
+                    status="FAILED",
+                    target=task_ref.target,
+                    command=task_ref.command,
+                    metadata=_json_dumps(task_metadata),
+                    updatedAt=terminated_at,
+                    completedAt=terminated_at,
+                    errorMessage=str(message)[:2000],
+                    errorDetails=_json_dumps(failure_payload),
+                )
+            except Exception as task_exc:
+                logger.warning("Could not persist FAILED task state for %s: %s", task_ref.id, task_exc, exc_info=True)
+
+        if not is_builtin_procedure_id(procedure_id):
+            try:
+                _update_procedure_status_and_metadata(
+                    client,
+                    procedure_id,
+                    status="FAILED",
+                    metadata_patch={
+                        "runtime": runtime_identity,
+                        "last_failure": failure_payload,
+                    },
+                )
+            except Exception as proc_exc:
+                logger.warning(
+                    "Could not persist FAILED procedure state for %s: %s",
+                    procedure_id,
+                    proc_exc,
+                    exc_info=True,
+                )
+
+        result.update(
+            {
+                "status": "FAILED",
+                "error": str(message),
+                "message": f"Experiment failed: {message}",
+                "failure": failure_payload,
+            }
+        )
+        return failure_payload
+
+    _install_signal_guards()
+
     try:
+        _mark_run_started()
+
         # Start with Hypothesis stage (only if we have a tracker)
         if tracker:
             tracker.current_stage.status_message = "Starting experiment hypothesis generation"
             tracker.update(current_items=0)
-        
+
         # Import and run the actual procedure using ProcedureService
         from plexus.cli.procedure.service import ProcedureService
         service = ProcedureService(client)
@@ -412,8 +695,8 @@ async def run_experiment_with_task_tracking(
         run_options = dict(experiment_options)
         run_options.setdefault("account_id", account_id)
         # Pass the task ID so the executor can update stage status in real-time
-        if task and task.id:
-            run_options.setdefault("_task_id_for_stage_tracking", task.id)
+        if task_ref and task_ref.id:
+            run_options.setdefault("_task_id_for_stage_tracking", task_ref.id)
         experiment_result = await service.run_experiment(procedure_id, **run_options)
 
         procedure_status = str(experiment_result.get("status") or "").upper()
@@ -443,92 +726,87 @@ async def run_experiment_with_task_tracking(
         else:
             mapped_task_status = "FAILED"
             mapped_procedure_status = "FAILED"
+            err_text = experiment_result.get("error") or experiment_result.get("message") or "Procedure failed"
             logger.warning(
                 f"[PROCEDURE_RUN] procedure={procedure_id} reported failure — "
                 f"error={experiment_result.get('error')} message={experiment_result.get('message')}"
             )
+            _finalize_failed(kind="exception", message=str(err_text))
 
         # Complete or update the task
-        if tracker and tracker.task:
+        if task_ref and mapped_task_status != "FAILED":
             update_data = {
-                "accountId": tracker.task.accountId,
-                "type": tracker.task.type,
+                "accountId": task_ref.accountId,
+                "type": task_ref.type,
                 "status": mapped_task_status,
-                "target": tracker.task.target,
-                "command": tracker.task.command,
+                "target": task_ref.target,
+                "command": task_ref.command,
                 "updatedAt": datetime.now(timezone.utc).isoformat(),
                 "output": json.dumps(experiment_result, default=str),
             }
             if mapped_task_status in {"COMPLETED", "FAILED"}:
                 update_data["completedAt"] = datetime.now(timezone.utc).isoformat()
-            if mapped_task_status == "FAILED":
-                err_text = experiment_result.get("error") or experiment_result.get("message") or "Procedure failed"
-                update_data["errorMessage"] = str(err_text)[:2000]
-                logger.warning(f"[PROCEDURE_RUN] Updating task {tracker.task.id} to FAILED: {err_text}")
-            tracker.task.update(**update_data)
-
-        _procedure_status_mutation = """
-        mutation UpdateProcedureStatus($input: UpdateProcedureInput!) {
-            updateProcedure(input: $input) {
-                id
-                status
-                updatedAt
-            }
-        }
-        """
+            task_ref.update(**update_data)
 
         # Keep procedure status consistent with the actual run outcome for DB-backed procedures.
-        if not is_builtin_procedure_id(procedure_id):
+        if mapped_procedure_status != "FAILED" and not is_builtin_procedure_id(procedure_id):
             try:
                 logger.info(f"[PROCEDURE_RUN] Updating procedure {procedure_id} status → {mapped_procedure_status}")
-                client.execute(_procedure_status_mutation, {"input": {"id": procedure_id, "status": mapped_procedure_status}})
+                _update_procedure_status_and_metadata(client, procedure_id, status=mapped_procedure_status)
             except Exception as _pe:
                 logger.warning(f"Failed to update procedure status for {procedure_id}: {_pe}")
 
         # Update result with experiment outcome
         result.update(experiment_result)
-        result['status'] = mapped_procedure_status
-        result['message'] = 'Experiment completed successfully' if mapped_procedure_status == 'COMPLETED' else result.get('message', 'Experiment execution updated')
+        result["status"] = mapped_procedure_status
+        result["message"] = (
+            "Experiment completed successfully"
+            if mapped_procedure_status == "COMPLETED"
+            else result.get("message", "Experiment execution updated")
+        )
 
-    except Exception as e:
-        logging.error(f"Experiment run failed: {str(e)}", exc_info=True)
-
-        # Update task with error
-        if tracker and tracker.task:
-            logger.warning(f"[PROCEDURE_RUN] Exception path — updating task {tracker.task.id} to FAILED: {e}")
-            tracker.task.update(
-                accountId=tracker.task.accountId,
-                type=tracker.task.type,
-                status='FAILED',
-                target=tracker.task.target,
-                command=tracker.task.command,
-                completedAt=datetime.now(timezone.utc).isoformat(),
-                updatedAt=datetime.now(timezone.utc).isoformat(),
-                errorMessage=str(e),
-                errorDetails=json.dumps({'error': str(e), 'type': type(e).__name__}, default=str),
+    except ProcedureRunTermination as exc:
+        logger.warning("Procedure %s interrupted by %s", procedure_id, exc.signal_name)
+        _finalize_failed(
+            kind="signal",
+            signal_name=exc.signal_name,
+            message=f"Procedure run interrupted by {exc.signal_name}",
+        )
+        raise SystemExit(128 + exc.signum) from None
+    except KeyboardInterrupt:
+        logger.warning("Procedure %s interrupted by keyboard", procedure_id)
+        _finalize_failed(
+            kind="signal",
+            signal_name="SIGINT",
+            message="Procedure run interrupted by SIGINT",
+        )
+        raise
+    except click.Abort as exc:
+        logger.warning("Procedure %s aborted", procedure_id)
+        _finalize_failed(
+            kind="abort",
+            exception_type=type(exc).__name__,
+            message=str(exc) or "Procedure run aborted",
+        )
+        raise
+    except SystemExit as exc:
+        if _system_exit_is_failure(exc.code):
+            logger.warning("Procedure %s exited early with code %s", procedure_id, exc.code)
+            _finalize_failed(
+                kind="system_exit",
+                exception_type=type(exc).__name__,
+                message=f"Procedure run exited with status {exc.code}",
             )
-
-        # Update procedure record status even on unexpected exception
-        if not is_builtin_procedure_id(procedure_id):
-            try:
-                _procedure_status_mutation = """
-                mutation UpdateProcedureStatus($input: UpdateProcedureInput!) {
-                    updateProcedure(input: $input) {
-                        id
-                        status
-                        updatedAt
-                    }
-                }
-                """
-                logger.warning(f"[PROCEDURE_RUN] Exception path — updating procedure {procedure_id} status → FAILED")
-                client.execute(_procedure_status_mutation, {"input": {"id": procedure_id, "status": "FAILED"}})
-            except Exception as _pe:
-                logger.warning(f"Failed to update procedure status after exception for {procedure_id}: {_pe}")
-
-        result.update({
-            'status': 'error',
-            'error': str(e),
-            'message': f'Experiment failed: {str(e)}'
-        })
+        raise
+    except Exception as exc:
+        logging.error(f"Experiment run failed: {str(exc)}", exc_info=True)
+        _finalize_failed(
+            kind="exception",
+            exception_type=type(exc).__name__,
+            message=str(exc),
+            traceback_text=traceback.format_exc(),
+        )
+    finally:
+        _restore_signal_guards()
     
     return result

--- a/plexus/cli/shared/test_experiment_runner.py
+++ b/plexus/cli/shared/test_experiment_runner.py
@@ -1,4 +1,92 @@
+import json
+import signal
+from types import SimpleNamespace
+
+import click
+import pytest
+
 from plexus.cli.shared.experiment_runner import _extract_run_parameters_from_procedure_yaml
+from plexus.cli.shared.experiment_runner import run_experiment_with_task_tracking
+
+
+class _FakeTask:
+    def __init__(self):
+        self.id = "task-123"
+        self.accountId = "acct-123"
+        self.type = "Procedure Run"
+        self.status = "PENDING"
+        self.target = "procedure/run/proc-123"
+        self.command = "procedure run proc-123"
+        self.metadata = json.dumps({"seed": "value"})
+        self.currentStageId = "stage-1"
+        self.update_calls = []
+
+    def update(self, **kwargs):
+        self.update_calls.append(kwargs)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        return self
+
+    def get_stages(self):
+        return [
+            SimpleNamespace(id="stage-1", name="Baseline Evaluation", status="RUNNING"),
+            SimpleNamespace(id="stage-2", name="Candidate Evaluation", status="PENDING"),
+        ]
+
+
+class _FakeClient:
+    def __init__(self):
+        self.procedure_metadata = {"existing": "value", "last_failure": {"message": "stale"}}
+        self.procedure_status = None
+        self.calls = []
+
+    def execute(self, query, variables):
+        self.calls.append((query, variables))
+        if "getProcedure(id: $id)" in query and "metadata" in query:
+            return {
+                "getProcedure": {
+                    "id": variables["id"],
+                    "metadata": json.dumps(self.procedure_metadata),
+                    "waitingOnMessageId": None,
+                }
+            }
+        if "updateProcedure(input: $input)" in query:
+            input_data = variables["input"]
+            self.procedure_status = input_data.get("status", self.procedure_status)
+            if "metadata" in input_data:
+                self.procedure_metadata = json.loads(input_data["metadata"])
+            return {
+                "updateProcedure": {
+                    "id": input_data["id"],
+                    "status": self.procedure_status,
+                    "metadata": json.dumps(self.procedure_metadata),
+                    "waitingOnMessageId": None,
+                    "updatedAt": "2026-04-20T00:00:00Z",
+                }
+            }
+        raise AssertionError(f"Unexpected GraphQL call: {query}")
+
+
+def _patch_tracker(monkeypatch, fake_task):
+    monkeypatch.setattr(
+        "plexus.cli.shared.experiment_runner.create_tracker_and_experiment_task",
+        lambda **_kwargs: (None, None, fake_task),
+    )
+    monkeypatch.setattr(
+        "plexus.cli.shared.experiment_runner.DashboardProcedure.get_by_id",
+        lambda **_kwargs: SimpleNamespace(code=None),
+    )
+
+
+def _patch_service(monkeypatch, run_impl):
+    class _FakeProcedureService:
+        def __init__(self, _client):
+            self.client = _client
+
+        async def run_experiment(self, procedure_id, **options):
+            return await run_impl(procedure_id, **options)
+
+    monkeypatch.setattr("plexus.cli.procedure.service.ProcedureService", _FakeProcedureService)
 
 
 def test_extract_run_parameters_prefers_value_then_default_for_params_mapping():
@@ -37,3 +125,129 @@ parameters:
     result = _extract_run_parameters_from_procedure_yaml(yaml_text)
     assert result["days"] == 365
     assert result["hint"] == "focus on transfer language"
+
+
+@pytest.mark.asyncio
+async def test_run_experiment_persists_failed_result_telemetry(monkeypatch):
+    fake_task = _FakeTask()
+    fake_client = _FakeClient()
+    stage_fail_calls = []
+
+    _patch_tracker(monkeypatch, fake_task)
+    monkeypatch.setattr(
+        "plexus.cli.procedure.procedure_executor._fail_all_task_stages",
+        lambda client, task_id, error_message="": stage_fail_calls.append((client, task_id, error_message)),
+    )
+
+    async def _run_impl(_procedure_id, **_options):
+        return {"success": False, "error": "optimizer blew up"}
+
+    _patch_service(monkeypatch, _run_impl)
+
+    result = await run_experiment_with_task_tracking(
+        procedure_id="proc-123",
+        client=fake_client,
+        account_id="acct-123",
+    )
+
+    assert result["status"] == "FAILED"
+    assert fake_client.procedure_status == "FAILED"
+    assert fake_client.procedure_metadata["runtime"]["command"] == "procedure run proc-123"
+    assert fake_client.procedure_metadata["last_failure"]["kind"] == "exception"
+    assert fake_client.procedure_metadata["last_failure"]["message"] == "optimizer blew up"
+    assert fake_client.procedure_metadata["last_failure"]["phase"] == "Baseline Evaluation"
+    assert stage_fail_calls == [(fake_client, "task-123", "optimizer blew up")]
+    assert fake_task.update_calls[-1]["status"] == "FAILED"
+    assert fake_task.update_calls[-1]["errorMessage"] == "optimizer blew up"
+    assert json.loads(fake_task.update_calls[-1]["errorDetails"])["kind"] == "exception"
+
+
+@pytest.mark.asyncio
+async def test_run_experiment_persists_sigterm_telemetry_and_reraises(monkeypatch):
+    fake_task = _FakeTask()
+    fake_client = _FakeClient()
+    stage_fail_calls = []
+    handlers = {}
+
+    _patch_tracker(monkeypatch, fake_task)
+    monkeypatch.setattr(
+        "plexus.cli.procedure.procedure_executor._fail_all_task_stages",
+        lambda client, task_id, error_message="": stage_fail_calls.append((client, task_id, error_message)),
+    )
+    monkeypatch.setattr("signal.getsignal", lambda _sig: signal.SIG_DFL)
+    monkeypatch.setattr("signal.signal", lambda sig, handler: handlers.setdefault(sig, handler))
+
+    async def _run_impl(_procedure_id, **_options):
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+        raise AssertionError("SIGTERM handler should have interrupted execution")
+
+    _patch_service(monkeypatch, _run_impl)
+
+    with pytest.raises(SystemExit) as excinfo:
+        await run_experiment_with_task_tracking(
+            procedure_id="proc-123",
+            client=fake_client,
+            account_id="acct-123",
+        )
+
+    assert excinfo.value.code == 128 + signal.SIGTERM
+    assert fake_client.procedure_status == "FAILED"
+    assert fake_client.procedure_metadata["last_failure"]["kind"] == "signal"
+    assert fake_client.procedure_metadata["last_failure"]["signal"] == "SIGTERM"
+    assert stage_fail_calls == [(fake_client, "task-123", "Procedure run interrupted by SIGTERM")]
+
+
+@pytest.mark.asyncio
+async def test_run_experiment_persists_abort_and_reraises(monkeypatch):
+    fake_task = _FakeTask()
+    fake_client = _FakeClient()
+
+    _patch_tracker(monkeypatch, fake_task)
+    monkeypatch.setattr(
+        "plexus.cli.procedure.procedure_executor._fail_all_task_stages",
+        lambda *_args, **_kwargs: None,
+    )
+
+    async def _run_impl(_procedure_id, **_options):
+        raise click.Abort()
+
+    _patch_service(monkeypatch, _run_impl)
+
+    with pytest.raises(click.Abort):
+        await run_experiment_with_task_tracking(
+            procedure_id="proc-123",
+            client=fake_client,
+            account_id="acct-123",
+        )
+
+    assert fake_client.procedure_status == "FAILED"
+    assert fake_client.procedure_metadata["last_failure"]["kind"] == "abort"
+
+
+@pytest.mark.asyncio
+async def test_run_experiment_persists_nonzero_system_exit_and_reraises(monkeypatch):
+    fake_task = _FakeTask()
+    fake_client = _FakeClient()
+
+    _patch_tracker(monkeypatch, fake_task)
+    monkeypatch.setattr(
+        "plexus.cli.procedure.procedure_executor._fail_all_task_stages",
+        lambda *_args, **_kwargs: None,
+    )
+
+    async def _run_impl(_procedure_id, **_options):
+        raise SystemExit(2)
+
+    _patch_service(monkeypatch, _run_impl)
+
+    with pytest.raises(SystemExit) as excinfo:
+        await run_experiment_with_task_tracking(
+            procedure_id="proc-123",
+            client=fake_client,
+            account_id="acct-123",
+        )
+
+    assert excinfo.value.code == 2
+    assert fake_client.procedure_status == "FAILED"
+    assert fake_client.procedure_metadata["last_failure"]["kind"] == "system_exit"
+    assert fake_client.procedure_metadata["last_failure"]["message"] == "Procedure run exited with status 2"

--- a/plexus/dashboard/api/models/evaluation.py
+++ b/plexus/dashboard/api/models/evaluation.py
@@ -31,6 +31,7 @@ class Evaluation(BaseModel):
     inferences: Optional[int] = None
     accuracy: Optional[float] = None
     cost: Optional[float] = None
+    costDetails: Optional[Dict] = None
     startedAt: Optional[datetime] = None
     elapsedSeconds: Optional[int] = None
     estimatedRemainingSeconds: Optional[int] = None
@@ -63,6 +64,7 @@ class Evaluation(BaseModel):
         inferences: Optional[int] = None,
         accuracy: Optional[float] = None,
         cost: Optional[float] = None,
+        costDetails: Optional[Dict] = None,
         startedAt: Optional[datetime] = None,
         elapsedSeconds: Optional[int] = None,
         estimatedRemainingSeconds: Optional[int] = None,
@@ -92,6 +94,7 @@ class Evaluation(BaseModel):
         self.inferences = inferences
         self.accuracy = accuracy
         self.cost = cost
+        self.costDetails = costDetails
         self.startedAt = startedAt
         self.elapsedSeconds = elapsedSeconds
         self.estimatedRemainingSeconds = estimatedRemainingSeconds
@@ -125,6 +128,7 @@ class Evaluation(BaseModel):
             inferences
             accuracy
             cost
+            costDetails
             startedAt
             elapsedSeconds
             estimatedRemainingSeconds
@@ -211,6 +215,7 @@ class Evaluation(BaseModel):
             inferences=data.get('inferences'),
             accuracy=data.get('accuracy'),
             cost=data.get('cost'),
+            costDetails=data.get('costDetails'),
             startedAt=data.get('startedAt'),
             elapsedSeconds=data.get('elapsedSeconds'),
             estimatedRemainingSeconds=data.get('estimatedRemainingSeconds'),

--- a/plexus/dashboard/api/models/evaluation.py
+++ b/plexus/dashboard/api/models/evaluation.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _evaluation_cost_details_enabled() -> bool:
+    """Cost details are stored in parameters.metadata; GraphQL field is disabled."""
+    return False
+
 @dataclass
 class Evaluation(BaseModel):
     type: str
@@ -116,7 +121,7 @@ class Evaluation(BaseModel):
     @classmethod
     def fields(cls) -> str:
         """Fields to request in queries and mutations"""
-        return """
+        fields = """
             id
             type
             accountId
@@ -128,7 +133,6 @@ class Evaluation(BaseModel):
             inferences
             accuracy
             cost
-            costDetails
             startedAt
             elapsedSeconds
             estimatedRemainingSeconds
@@ -147,6 +151,9 @@ class Evaluation(BaseModel):
             isPredictedClassDistributionBalanced
             taskId
         """
+        if _evaluation_cost_details_enabled():
+            fields = fields.replace("            cost\n", "            cost\n            costDetails\n")
+        return fields
 
     @classmethod
     def create(
@@ -172,6 +179,8 @@ class Evaluation(BaseModel):
             'updatedAt': now,
             **kwargs
         }
+        if not _evaluation_cost_details_enabled():
+            input_data.pop('costDetails', None)
         
         if scorecardId:
             input_data['scorecardId'] = scorecardId
@@ -250,6 +259,8 @@ class Evaluation(BaseModel):
             kwargs['updatedAt'] = datetime.now(timezone.utc).isoformat().replace(
                 '+00:00', 'Z'
             )
+            if not _evaluation_cost_details_enabled():
+                kwargs.pop("costDetails", None)
 
             mutation = """
             mutation UpdateEvaluation($input: UpdateEvaluationInput!) {

--- a/plexus/procedures/feedback_alignment_optimizer.yaml
+++ b/plexus/procedures/feedback_alignment_optimizer.yaml
@@ -497,6 +497,8 @@ code: |
     if type(evaluation) ~= "table" then evaluation = {} end
     if type(evaluation.entries) ~= "table" then evaluation.entries = {} end
     if type(evaluation.seen_ids) ~= "table" then evaluation.seen_ids = {} end
+    if type(evaluation.breakdown) ~= "table" then evaluation.breakdown = {} end
+    if type(evaluation.breakdown_index) ~= "table" then evaluation.breakdown_index = {} end
     evaluation.incurred_total = tonumber(evaluation.incurred_total) or 0
     evaluation.reused_total = tonumber(evaluation.reused_total) or 0
     evaluation.total = tonumber(evaluation.total) or (evaluation.incurred_total + evaluation.reused_total)
@@ -505,6 +507,88 @@ code: |
     if type(costs.totals) ~= "table" then costs.totals = {} end
     if type(costs.inference) ~= "table" then costs.inference = {} end
     return costs, evaluation
+  end
+
+  local function merge_evaluation_breakdown(evaluation, eval_result, reused, fallback_cost)
+    local rows = {}
+    local cost_details = eval_result.cost_details
+    if type(cost_details) == "table" and type(cost_details.breakdown) == "table" then
+      rows = cost_details.breakdown
+    end
+
+    if #rows == 0 then
+      local model_name = nil
+      local provider_name = nil
+      if type(eval_result.parameters) == "table" then
+        model_name = eval_result.parameters.model_name
+        provider_name = eval_result.parameters.model_provider
+      end
+      rows = {{
+        provider = provider_name,
+        model = model_name,
+        spent_usd = fallback_cost,
+        reused_usd = 0,
+        referenced_usd = fallback_cost,
+        llm_calls = 0,
+        evaluation_runs = 1,
+        prompt_tokens = 0,
+        completion_tokens = 0,
+        total_tokens = 0,
+        cached_tokens = 0,
+      }}
+    end
+
+    for _, row in ipairs(rows) do
+      if type(row) == "table" then
+        local provider_key = tostring(row.provider or "")
+        local model_key = tostring(row.model or "")
+        local key = provider_key .. "|" .. model_key
+        local entry = evaluation.breakdown_index[key]
+        if type(entry) ~= "table" then
+          entry = {
+            provider = row.provider or nil,
+            model = row.model or nil,
+            spent_usd = 0,
+            reused_usd = 0,
+            referenced_usd = 0,
+            llm_calls = 0,
+            evaluation_runs = 0,
+            prompt_tokens = 0,
+            completion_tokens = 0,
+            total_tokens = 0,
+            cached_tokens = 0,
+          }
+          evaluation.breakdown_index[key] = entry
+        end
+
+        local row_spent = tonumber(row.spent_usd) or tonumber(row.referenced_usd) or 0
+        local row_reused = tonumber(row.reused_usd) or 0
+        local row_ref = tonumber(row.referenced_usd) or (row_spent + row_reused)
+        if reused then
+          entry.reused_usd = (tonumber(entry.reused_usd) or 0) + row_ref
+          entry.spent_usd = tonumber(entry.spent_usd) or 0
+        else
+          entry.spent_usd = (tonumber(entry.spent_usd) or 0) + row_spent
+          entry.reused_usd = (tonumber(entry.reused_usd) or 0) + row_reused
+        end
+        entry.referenced_usd = (tonumber(entry.referenced_usd) or 0) + row_ref
+        entry.llm_calls = (tonumber(entry.llm_calls) or 0) + (tonumber(row.llm_calls) or 0)
+        entry.evaluation_runs = (tonumber(entry.evaluation_runs) or 0) + 1
+        entry.prompt_tokens = (tonumber(entry.prompt_tokens) or 0) + (tonumber(row.prompt_tokens) or 0)
+        entry.completion_tokens = (tonumber(entry.completion_tokens) or 0) + (tonumber(row.completion_tokens) or 0)
+        entry.total_tokens = (tonumber(entry.total_tokens) or 0) + (tonumber(row.total_tokens) or 0)
+        entry.cached_tokens = (tonumber(entry.cached_tokens) or 0) + (tonumber(row.cached_tokens) or 0)
+      end
+    end
+
+    local flattened = {}
+    for _, row in pairs(evaluation.breakdown_index) do
+      table.insert(flattened, row)
+    end
+    table.sort(flattened, function(a, b)
+      return (tonumber(a.referenced_usd) or 0) > (tonumber(b.referenced_usd) or 0)
+    end)
+    evaluation.breakdown = flattened
   end
 
   local function record_evaluation_cost(eval_result, source_label, fallback_eval_type)
@@ -532,6 +616,7 @@ code: |
       source = source_label or "unspecified",
       reused = reused,
       cost = cost,
+      cost_details = eval_result.cost_details,
       processed_items = processed_items,
       cost_per_item = cost_per_item,
       score_version_id = eval_result.score_version_id or eval_result.scoreVersionId,
@@ -544,6 +629,7 @@ code: |
     else
       evaluation.incurred_total = (tonumber(evaluation.incurred_total) or 0) + cost
     end
+    merge_evaluation_breakdown(evaluation, eval_result, reused, cost)
     evaluation.total = (tonumber(evaluation.incurred_total) or 0) + (tonumber(evaluation.reused_total) or 0)
     costs.evaluation = evaluation
 

--- a/plexus/scores/LangGraphScore.py
+++ b/plexus/scores/LangGraphScore.py
@@ -929,21 +929,102 @@ class LangGraphScore(Score, LangChainUser):
         :return: A dictionary containing cost and usage information.
         """
         usage = self.get_token_usage()
+        components = []
+        total_input_cost = 0.0
+        total_output_cost = 0.0
 
-        try:
-            prompt_cost, completion_cost = _litellm.cost_per_token(
-                model=self.parameters.model_name,
-                prompt_tokens=usage['prompt_tokens'],
-                completion_tokens=usage['completion_tokens']
-            )
-            cost_info = {
-                "input_cost": float(prompt_cost),
-                "output_cost": float(completion_cost),
-                "total_cost": float(prompt_cost + completion_cost),
+        def _normalize_provider(provider_name: Optional[str]) -> Optional[str]:
+            if not provider_name:
+                return None
+            normalized = str(provider_name).strip().lower()
+            mapping = {
+                "chatopenai": "openai",
+                "azurechatopenai": "azure_openai",
+                "bedrockchat": "bedrock",
+                "chatvertexai": "vertexai",
+                "chatollama": "ollama",
             }
-        except Exception as e:
-            logging.error(f"Error calculating cost: {str(e)}")
-            cost_info = {"input_cost": 0, "output_cost": 0, "total_cost": 0}
+            return mapping.get(normalized, normalized)
+
+        node_instances = getattr(self, "node_instances", None)
+        if isinstance(node_instances, list):
+            for node_name, node_instance in node_instances:
+                if not hasattr(node_instance, "get_token_usage"):
+                    continue
+                try:
+                    node_usage = node_instance.get_token_usage() or {}
+                except Exception as e:
+                    logging.error(f"Error getting token usage for node '{node_name}': {str(e)}")
+                    continue
+
+                prompt_tokens = int(node_usage.get("prompt_tokens", 0) or 0)
+                completion_tokens = int(node_usage.get("completion_tokens", 0) or 0)
+                total_tokens = int(node_usage.get("total_tokens", prompt_tokens + completion_tokens) or 0)
+                cached_tokens = int(node_usage.get("cached_tokens", 0) or 0)
+                llm_calls = int(node_usage.get("successful_requests", 0) or 0)
+                if llm_calls <= 0 and total_tokens <= 0:
+                    continue
+
+                node_params = getattr(node_instance, "parameters", None)
+                model_name = (
+                    getattr(node_params, "model_name", None)
+                    or self.parameters.model_name
+                )
+                provider_name = _normalize_provider(
+                    getattr(node_params, "model_provider", None) or self.parameters.model_provider
+                )
+
+                prompt_cost = 0.0
+                completion_cost = 0.0
+                if model_name:
+                    try:
+                        node_prompt_cost, node_completion_cost = _litellm.cost_per_token(
+                            model=model_name,
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=completion_tokens,
+                        )
+                        prompt_cost = float(node_prompt_cost)
+                        completion_cost = float(node_completion_cost)
+                    except Exception as e:
+                        logging.error(f"Error calculating cost for node '{node_name}': {str(e)}")
+
+                total_input_cost += prompt_cost
+                total_output_cost += completion_cost
+                components.append({
+                    "type": "api_call",
+                    "provider": provider_name,
+                    "model": model_name,
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "cached_tokens": cached_tokens,
+                    "llm_calls": llm_calls,
+                    "usd": float(prompt_cost + completion_cost),
+                    "metadata": {"node_name": node_name},
+                })
+
+        if not components:
+            try:
+                prompt_cost, completion_cost = _litellm.cost_per_token(
+                    model=self.parameters.model_name,
+                    prompt_tokens=usage['prompt_tokens'],
+                    completion_tokens=usage['completion_tokens']
+                )
+                total_input_cost = float(prompt_cost)
+                total_output_cost = float(completion_cost)
+                if usage['total_tokens'] > 0 or usage['successful_requests'] > 0:
+                    components.append({
+                        "type": "api_call",
+                        "provider": _normalize_provider(self.parameters.model_provider),
+                        "model": self.parameters.model_name,
+                        "prompt_tokens": usage['prompt_tokens'],
+                        "completion_tokens": usage['completion_tokens'],
+                        "cached_tokens": usage['cached_tokens'],
+                        "llm_calls": usage['successful_requests'],
+                        "usd": float(total_input_cost + total_output_cost),
+                        "metadata": {"node_name": "score"},
+                    })
+            except Exception as e:
+                logging.error(f"Error calculating cost: {str(e)}")
 
         return {
             "prompt_tokens":     usage['prompt_tokens'],
@@ -951,9 +1032,10 @@ class LangGraphScore(Score, LangChainUser):
             "total_tokens":      usage['total_tokens'],
             "llm_calls":         usage['successful_requests'],
             "cached_tokens":     usage['cached_tokens'],
-            "input_cost":        cost_info['input_cost'],
-            "output_cost":       cost_info['output_cost'],
-            "total_cost":        cost_info['total_cost']
+            "input_cost":        total_input_cost,
+            "output_cost":       total_output_cost,
+            "total_cost":        float(total_input_cost + total_output_cost),
+            "components":        components,
         }
 
     def reset_token_usage(self):
@@ -1685,4 +1767,3 @@ class LangGraphScore(Score, LangChainUser):
                        for item in result.get('listBatchJobScoringJobs', {}).get('items', [])]
         logging.info(f"Found {len(scoring_jobs)} scoring jobs for batch {batch_job_id}")
         return scoring_jobs
-

--- a/plexus/scores/TactusScore.py
+++ b/plexus/scores/TactusScore.py
@@ -304,10 +304,14 @@ class TactusScore(Score):
         # CostEvent objects are dataclasses, not dicts — use getattr()
         if cost_breakdown:
             for call in cost_breakdown:
+                provider = getattr(call, 'provider', None)
+                model = getattr(call, 'model', None)
+                if (not provider) and isinstance(model, str) and "/" in model:
+                    provider = model.split("/", 1)[0]
                 from decimal import Decimal
                 self._cost_accumulator.add_api_call(
-                    provider='tactus',
-                    model=getattr(call, 'model', None),
+                    provider=str(provider or "tactus"),
+                    model=model,
                     prompt_tokens=getattr(call, 'prompt_tokens', 0),
                     completion_tokens=getattr(call, 'completion_tokens', 0),
                     cached_tokens=getattr(call, 'cache_tokens', 0) or 0,

--- a/plexus/scores/test_langgraph_cost_components.py
+++ b/plexus/scores/test_langgraph_cost_components.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from plexus.scores.LangGraphScore import LangGraphScore
+
+
+def test_langgraph_get_accumulated_costs_returns_model_components_per_node():
+    score = object.__new__(LangGraphScore)
+    score.parameters = SimpleNamespace(model_provider="ChatOpenAI", model_name="gpt-4o-mini")
+
+    node_a = SimpleNamespace(
+        parameters=SimpleNamespace(model_provider="ChatOpenAI", model_name="gpt-4o-mini"),
+        get_token_usage=lambda: {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+            "successful_requests": 2,
+            "cached_tokens": 10,
+        },
+    )
+    node_b = SimpleNamespace(
+        parameters=SimpleNamespace(model_provider="BedrockChat", model_name="anthropic.claude-3-haiku-20240307-v1:0"),
+        get_token_usage=lambda: {
+            "prompt_tokens": 200,
+            "completion_tokens": 40,
+            "total_tokens": 240,
+            "successful_requests": 3,
+            "cached_tokens": 0,
+        },
+    )
+    score.node_instances = [("node_a", node_a), ("node_b", node_b)]
+    score.get_token_usage = lambda: {
+        "prompt_tokens": 300,
+        "completion_tokens": 90,
+        "total_tokens": 390,
+        "successful_requests": 5,
+        "cached_tokens": 10,
+    }
+
+    with patch("plexus.scores.LangGraphScore._litellm.cost_per_token") as mock_cost_per_token:
+        mock_cost_per_token.side_effect = [(0.01, 0.02), (0.03, 0.01)]
+        costs = score.get_accumulated_costs()
+
+    assert costs["total_cost"] == pytest.approx(0.07)
+    assert costs["llm_calls"] == 5
+    assert isinstance(costs.get("components"), list)
+    assert len(costs["components"]) == 2
+
+    components = {(c.get("provider"), c.get("model")): c for c in costs["components"]}
+    first = components[("openai", "gpt-4o-mini")]
+    assert first["llm_calls"] == 2
+    assert first["prompt_tokens"] == 100
+    assert first["completion_tokens"] == 50
+
+    second = components[("bedrock", "anthropic.claude-3-haiku-20240307-v1:0")]
+    assert second["llm_calls"] == 3
+    assert second["prompt_tokens"] == 200
+    assert second["completion_tokens"] == 40

--- a/plexus/test_evaluation_cost_details.py
+++ b/plexus/test_evaluation_cost_details.py
@@ -1,0 +1,64 @@
+import pytest
+
+from plexus.Evaluation import Evaluation
+
+
+def test_build_cost_details_from_expenses_single_model():
+    expenses = {
+        "total_cost": 1.25,
+        "llm_calls": 2,
+        "prompt_tokens": 500,
+        "completion_tokens": 100,
+        "cached_tokens": 0,
+        "components": [
+            {
+                "type": "api_call",
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "prompt_tokens": 300,
+                "completion_tokens": 60,
+                "cached_tokens": 0,
+                "usd": 0.75,
+            },
+            {
+                "type": "api_call",
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "prompt_tokens": 200,
+                "completion_tokens": 40,
+                "cached_tokens": 0,
+                "usd": 0.50,
+            },
+        ],
+    }
+
+    details = Evaluation.build_cost_details_from_expenses(expenses)
+    assert details["schema_version"] == 1
+    assert details["total_usd"] == pytest.approx(1.25)
+    assert details["llm_calls"] == 2
+    assert len(details["breakdown"]) == 1
+    row = details["breakdown"][0]
+    assert row["provider"] == "openai"
+    assert row["model"] == "gpt-4o-mini"
+    assert row["spent_usd"] == pytest.approx(1.25)
+    assert row["total_tokens"] == 600
+
+
+def test_build_cost_details_from_expenses_multi_model():
+    expenses = {
+        "total_cost": 3.0,
+        "llm_calls": 3,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "cached_tokens": 0,
+        "components": [
+            {"type": "api_call", "provider": "openai", "model": "gpt-4o-mini", "usd": 1.0, "prompt_tokens": 100, "completion_tokens": 10},
+            {"type": "api_call", "provider": "openai", "model": "gpt-4o", "usd": 2.0, "prompt_tokens": 50, "completion_tokens": 5},
+            {"type": "http_call", "service": "irrelevant", "usd": 99.0},
+        ],
+    }
+    details = Evaluation.build_cost_details_from_expenses(expenses)
+    assert len(details["breakdown"]) == 2
+    models = {(row["provider"], row["model"]): row for row in details["breakdown"]}
+    assert models[("openai", "gpt-4o-mini")]["spent_usd"] == pytest.approx(1.0)
+    assert models[("openai", "gpt-4o")]["spent_usd"] == pytest.approx(2.0)

--- a/plexus/test_evaluation_cost_details.py
+++ b/plexus/test_evaluation_cost_details.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime, timezone
 
 from plexus.Evaluation import Evaluation
 
@@ -62,3 +63,85 @@ def test_build_cost_details_from_expenses_multi_model():
     models = {(row["provider"], row["model"]): row for row in details["breakdown"]}
     assert models[("openai", "gpt-4o-mini")]["spent_usd"] == pytest.approx(1.0)
     assert models[("openai", "gpt-4o")]["spent_usd"] == pytest.approx(2.0)
+
+
+def test_update_variables_preserves_notes_and_baselines_when_adding_cost_details():
+    class _Scorecard:
+        @staticmethod
+        def get_accumulated_costs():
+            return {
+                "total_cost": 0.42,
+                "llm_calls": 2,
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "cached_tokens": 0,
+                "components": [
+                    {
+                        "type": "api_call",
+                        "provider": "openai",
+                        "model": "gpt-5.4",
+                        "prompt_tokens": 100,
+                        "completion_tokens": 20,
+                        "cached_tokens": 0,
+                        "usd": 0.42,
+                    }
+                ],
+            }
+
+    class _DashboardClient:
+        @staticmethod
+        def execute(_query, _variables):
+            return {
+                "getEvaluation": {
+                    "parameters": {
+                        "notes": "Hypothesis 2: tighten ambiguous cost language",
+                        "metadata": {
+                            "baseline": "eval-baseline",
+                            "current_baseline": "eval-current",
+                        },
+                    }
+                }
+            }
+
+    evaluation = object.__new__(Evaluation)
+    evaluation.started_at = datetime.now(timezone.utc)
+    evaluation.processed_items = 5
+    evaluation.number_of_texts_to_sample = 200
+    evaluation.experiment_id = "eval-123"
+    evaluation.scorecard = _Scorecard()
+    evaluation.dashboard_client = _DashboardClient()
+    evaluation.parameters = None
+    evaluation.score_id = None
+    evaluation.score_version_id = None
+    evaluation.logging = __import__("logging").getLogger("test")
+
+    running_variables = evaluation._get_update_variables(
+        metrics={"alignment": 0.51, "accuracy": 0.75, "precision": 0.8, "recall": 0.7},
+        status="RUNNING",
+    )
+    running_input = running_variables["input"]
+    assert running_input["cost"] == pytest.approx(0.42)
+    assert running_input.get("parameters") is None
+
+    evaluation.parameters = {
+        "notes": "Hypothesis 2: tighten ambiguous cost language",
+        "metadata": {
+            "baseline": "eval-baseline",
+            "current_baseline": "eval-current",
+        },
+    }
+
+    variables = evaluation._get_update_variables(
+        metrics={"alignment": 0.51, "accuracy": 0.75, "precision": 0.8, "recall": 0.7},
+        status="COMPLETED",
+    )
+    update_input = variables["input"]
+    assert update_input["cost"] == pytest.approx(0.42)
+    params = update_input.get("parameters")
+    assert isinstance(params, str)
+    parsed = __import__("json").loads(params)
+    assert parsed.get("notes") == "Hypothesis 2: tighten ambiguous cost language"
+    metadata = parsed.get("metadata") or {}
+    assert metadata.get("baseline") == "eval-baseline"
+    assert metadata.get("current_baseline") == "eval-current"
+    assert isinstance(metadata.get("cost_details"), dict)

--- a/project/events/2026-04-20T02:14:04.820Z__2d815426-4e76-45a1-b03a-14076eb3e5fd.json
+++ b/project/events/2026-04-20T02:14:04.820Z__2d815426-4e76-45a1-b03a-14076eb3e5fd.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2d815426-4e76-45a1-b03a-14076eb3e5fd",
+  "issue_id": "plx-3da3a774-e699-4ac9-8750-d390a36a94d2",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T02:14:04.820Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "ffad7983-4261-4682-a96d-8bcae48a09e8"
+  }
+}

--- a/project/events/2026-04-20T04:33:36.941Z__b4ecab03-b8d5-44b7-8591-51c33d02a7cc.json
+++ b/project/events/2026-04-20T04:33:36.941Z__b4ecab03-b8d5-44b7-8591-51c33d02a7cc.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b4ecab03-b8d5-44b7-8591-51c33d02a7cc",
+  "issue_id": "plx-3da3a774-e699-4ac9-8750-d390a36a94d2",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T04:33:36.941Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e6ad5cbb-31d1-4db2-8341-13b226fe1f65"
+  }
+}

--- a/project/events/2026-04-20T12:08:40.451Z__aba9e821-4fa3-424d-b6e5-33b9dd23fb03.json
+++ b/project/events/2026-04-20T12:08:40.451Z__aba9e821-4fa3-424d-b6e5-33b9dd23fb03.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "aba9e821-4fa3-424d-b6e5-33b9dd23fb03",
+  "issue_id": "plx-740ac0ee-f536-48f4-b4a7-73d1f887c188",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-20T12:08:40.451Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-20T12:08:40.455Z__7c728541-af2c-4923-80d0-0c9a1f2df74f.json
+++ b/project/events/2026-04-20T12:08:40.455Z__7c728541-af2c-4923-80d0-0c9a1f2df74f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7c728541-af2c-4923-80d0-0c9a1f2df74f",
+  "issue_id": "plx-740ac0ee-f536-48f4-b4a7-73d1f887c188",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T12:08:40.455Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "fed6e5d5-d5b3-4468-8313-cb77f8e03bcd"
+  }
+}

--- a/project/events/2026-04-20T12:17:27.559Z__ef2fba3b-2094-485e-97b2-d101dc1743c3.json
+++ b/project/events/2026-04-20T12:17:27.559Z__ef2fba3b-2094-485e-97b2-d101dc1743c3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ef2fba3b-2094-485e-97b2-d101dc1743c3",
+  "issue_id": "plx-740ac0ee-f536-48f4-b4a7-73d1f887c188",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T12:17:27.559Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "39b227fc-52f0-495f-861c-97c9115075b3"
+  }
+}

--- a/project/issues/plx-3da3a774-e699-4ac9-8750-d390a36a94d2.json
+++ b/project/issues/plx-3da3a774-e699-4ac9-8750-d390a36a94d2.json
@@ -58,10 +58,22 @@
       "author": "ryan",
       "text": "Committed and pushed current branch snapshot as 8e8c8578a. Validation passed locally: dashboard typecheck and fetch_score_configurations_test. Waiting for GitHub Actions on branch feature/tighten-procedure-cycles-header before closing anything.",
       "created_at": "2026-04-20T02:02:18.127502Z"
+    },
+    {
+      "id": "ffad7983-4261-4682-a96d-8bcae48a09e8",
+      "author": "ryan",
+      "text": "Branch feature/tighten-procedure-cycles-header pushed at 8e8c8578a and GitHub Actions run 24644992753 passed. Local checks passed earlier: dashboard typecheck and fetch_score_configurations_test. Leaving story in_progress because this is committed/pushed branch work, not merged release work.",
+      "created_at": "2026-04-20T02:14:04.819604Z"
+    },
+    {
+      "id": "e6ad5cbb-31d1-4db2-8341-13b226fe1f65",
+      "author": "ryan",
+      "text": "Investigating why Cost Breakdown is absent for the prior procedure run UI. Checking the stored task/procedure payload and the render conditions in ProcedureTask before making any code changes.",
+      "created_at": "2026-04-20T04:33:36.940380Z"
     }
   ],
   "created_at": "2026-04-19T20:36:27.392885Z",
-  "updated_at": "2026-04-20T02:02:18.127502Z",
+  "updated_at": "2026-04-20T04:33:36.940380Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-740ac0ee-f536-48f4-b4a7-73d1f887c188.json
+++ b/project/issues/plx-740ac0ee-f536-48f4-b4a7-73d1f887c188.json
@@ -3,16 +3,29 @@
   "title": "Track optimizer run costs with evaluation vs inference breakdown",
   "description": "## User Story As an optimizer operator I want each procedure run to report incurred evaluation spend separately from optimizer inference spend So that I can understand total run cost and where money is being spent  ## Behavior Spec (Gherkin) Feature: Optimizer run cost accounting Scenario: Run records both evaluation and inference costs Given an optimizer procedure run executes evaluations and LLM inference When the run completes Then procedure state includes a cost summary with evaluation incurred cost and optimization inference cost And total incurred cost equals evaluation incurred cost plus optimization inference cost  Scenario: Reused evaluations are not counted as incurred spend Given the optimizer reuses a cached or explicitly resumed evaluation When cost summary is computed Then referenced evaluation cost is visible And incurred evaluation cost contribution for that reused evaluation is zero  Scenario: Branch starts with fresh cost accounting Given a branch procedure is created from a source procedure When the branch run starts Then the branch does not inherit source procedure cost totals  Scenario: Continue preserves cost accounting Given a procedure is continued for additional cycles When continuation runs Then previous run cost totals are preserved And new invocation costs are added without double counting",
   "type": "story",
-  "status": "open",
+  "status": "in_progress",
   "priority": 1,
   "assignee": null,
   "creator": null,
   "parent": "plx-a478745c-8259-4de1-bd3e-ff3f8ebe5811",
   "labels": [],
   "dependencies": [],
-  "comments": [],
+  "comments": [
+    {
+      "id": "fed6e5d5-d5b3-4468-8313-cb77f8e03bcd",
+      "author": "ryan",
+      "text": "Starting implementation: add model-level cost attribution in evaluation persistence, procedure ledger, chat trace metadata, and UI (ProcedureTask + conversation viewer), with tests.",
+      "created_at": "2026-04-20T12:08:40.455347Z"
+    },
+    {
+      "id": "39b227fc-52f0-495f-861c-97c9115075b3",
+      "author": "ryan",
+      "text": "Implemented model-level cost attribution end-to-end: Evaluation.costDetails persistence + MCP outputs, optimizer state.costs breakdown arrays for evaluation/inference, live chat message cost metadata (assistant/tool), ProcedureTask model table, and conversation cost pills/details. Added tests: test_trace_sink cost metadata cases, test_procedure_executor_compat inference breakdown, and new test_evaluation_cost_details. Targeted pytest passed (13 tests).",
+      "created_at": "2026-04-20T12:17:27.559166Z"
+    }
+  ],
   "created_at": "2026-04-19T21:07:20.046345Z",
-  "updated_at": "2026-04-19T21:07:27.997307Z",
+  "updated_at": "2026-04-20T12:17:27.559166Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-9f21b2a5-fd83-4d7a-95dd-0ceabad5b00a.json
+++ b/project/issues/plx-9f21b2a5-fd83-4d7a-95dd-0ceabad5b00a.json
@@ -34,12 +34,4 @@
   "updated_at": "2026-04-20T01:22:30.795407Z",
   "closed_at": null,
   "custom": {}
-}e are no live local 'plexus procedure run/optimize' processes, but the latest Procedure task still shows RUNNING in the database. Plan: kill any DB-side in-progress procedures/tasks we find, relaunch the latest optimizer run at 200 samples / 10 cycles, and verify actual liveness via both process inspection and task/stage timestamps.",
-      "created_at": "2026-04-20T01:22:30.795234Z"
-    }
-  ],
-  "created_at": "2026-04-02T16:09:15.727062Z",
-  "updated_at": "2026-04-20T01:22:30.795234Z",
-  "closed_at": null,
-  "custom": {}
 }

--- a/project/issues/plx-faa41570-d5e1-482d-ae26-1786f96a72e3.json
+++ b/project/issues/plx-faa41570-d5e1-482d-ae26-1786f96a72e3.json
@@ -16,10 +16,52 @@
       "author": "ryan",
       "text": "Implemented canonical procedure cost ledger plumbing: persisted inference CostEvents into state.costs, added evaluation cost ledger recording across baseline/hypothesis/strategy/synthesis eval paths, cleared costs on branch clone, and added ProcedureTask cost breakdown UI. Added tests for inference-cost persistence and branch clone cost reset; targeted pytest suite passing.",
       "created_at": "2026-04-19T21:12:13.216577Z"
+    },
+    {
+      "id": "5dfa104c-b6df-4300-b78d-cd80d72ad0a0",
+      "author": "ryan",
+      "text": "Investigating live assistant completion cost pills showing /bin/zsh/0 tokens despite non-zero inference totals. Tracing cost-event attachment path in PlexusTraceSink and Procedure log bridge; preparing patch and regression test.",
+      "created_at": "2026-04-20T13:03:18.130044Z"
+    },
+    {
+      "id": "a54c328d-2f0e-448d-a23c-dc10858c43c4",
+      "author": "ryan",
+      "text": "Fixing misleading zero-cost completion badges/details: suppress empty cost summaries in conversation UI and harden trace cost attachment semantics.",
+      "created_at": "2026-04-20T13:10:06.368919Z"
+    },
+    {
+      "id": "f154bb82-2aff-41b1-9c12-66e5d912170f",
+      "author": "ryan",
+      "text": "Integration run e3701ef8-882f-42d1-a483-810ba4ecc86a is live. Verified non-zero assistant completion cost metadata in chat (message b198ecbb... total_usd=0.025708, llm_calls=1) and live state aggregation (inference_total=0.036058, entries=2, model=openai/gpt-5.4). Also removed GraphQL costDetails writes; now persisting cost_details under evaluation parameters.metadata to avoid schema dependency.",
+      "created_at": "2026-04-20T13:21:08.015757Z"
+    },
+    {
+      "id": "cf970ba0-6da4-40b5-9ace-bdeffe0862ec",
+      "author": "ryan",
+      "text": "Investigating regression: evaluation notes/hypothesis context missing in in-progress procedure run. Checking recent cost-related parameter update path for metadata overwrite.",
+      "created_at": "2026-04-20T13:43:11.658426Z"
+    },
+    {
+      "id": "8ed85f06-2ee3-45af-9776-ebf8c038f0f1",
+      "author": "ryan",
+      "text": "Implemented fixes for two regressions: (1) preserve evaluation parameters when injecting cost_details so notes + baseline/current_baseline metadata are not clobbered, and (2) add model-level cost components for LangGraphScore + improved provider/model extraction in TactusScore. Added tests for parameter preservation and per-node model components.",
+      "created_at": "2026-04-20T13:51:16.885136Z"
+    },
+    {
+      "id": "ce90237c-fc44-4edc-97c2-a0f25ad7d53a",
+      "author": "ryan",
+      "text": "Executing fresh 200x10 integration validation now: preflight -> launch procedure -> verify notes/baseline/model breakdown in backend + UI data surfaces.",
+      "created_at": "2026-04-20T13:59:26.938142Z"
+    },
+    {
+      "id": "bcfff527-cdc4-4334-b798-381dfab76587",
+      "author": "ryan",
+      "text": "Landing final pending changes now: run targeted quality gates, commit remaining model-cost-attribution updates, open PR to develop, and verify CI before merging so develop->main PR includes this work.",
+      "created_at": "2026-04-20T17:54:50.032794Z"
     }
   ],
   "created_at": "2026-04-19T21:07:30.685196Z",
-  "updated_at": "2026-04-19T21:12:13.216577Z",
+  "updated_at": "2026-04-20T17:54:50.032794Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
## Summary
- finalize procedure/evaluation cost attribution plumbing across runtime, storage, and score executors
- preserve existing evaluation parameters while writing cost metadata
- add model-level cost components for LangGraph and Tactus score paths
- harden conversation/procedure dashboard cost rendering to avoid misleading zero-cost pills
- add regression tests for trace/session status, storage metadata preservation, and model cost components

## Validation
- `python -m pytest -q plexus/cli/procedure/test_trace_sink.py plexus/cli/procedure/test_procedure_executor_compat.py plexus/cli/shared/test_experiment_runner.py plexus/test_evaluation_cost_details.py plexus/scores/test_langgraph_cost_components.py plexus/cli/procedure/test_storage_metadata_preservation.py plexus/cli/procedure/lua_dsl/test_runtime_failure_session_status.py`
- `cd dashboard && npm run ci:typecheck`
