### PR TITLE
fix(reports): use identityPool guest auth for shared report access

### DIFF
--- a/dashboard/app/reports/[id]/page.tsx
+++ b/dashboard/app/reports/[id]/page.tsx
@@ -71,17 +71,15 @@ export class ReportService {
   // Fetch report by ID for dashboard deep links
   async fetchReportById(id: string): Promise<any> {
     try {
-      // Determine auth mode for unauthenticated access
-      let authMode: 'userPool' | 'apiKey' | undefined = undefined;
+      // Determine auth mode based on user's session
+      let authMode: 'userPool' | 'identityPool' = 'identityPool';
       try {
         const session = await fetchAuthSession();
         if (session.tokens?.idToken) {
           authMode = 'userPool';
-        } else {
-          authMode = 'apiKey';
         }
       } catch (error) {
-        authMode = 'apiKey';
+        console.log('Error checking auth session, falling back to guest access:', error);
       }
 
       // Use the graphql API directly with a single, comprehensive query
@@ -143,19 +141,14 @@ export class ReportService {
   async fetchReportByShareToken(token: string): Promise<any> {
     try {
       // Determine auth mode based on user's session
-      let authMode: 'userPool' | 'apiKey' | undefined = undefined; // Default to public access
+      let authMode: 'userPool' | 'identityPool' = 'identityPool';
       try {
         const session = await fetchAuthSession();
         if (session.tokens?.idToken) {
           authMode = 'userPool';
-        } else {
-          // For unauthenticated access, use API key instead of identity pool
-          authMode = 'apiKey';
-          console.log('Using API key access mode');
         }
       } catch (error) {
-        console.log('Error checking auth session, falling back to API key access');
-        authMode = 'apiKey';
+        console.log('Error checking auth session, falling back to guest access:', error);
       }
       
       // First get the share link data and resource ID

--- a/project/events/2026-04-20T17:48:22.157Z__c0c71fba-f82a-45e4-bf31-5f59e06e7828.json
+++ b/project/events/2026-04-20T17:48:22.157Z__c0c71fba-f82a-45e4-bf31-5f59e06e7828.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c0c71fba-f82a-45e4-bf31-5f59e06e7828",
+  "issue_id": "plx-51de29d8-c8d5-4fb8-ab96-5d8f82fe09fb",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-20T17:48:22.157Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Investigate and fix regression where report share URLs return GraphQL 401 Unauthorized for unauthenticated users. Identify root cause from recent changes, implement fix, and verify public share links work without login.",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Restore unauthenticated report share URL access"
+  }
+}

--- a/project/events/2026-04-20T17:48:39.439Z__871a396a-a4fb-4ea3-8575-daba78d1d8d0.json
+++ b/project/events/2026-04-20T17:48:39.439Z__871a396a-a4fb-4ea3-8575-daba78d1d8d0.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "871a396a-a4fb-4ea3-8575-daba78d1d8d0",
+  "issue_id": "plx-d0387d86-87fb-4116-802e-181a9f467797",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-20T17:48:39.439Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "As an unauthenticated viewer opening a report share URL, I want the report to load by share token without login, so that shared report links remain publicly viewable as intended.\n\nObserved behavior (since week of 2026-04-13): AppSync request for fetchReportByShareToken fails with Unauthorized (401).\n\nDebug scope:\n- Check frontend authMode used for share-token query\n- Check AppSync auth rules / resolver auth mode for share-token path\n- Check recent commits in last 7-10 days for auth-related regressions\n- Confirm whether API key expiry was relevant vs IAM/lambda/userPool config\n\nDone criteria:\n- Root cause identified with commit/config evidence\n- Fix implemented\n- Verified unauthenticated share URL works end-to-end",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-51de29d8-c8d5-4fb8-ab96-5d8f82fe09fb",
+    "priority": 1,
+    "status": "open",
+    "title": "Share token GraphQL request returns 401 for unauthenticated users"
+  }
+}

--- a/project/events/2026-04-20T17:48:48.665Z__d75e8bfa-54fe-4323-9309-b5d89e5d916b.json
+++ b/project/events/2026-04-20T17:48:48.665Z__d75e8bfa-54fe-4323-9309-b5d89e5d916b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d75e8bfa-54fe-4323-9309-b5d89e5d916b",
+  "issue_id": "plx-d0387d86-87fb-4116-802e-181a9f467797",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-20T17:48:48.665Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-20T17:48:48.677Z__d2a5b655-9209-4773-beb7-f02ab5bada22.json
+++ b/project/events/2026-04-20T17:48:48.677Z__d2a5b655-9209-4773-beb7-f02ab5bada22.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d2a5b655-9209-4773-beb7-f02ab5bada22",
+  "issue_id": "plx-d0387d86-87fb-4116-802e-181a9f467797",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T17:48:48.677Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "1006509d-b1b5-4006-8af9-91000a67fc4a"
+  }
+}

--- a/project/events/2026-04-20T17:53:10.817Z__12424de9-1d1e-4eea-9533-4b5f9aa08a47.json
+++ b/project/events/2026-04-20T17:53:10.817Z__12424de9-1d1e-4eea-9533-4b5f9aa08a47.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "12424de9-1d1e-4eea-9533-4b5f9aa08a47",
+  "issue_id": "plx-d0387d86-87fb-4116-802e-181a9f467797",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T17:53:10.817Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "16be0678-d34a-4ea2-b9d3-bea4ea333bc0"
+  }
+}

--- a/project/events/2026-04-20T18:00:56.216Z__41b06435-6327-411e-ad7a-40a306d782f4.json
+++ b/project/events/2026-04-20T18:00:56.216Z__41b06435-6327-411e-ad7a-40a306d782f4.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "41b06435-6327-411e-ad7a-40a306d782f4",
+  "issue_id": "plx-09a2c340-b32d-4d16-b27d-3e9717a80a0e",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-20T18:00:56.216Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Track work to map and persist required Call Criteria prompt metadata into Plexus Item.metadata so prompt templates resolve reliably.",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Ensure prompt metadata fields are persisted on Plexus items"
+  }
+}

--- a/project/events/2026-04-20T18:00:58.865Z__741e9cce-b5d3-4510-b4ad-414863616956.json
+++ b/project/events/2026-04-20T18:00:58.865Z__741e9cce-b5d3-4510-b4ad-414863616956.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "741e9cce-b5d3-4510-b4ad-414863616956",
+  "issue_id": "plx-c5bf9c9e-0cad-43ff-81f3-db29aa3e584c",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-20T18:00:58.865Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Identify metadata placeholders used by system/user prompts and ensure Plexus write path persists corresponding fields for reliable prompt rendering.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-09a2c340-b32d-4d16-b27d-3e9717a80a0e",
+    "priority": 1,
+    "status": "open",
+    "title": "Map missing prompt placeholders into persisted Item.metadata"
+  }
+}

--- a/project/events/2026-04-20T18:01:03.983Z__a5be92ae-29ca-4bb2-bd5e-007d1bf7056e.json
+++ b/project/events/2026-04-20T18:01:03.983Z__a5be92ae-29ca-4bb2-bd5e-007d1bf7056e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a5be92ae-29ca-4bb2-bd5e-007d1bf7056e",
+  "issue_id": "plx-c5bf9c9e-0cad-43ff-81f3-db29aa3e584c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-20T18:01:03.983Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-20T18:29:19.516Z__cfd6c846-353b-420d-b308-48d84c37002e.json
+++ b/project/events/2026-04-20T18:29:19.516Z__cfd6c846-353b-420d-b308-48d84c37002e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cfd6c846-353b-420d-b308-48d84c37002e",
+  "issue_id": "plx-d0387d86-87fb-4116-802e-181a9f467797",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T18:29:19.516Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "4919a17a-f34d-4028-b992-a96e052b20f6"
+  }
+}

--- a/project/events/2026-04-20T18:41:46.514Z__2bdf70b8-01fc-4743-95c3-8a3c96de6cc6.json
+++ b/project/events/2026-04-20T18:41:46.514Z__2bdf70b8-01fc-4743-95c3-8a3c96de6cc6.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2bdf70b8-01fc-4743-95c3-8a3c96de6cc6",
+  "issue_id": "plx-d0387d86-87fb-4116-802e-181a9f467797",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T18:41:46.514Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "a40e72dd-1c9c-4262-8a5e-eb143559a1c3"
+  }
+}

--- a/project/events/2026-04-20T18:43:29.646Z__0f0637f7-6e2c-4b93-9f6f-f559500cb06e.json
+++ b/project/events/2026-04-20T18:43:29.646Z__0f0637f7-6e2c-4b93-9f6f-f559500cb06e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0f0637f7-6e2c-4b93-9f6f-f559500cb06e",
+  "issue_id": "plx-d0387d86-87fb-4116-802e-181a9f467797",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T18:43:29.646Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "531c90a6-0848-40ff-9db2-f51b33ad7343"
+  }
+}

--- a/project/issues/plx-09a2c340-b32d-4d16-b27d-3e9717a80a0e.json
+++ b/project/issues/plx-09a2c340-b32d-4d16-b27d-3e9717a80a0e.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-09a2c340-b32d-4d16-b27d-3e9717a80a0e",
+  "title": "Ensure prompt metadata fields are persisted on Plexus items",
+  "description": "Track work to map and persist required Call Criteria prompt metadata into Plexus Item.metadata so prompt templates resolve reliably.",
+  "type": "epic",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-20T18:00:56.216471548Z",
+  "updated_at": "2026-04-20T18:00:56.216471548Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-51de29d8-c8d5-4fb8-ab96-5d8f82fe09fb.json
+++ b/project/issues/plx-51de29d8-c8d5-4fb8-ab96-5d8f82fe09fb.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-51de29d8-c8d5-4fb8-ab96-5d8f82fe09fb",
+  "title": "Restore unauthenticated report share URL access",
+  "description": "Investigate and fix regression where report share URLs return GraphQL 401 Unauthorized for unauthenticated users. Identify root cause from recent changes, implement fix, and verify public share links work without login.",
+  "type": "epic",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-20T17:48:22.157345286Z",
+  "updated_at": "2026-04-20T17:48:22.157345286Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-c5bf9c9e-0cad-43ff-81f3-db29aa3e584c.json
+++ b/project/issues/plx-c5bf9c9e-0cad-43ff-81f3-db29aa3e584c.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-c5bf9c9e-0cad-43ff-81f3-db29aa3e584c",
+  "title": "Map missing prompt placeholders into persisted Item.metadata",
+  "description": "Identify metadata placeholders used by system/user prompts and ensure Plexus write path persists corresponding fields for reliable prompt rendering.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-09a2c340-b32d-4d16-b27d-3e9717a80a0e",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-20T18:00:58.865819252Z",
+  "updated_at": "2026-04-20T18:01:03.982289304Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-d0387d86-87fb-4116-802e-181a9f467797.json
+++ b/project/issues/plx-d0387d86-87fb-4116-802e-181a9f467797.json
@@ -1,0 +1,49 @@
+{
+  "id": "plx-d0387d86-87fb-4116-802e-181a9f467797",
+  "title": "Share token GraphQL request returns 401 for unauthenticated users",
+  "description": "As an unauthenticated viewer opening a report share URL, I want the report to load by share token without login, so that shared report links remain publicly viewable as intended.\n\nObserved behavior (since week of 2026-04-13): AppSync request for fetchReportByShareToken fails with Unauthorized (401).\n\nDebug scope:\n- Check frontend authMode used for share-token query\n- Check AppSync auth rules / resolver auth mode for share-token path\n- Check recent commits in last 7-10 days for auth-related regressions\n- Confirm whether API key expiry was relevant vs IAM/lambda/userPool config\n\nDone criteria:\n- Root cause identified with commit/config evidence\n- Fix implemented\n- Verified unauthenticated share URL works end-to-end",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-51de29d8-c8d5-4fb8-ab96-5d8f82fe09fb",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "1006509d-b1b5-4006-8af9-91000a67fc4a",
+      "author": "derek",
+      "text": "Starting investigation. First pass will diff commits from 2026-04-13 onward around dashboard reports share-token fetching and Amplify GraphQL auth mode usage.",
+      "created_at": "2026-04-20T17:48:48.677109094Z"
+    },
+    {
+      "id": "16be0678-d34a-4ea2-b9d3-bea4ea333bc0",
+      "author": "derek",
+      "text": "Findings so far (2026-04-20):\n1) No report share-token auth logic changes landed in last 7-10 days; recent report page commit (5bd6f622 on 2026-04-18) is display-name-only.\n2) Report share flow uses authMode=apiKey for unauth users in dashboard/app/reports/[id]/page.tsx.\n3) Direct AppSync probe with the API key currently present in dashboard/amplify_outputs.json returns HTTP 401 Unauthorized.\n4) This matches browser error (Unauthorized for getResourceByShareToken) and points to invalid/expired API key as immediate break cause, not lambda role path.\nNext: recommend rotate/redeploy API key and optionally harden report share flow to use identityPool guest path like evaluations to reduce API-key fragility.",
+      "created_at": "2026-04-20T17:53:10.817808777Z"
+    },
+    {
+      "id": "4919a17a-f34d-4028-b992-a96e052b20f6",
+      "author": "derek",
+      "text": "Implementing fix now: create a bugfix branch from develop and update report share auth flow to match evaluation page guest auth (identityPool) instead of apiKey.",
+      "created_at": "2026-04-20T18:29:19.516574664Z"
+    },
+    {
+      "id": "a40e72dd-1c9c-4262-8a5e-eb143559a1c3",
+      "author": "derek",
+      "text": "Implemented code fix on branch bugfix/report-share-identitypool-auth: report page now uses userPool when signed in and identityPool guest when unauthenticated, mirroring evaluation share-token auth behavior. Removed apiKey fallback from report share and report ID fetch paths.",
+      "created_at": "2026-04-20T18:41:46.513934396Z"
+    },
+    {
+      "id": "531c90a6-0848-40ff-9db2-f51b33ad7343",
+      "author": "derek",
+      "text": "Fix branch pushed: bugfix/report-share-identitypool-auth (commit 6cb41477). Report page auth mode now mirrors evaluations: userPool when authenticated, identityPool guest when unauthenticated (no apiKey dependency in report fetch paths).",
+      "created_at": "2026-04-20T18:43:29.646006734Z"
+    }
+  ],
+  "created_at": "2026-04-20T17:48:39.439276117Z",
+  "updated_at": "2026-04-20T18:43:29.646006734Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
**Summary**
- Switch report-page GraphQL auth mode selection to mirror evaluations in `dashboard/app/reports/[id]/page.tsx`.
- Use `userPool` when an authenticated session exists.
- Default unauthenticated report access to `identityPool` guest auth instead of `apiKey` for both:
- `fetchReportById`
- `fetchReportByShareToken`
- Include required Kanbus artifact files in this branch (`project/events/*`, `project/issues/*`) per requested workflow.

**Why**
- Production report share URLs for unauthenticated users were failing with `401 Unauthorized` due to API-key dependence.
- Evaluations already succeed for unauthenticated users using guest IAM (`identityPool`); reports should follow the same auth path.
- This removes report-share fragility tied to API-key validity and aligns auth behavior across shared resources.

**Validation**
- Root-cause confirmation:
- `curl` to AppSync with the configured API key returned `HTTP 401 Unauthorized`.
- Code review:
- Verified report auth-mode logic now matches evaluation-page guest auth strategy.
- Local checks attempted:
- `cd dashboard && npm -s run test -- --runInBand app/evaluations/[id]/__tests__/page.test.tsx` (no matching tests by pattern)
- `cd dashboard && npx -y eslint app/reports/[id]/page.tsx` (tooling/runtime error in current environment: `@eslint/eslintrc`/`ajv`)

**Expected Outcome**
- Unauthenticated report share URLs use guest IAM auth (`identityPool`) and no longer rely on AppSync API key validity.
- Authenticated users continue using `userPool`.
- Report share behavior matches evaluation share behavior.

**Kanbus / Task Tracking**
- `plx-51de29` (epic): Restore unauthenticated report share URL access
- `plx-d0387d` (bug): Share token GraphQL request returns 401 for unauthenticated users
