### PR TITLE
fix(langgraph): stabilize cost model-name resolution

### DIFF
--- a/plexus/scores/LangGraphScore.py
+++ b/plexus/scores/LangGraphScore.py
@@ -946,6 +946,16 @@ class LangGraphScore(Score, LangChainUser):
             }
             return mapping.get(normalized, normalized)
 
+        def _coerce_model_name(node_params: Any) -> Optional[str]:
+            node_model_name = getattr(node_params, "model_name", None)
+            if isinstance(node_model_name, str) and node_model_name.strip():
+                return node_model_name.strip()
+
+            score_model_name = getattr(self.parameters, "model_name", None)
+            if isinstance(score_model_name, str) and score_model_name.strip():
+                return score_model_name.strip()
+            return None
+
         node_instances = getattr(self, "node_instances", None)
         if isinstance(node_instances, list):
             for node_name, node_instance in node_instances:
@@ -966,10 +976,7 @@ class LangGraphScore(Score, LangChainUser):
                     continue
 
                 node_params = getattr(node_instance, "parameters", None)
-                model_name = (
-                    getattr(node_params, "model_name", None)
-                    or self.parameters.model_name
-                )
+                model_name = _coerce_model_name(node_params)
                 provider_name = _normalize_provider(
                     getattr(node_params, "model_provider", None) or self.parameters.model_provider
                 )

--- a/project/events/2026-04-20T18:54:47.399Z__85057794-284f-4002-ba38-503e1170f385.json
+++ b/project/events/2026-04-20T18:54:47.399Z__85057794-284f-4002-ba38-503e1170f385.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "85057794-284f-4002-ba38-503e1170f385",
+  "issue_id": "plx-5bbd8047-62a2-4e40-9368-498b3fda02fb",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-20T18:54:47.399Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Investigate and fix failing test: plexus/scores/LangGraphScore_test.py::test_cost_calculation_across_model_providers.\n\nObserved: get_accumulated_costs now calls litellm.cost_per_token with a MagicMock model value from node parameters instead of the configured model string, causing assertion failure in CI/develop.\n\nDone criteria:\n- Root cause identified\n- Minimal fix applied\n- Target test passes locally",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-51de29d8-c8d5-4fb8-ab96-5d8f82fe09fb",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix LangGraphScore cost calculation test regression"
+  }
+}

--- a/project/events/2026-04-20T18:55:04.799Z__e282e012-b6f1-4321-ac85-b24967c3e4e1.json
+++ b/project/events/2026-04-20T18:55:04.799Z__e282e012-b6f1-4321-ac85-b24967c3e4e1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e282e012-b6f1-4321-ac85-b24967c3e4e1",
+  "issue_id": "plx-5bbd8047-62a2-4e40-9368-498b3fda02fb",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-20T18:55:04.799Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-20T18:55:04.810Z__cec0330b-ee90-4e3c-b369-ddea1af83e4d.json
+++ b/project/events/2026-04-20T18:55:04.810Z__cec0330b-ee90-4e3c-b369-ddea1af83e4d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cec0330b-ee90-4e3c-b369-ddea1af83e4d",
+  "issue_id": "plx-5bbd8047-62a2-4e40-9368-498b3fda02fb",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T18:55:04.810Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "6b2313de-ffb2-4ec4-abfd-d27d81132f89"
+  }
+}

--- a/project/events/2026-04-20T18:55:55.739Z__62bdb9be-f45f-43ff-af00-1ad772ae4c72.json
+++ b/project/events/2026-04-20T18:55:55.739Z__62bdb9be-f45f-43ff-af00-1ad772ae4c72.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "62bdb9be-f45f-43ff-af00-1ad772ae4c72",
+  "issue_id": "plx-5bbd8047-62a2-4e40-9368-498b3fda02fb",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T18:55:55.739Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "74211101-4f03-42b2-b326-e131ea8d4650"
+  }
+}

--- a/project/issues/plx-5bbd8047-62a2-4e40-9368-498b3fda02fb.json
+++ b/project/issues/plx-5bbd8047-62a2-4e40-9368-498b3fda02fb.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-5bbd8047-62a2-4e40-9368-498b3fda02fb",
+  "title": "Fix LangGraphScore cost calculation test regression",
+  "description": "Investigate and fix failing test: plexus/scores/LangGraphScore_test.py::test_cost_calculation_across_model_providers.\n\nObserved: get_accumulated_costs now calls litellm.cost_per_token with a MagicMock model value from node parameters instead of the configured model string, causing assertion failure in CI/develop.\n\nDone criteria:\n- Root cause identified\n- Minimal fix applied\n- Target test passes locally",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-51de29d8-c8d5-4fb8-ab96-5d8f82fe09fb",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "6b2313de-ffb2-4ec4-abfd-d27d81132f89",
+      "author": "derek",
+      "text": "Reproduced failure locally on branch bugfix/report-share-identitypool-auth. Next step: inspect get_accumulated_costs model-name resolution and patch to use concrete string fallback when node parameters contain mocks/non-string values.",
+      "created_at": "2026-04-20T18:55:04.810752473Z"
+    },
+    {
+      "id": "74211101-4f03-42b2-b326-e131ea8d4650",
+      "author": "derek",
+      "text": "Root cause confirmed: get_accumulated_costs resolved model_name from node parameters without type validation. In this test, node.parameters is a MagicMock, so model_name became MagicMock instead of configured 'gpt-4'. Implemented fix: coerce model name to a non-empty string; otherwise fallback to score-level model_name.",
+      "created_at": "2026-04-20T18:55:55.739669354Z"
+    }
+  ],
+  "created_at": "2026-04-20T18:54:47.399590398Z",
+  "updated_at": "2026-04-20T18:55:55.739669354Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
**Summary**
- Fix `LangGraphScore.get_accumulated_costs()` model resolution so node-level `model_name` is used only when it is a non-empty string.
- Fallback to score-level `self.parameters.model_name` when node-level value is missing or non-string (e.g. `MagicMock`).
- Include Kanbus artifact files generated for this regression investigation.

**Why**
- `plexus/scores/LangGraphScore_test.py::test_cost_calculation_across_model_providers` was failing because `litellm.cost_per_token()` received a `MagicMock` model instead of `"gpt-4"`.
- This regression can occur whenever node parameters are mocked or partially populated.

**Validation**
- `poetry run pytest -q plexus/scores/LangGraphScore_test.py::test_cost_calculation_across_model_providers` (pass)
- `poetry run pytest -q plexus/scores/LangGraphScore_test.py -k "cost_calculation"` (3 passed)

**Expected Outcome**
- Cost calculation always sends a concrete model string to LiteLLM.
- The failing cost-calculation test passes consistently.

**Kanbus / Task Tracking**
- `plx-5bbd80` (bug): Fix LangGraphScore cost calculation test regression
