### PR TITLE
fix(release): keep Plexus package version in sync with semantic-release tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,51 @@ permissions:
   contents: write
 
 jobs:
+  version-sync:
+    name: Version Sync Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Validate pyproject and _version.py stay in sync
+      run: |
+        python - <<'PY'
+        import re
+        import sys
+        from pathlib import Path
+
+        pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
+        version_file_text = Path("plexus/_version.py").read_text(encoding="utf-8")
+
+        pyproject_match = re.search(r'(?m)^version\s*=\s*"([^"]+)"\s*$', pyproject_text)
+        version_file_match = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"\s*$', version_file_text)
+
+        if not pyproject_match or not version_file_match:
+            print("Unable to parse version from pyproject.toml or plexus/_version.py", file=sys.stderr)
+            sys.exit(1)
+
+        pyproject_version = pyproject_match.group(1)
+        version_file_version = version_file_match.group(1)
+
+        print(f"pyproject version: {pyproject_version}")
+        print(f"_version.py version: {version_file_version}")
+
+        if pyproject_version != version_file_version:
+            print(
+                "Version mismatch: pyproject.toml and plexus/_version.py must match. "
+                "Release automation should update both together.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        PY
+
   python-tests:
     name: Python Tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [version-sync]
     strategy:
       fail-fast: false
       matrix:

--- a/project/events/2026-04-20T22:23:51.733Z__e572dadd-ee73-474f-a791-2aaa577bfcdc.json
+++ b/project/events/2026-04-20T22:23:51.733Z__e572dadd-ee73-474f-a791-2aaa577bfcdc.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "e572dadd-ee73-474f-a791-2aaa577bfcdc",
+  "issue_id": "plx-cd63156f-930a-49d1-874c-cbe5d95e6879",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-20T22:23:51.733Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Sync Plexus package version with semantic-release tags"
+  }
+}

--- a/project/events/2026-04-20T22:23:54.385Z__3859a826-c76d-492a-8006-8ddcf078e035.json
+++ b/project/events/2026-04-20T22:23:54.385Z__3859a826-c76d-492a-8006-8ddcf078e035.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3859a826-c76d-492a-8006-8ddcf078e035",
+  "issue_id": "plx-cd63156f-930a-49d1-874c-cbe5d95e6879",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-20T22:23:54.385Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-20T22:23:54.397Z__3e7a92a0-c336-44dd-a7b0-00d6d932dfa9.json
+++ b/project/events/2026-04-20T22:23:54.397Z__3e7a92a0-c336-44dd-a7b0-00d6d932dfa9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3e7a92a0-c336-44dd-a7b0-00d6d932dfa9",
+  "issue_id": "plx-cd63156f-930a-49d1-874c-cbe5d95e6879",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T22:23:54.397Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "c9c07b03-685d-4d94-8d60-01eafebe6522"
+  }
+}

--- a/project/events/2026-04-20T22:24:35.750Z__f9a2b4c7-9095-45bc-a4f6-a20fdac224ee.json
+++ b/project/events/2026-04-20T22:24:35.750Z__f9a2b4c7-9095-45bc-a4f6-a20fdac224ee.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f9a2b4c7-9095-45bc-a4f6-a20fdac224ee",
+  "issue_id": "plx-cd63156f-930a-49d1-874c-cbe5d95e6879",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T22:24:35.750Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "d13f18ed-0d68-4340-843d-f6884fff6126"
+  }
+}

--- a/project/issues/plx-cd63156f-930a-49d1-874c-cbe5d95e6879.json
+++ b/project/issues/plx-cd63156f-930a-49d1-874c-cbe5d95e6879.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-cd63156f-930a-49d1-874c-cbe5d95e6879",
+  "title": "Sync Plexus package version with semantic-release tags",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "c9c07b03-685d-4d94-8d60-01eafebe6522",
+      "author": "derek",
+      "text": "Investigating semantic-release configuration: tags advance and plexus/_version.py updates, but pyproject.toml [tool.poetry].version remains 1.23.0, causing deployed package metadata to stay stale across tags.",
+      "created_at": "2026-04-20T22:23:54.396924194Z"
+    },
+    {
+      "id": "d13f18ed-0d68-4340-843d-f6884fff6126",
+      "author": "derek",
+      "text": "Implemented fix on branch fix/semantic-release-version-sync: (1) semantic-release now updates pyproject.toml tool.poetry.version via version_toml, (2) aligned current pyproject version to 1.34.0 to match plexus/_version.py, (3) added CI version-sync job to fail when pyproject and _version diverge.",
+      "created_at": "2026-04-20T22:24:35.750200899Z"
+    }
+  ],
+  "created_at": "2026-04-20T22:23:51.732917451Z",
+  "updated_at": "2026-04-20T22:24:35.750200899Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "plexus"
-version = "1.23.0"
+version = "1.34.0"
 description = "A Python module for configuring and managing data scoring"
 readme = "README.md"
 license = "MIT"
@@ -118,6 +118,7 @@ exclude_lines = [
 
 [tool.semantic_release]
 version_source = "tag"
+version_toml = ["pyproject.toml:tool.poetry.version"]
 version_variables = ["plexus/_version.py:__version__"]
 commit_message = "chore: release {version}"
 major_on_zero = false


### PR DESCRIPTION
## Summary
- configure semantic-release to update `tool.poetry.version` via `version_toml`
- keep updating `plexus/_version.py` via `version_variables`
- align current `pyproject.toml` package version with `_version.py` (`1.34.0`)
- add CI `version-sync` check to fail when `pyproject.toml` and `plexus/_version.py` diverge

## Why
Plexus release tags were advancing while package metadata stayed at `1.23.0`, which allowed deploy environments to keep stale installs even when git refs changed. This made downstream dependency updates unreliable.

## Validation
- local parse check confirms `pyproject.toml` and `plexus/_version.py` are both `1.34.0`
- local check confirms semantic-release config includes `version_toml = ["pyproject.toml:tool.poetry.version"]`
- branch pushed and ready for CI

## Kanbus
- `plx-cd6315`
