### PR TITLE
fix(release): align pyproject version with plexus/_version.py

### DIFF
--- a/project/events/2026-04-20T22:37:13.538Z__690e5e14-6927-411f-b2d0-689f7f2ebf2d.json
+++ b/project/events/2026-04-20T22:37:13.538Z__690e5e14-6927-411f-b2d0-689f7f2ebf2d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "690e5e14-6927-411f-b2d0-689f7f2ebf2d",
+  "issue_id": "plx-cd63156f-930a-49d1-874c-cbe5d95e6879",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T22:37:13.538Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "58b7befd-e18e-424c-b592-91d858c6cd6a"
+  }
+}

--- a/project/events/2026-04-20T22:37:44.402Z__cbecb2ee-0e99-4910-b498-8a527d9efb0f.json
+++ b/project/events/2026-04-20T22:37:44.402Z__cbecb2ee-0e99-4910-b498-8a527d9efb0f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cbecb2ee-0e99-4910-b498-8a527d9efb0f",
+  "issue_id": "plx-cd63156f-930a-49d1-874c-cbe5d95e6879",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-20T22:37:44.402Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "090ccf60-584e-454f-975a-90c51c5980dd"
+  }
+}

--- a/project/issues/plx-cd63156f-930a-49d1-874c-cbe5d95e6879.json
+++ b/project/issues/plx-cd63156f-930a-49d1-874c-cbe5d95e6879.json
@@ -28,10 +28,16 @@
       "author": "derek",
       "text": "Pushed branch fix/semantic-release-version-sync with commits 3b993607, b0350cf0, 2dfd80c2. Working tree clean. Ready for PR to develop and CI validation.",
       "created_at": "2026-04-20T22:24:50.620222045Z"
+    },
+    {
+      "id": "58b7befd-e18e-424c-b592-91d858c6cd6a",
+      "author": "derek",
+      "text": "Follow-up: release PR check failed because origin/develop drifted after merge from main (_version.py=1.35.0 while pyproject.toml stayed 1.34.0). Creating a small fix branch to align pyproject to 1.35.0.",
+      "created_at": "2026-04-20T22:37:13.537989655Z"
     }
   ],
   "created_at": "2026-04-20T22:23:51.732917451Z",
-  "updated_at": "2026-04-20T22:24:50.620222045Z",
+  "updated_at": "2026-04-20T22:37:13.537989655Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-cd63156f-930a-49d1-874c-cbe5d95e6879.json
+++ b/project/issues/plx-cd63156f-930a-49d1-874c-cbe5d95e6879.json
@@ -34,10 +34,16 @@
       "author": "derek",
       "text": "Follow-up: release PR check failed because origin/develop drifted after merge from main (_version.py=1.35.0 while pyproject.toml stayed 1.34.0). Creating a small fix branch to align pyproject to 1.35.0.",
       "created_at": "2026-04-20T22:37:13.537989655Z"
+    },
+    {
+      "id": "090ccf60-584e-454f-975a-90c51c5980dd",
+      "author": "derek",
+      "text": "Opened follow-up PR #190 to fix develop drift: https://github.com/AnthusAI/Plexus/pull/190. This aligns pyproject tool.poetry.version with _version.py at 1.35.0 so version-sync CI passes.",
+      "created_at": "2026-04-20T22:37:44.401216908Z"
     }
   ],
   "created_at": "2026-04-20T22:23:51.732917451Z",
-  "updated_at": "2026-04-20T22:37:13.537989655Z",
+  "updated_at": "2026-04-20T22:37:44.401216908Z",
   "closed_at": null,
   "custom": {}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "plexus"
-version = "1.34.0"
+version = "1.35.0"
 description = "A Python module for configuring and managing data scoring"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- set `tool.poetry.version` in `pyproject.toml` to `1.35.0`
- keep it aligned with `plexus/_version.py` (already `1.35.0` on develop)

## Why
The new CI `version-sync` guard correctly failed because develop had version drift (`pyproject.toml` at `1.34.0`, `_version.py` at `1.35.0`) after merging main back into develop.

## Validation
- local check confirms both files now report `1.35.0`

## Kanbus
- `plx-cd6315`
