### PR TITLE
feat(reports): add date-range parameters and stabilize report run UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ cp plexus.yaml.example .plexus/config.yaml
 
 The dashboard is a standard Next.js application located in the `dashboard/` directory.
 
-For local procedure execution from the UI, `npm run dev` now runs:
-- Next.js dev server
-- Local procedure task dispatcher (`PLEXUS_DISPATCH_MODE=local`)
+For local procedure execution from the UI:
+- `npm run dev` runs only the Next.js dev server
+- `npm run dev:dispatch` runs the local procedure task dispatcher (`PLEXUS_DISPATCH_MODE=local`)
 
 Set `PLEXUS_ACCOUNT_KEY` in your environment or `.env` for local auto-dispatch.
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -33,9 +33,9 @@ PLEXUS_API_KEY=...
 PLEXUS_ACCOUNT_KEY=...
 ```
 
-For local procedure runs from the dashboard UI, `npm run dev` now starts both:
-- Next.js dev server
-- Local task dispatcher (`PLEXUS_DISPATCH_MODE=local`)
+For local procedure runs from the dashboard UI:
+- `npm run dev` starts only the Next.js dev server
+- `npm run dev:dispatch` starts the local task dispatcher (`PLEXUS_DISPATCH_MODE=local`)
 
 `PLEXUS_ACCOUNT_KEY` is required for this local auto-dispatch flow.
 Console chat now targets the built-in procedure key `builtin:console/chat` backed by source-controlled Tactus code under `plexus/procedures/console/`.

--- a/dashboard/components/ReportConfigurationSelector.tsx
+++ b/dashboard/components/ReportConfigurationSelector.tsx
@@ -1,25 +1,12 @@
 import React, { useEffect, useState } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { generateClient } from "aws-amplify/data"
-import type { Schema } from "@/amplify/data/resource"
-import { ModelListResult } from '@/types/shared'
-import { listFromModel } from "@/utils/amplify-helpers"
 import { useAccount } from "@/app/contexts/AccountContext"
-
-let amplifyClient: ReturnType<typeof generateClient<Schema>> | null = null
-const getAmplifyClient = () => (amplifyClient ??= generateClient<Schema>())
+import { listAllReportConfigurationsByAccount } from "@/utils/report-configurations"
 
 export interface ReportConfigurationSelectorProps {
   selectedReportConfiguration: string | null;
   setSelectedReportConfiguration: (value: string | null) => void;
   useMockData?: boolean;
-}
-
-async function listReportConfigurations(accountId: string): ModelListResult<Schema['ReportConfiguration']['type']> {
-  return listFromModel<Schema['ReportConfiguration']['type']>(
-    getAmplifyClient().models.ReportConfiguration,
-    { accountId: { eq: accountId } }
-  )
 }
 
 const ReportConfigurationSelector: React.FC<ReportConfigurationSelectorProps> = ({
@@ -45,16 +32,9 @@ const ReportConfigurationSelector: React.FC<ReportConfigurationSelectorProps> = 
       try {
         setIsLoading(true)
         if (!accountId) return
-        const { data: configModels } = await listReportConfigurations(accountId)
+        const deduped = await listAllReportConfigurationsByAccount(accountId)
 
-        // Sort by updatedAt descending (most recent first)
-        const sortedConfigs = configModels.sort((a, b) => {
-          const aDate = new Date(a.updatedAt || a.createdAt || '').getTime()
-          const bDate = new Date(b.updatedAt || b.createdAt || '').getTime()
-          return bDate - aDate // Descending order
-        })
-
-        const formattedConfigurations = sortedConfigs.map(config => ({
+        const formattedConfigurations = deduped.map(config => ({
           value: config.id,
           label: config.name || `Config ${config.id.substring(0, 6)}`
         }))

--- a/dashboard/components/blocks/registrySetup.ts
+++ b/dashboard/components/blocks/registrySetup.ts
@@ -32,6 +32,7 @@ registerBlock('default', ReportBlock);
 // Register specific block types - use type casting to satisfy BlockComponent interface
 registerBlock('ScorecardReport', ScorecardReport as BlockComponent);
 registerBlock('FeedbackAlignment', FeedbackAlignment as BlockComponent);
+registerBlock('FeedbackAnalysis', FeedbackAlignment as BlockComponent);
 registerBlock('ExplanationAnalysis', ExplanationAnalysis as BlockComponent);
 registerBlock('text', TextBlock as BlockComponent);
 registerBlock('ScoreInfo', ScoreInfo as BlockComponent);

--- a/dashboard/components/task-dispatch/dialogs/ReportConfigurationDialog.tsx
+++ b/dashboard/components/task-dispatch/dialogs/ReportConfigurationDialog.tsx
@@ -32,6 +32,28 @@ interface ReportConfiguration {
   configuration?: string | null
 }
 
+function flattenReportParameters(parameters: Record<string, any>): Record<string, any> {
+  const flattened: Record<string, any> = {}
+
+  Object.entries(parameters).forEach(([key, value]) => {
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      ('start' in value || 'end' in value)
+    ) {
+      const start = typeof value.start === 'string' ? value.start : ''
+      const end = typeof value.end === 'string' ? value.end : ''
+      if (start) flattened[`${key}_start`] = start
+      if (end) flattened[`${key}_end`] = end
+      return
+    }
+    flattened[key] = value
+  })
+
+  return flattened
+}
+
 // GraphQL query to list report configurations
 const LIST_REPORT_CONFIGURATIONS = `
   query ListReportConfigurations($accountId: String!) {
@@ -166,13 +188,15 @@ export function ReportConfigurationDialog({ action, isOpen, onClose, onDispatch 
   
   const handleDispatchReport = async (parameters?: Record<string, any>) => {
     if (!selectedConfigId) return
+
+    const flattenedParameters = parameters ? flattenReportParameters(parameters) : undefined
     
     // Build the command for running this report
     let command = `report run --config ${selectedConfigId}`
     
     // Add parameter options if provided
-    if (parameters) {
-      Object.entries(parameters).forEach(([key, value]) => {
+    if (flattenedParameters) {
+      Object.entries(flattenedParameters).forEach(([key, value]) => {
         command += ` --param-${key}=${value}`
       })
     }
@@ -181,7 +205,7 @@ export function ReportConfigurationDialog({ action, isOpen, onClose, onDispatch 
     const metadata = {
       reportConfigurationId: selectedConfigId,
       reportConfigurationName: selectedConfig?.name || 'Report',
-      parameters: parameters || {}
+      parameters: flattenedParameters || {}
     }
     
     // Dispatch the task once and close only after dispatch attempt completes.

--- a/dashboard/components/task-dispatch/dialogs/ReportConfigurationDialog.tsx
+++ b/dashboard/components/task-dispatch/dialogs/ReportConfigurationDialog.tsx
@@ -23,12 +23,14 @@ import { toast } from "sonner"
 import { ConfigurableParametersDialog } from "@/components/ui/ConfigurableParametersDialog"
 import { parseParametersFromYaml, hasParameters } from "@/lib/parameter-parser"
 import { useAccount } from "@/app/contexts/AccountContext"
+import {
+  listAllReportConfigurationsByAccount,
+  type ReportConfigurationListItem,
+} from "@/utils/report-configurations"
 
 // Report configuration type definition
-interface ReportConfiguration {
+interface ReportConfiguration extends ReportConfigurationListItem {
   id: string
-  name: string
-  description?: string | null
   configuration?: string | null
 }
 
@@ -53,22 +55,6 @@ function flattenReportParameters(parameters: Record<string, any>): Record<string
 
   return flattened
 }
-
-// GraphQL query to list report configurations
-const LIST_REPORT_CONFIGURATIONS = `
-  query ListReportConfigurations($accountId: String!) {
-    listReportConfigurationByAccountIdAndUpdatedAt(
-      accountId: $accountId
-      limit: 100
-    ) {
-      items {
-        id
-        name
-        description
-      }
-    }
-  }
-`
 
 // GraphQL query to get full report configuration with content
 const GET_REPORT_CONFIGURATION = `
@@ -106,24 +92,18 @@ export function ReportConfigurationDialog({ action, isOpen, onClose, onDispatch 
       setError(null)
       
       try {
-        const configResponse = await getClient().graphql({
-          query: LIST_REPORT_CONFIGURATIONS,
-          variables: {
-            accountId: selectedAccount.id
-          }
-        })
-        
-        if ('data' in configResponse && 
-            configResponse.data?.listReportConfigurationByAccountIdAndUpdatedAt?.items) {
-          const configs = configResponse.data.listReportConfigurationByAccountIdAndUpdatedAt.items
-          setConfigurations(configs)
-          
-          // Auto-select the first config if none is selected
-          if (configs.length > 0 && !selectedConfigId) {
-            setSelectedConfigId(configs[0].id)
+        const allConfigs = await listAllReportConfigurationsByAccount(selectedAccount.id)
+
+        if (allConfigs.length > 0) {
+          setConfigurations(allConfigs)
+
+          // Prefer current selection when present, otherwise select most recent.
+          if (!selectedConfigId || !allConfigs.some((config) => config.id === selectedConfigId)) {
+            setSelectedConfigId(allConfigs[0].id)
           }
         } else {
           setError("No report configurations found")
+          setConfigurations([])
         }
       } catch (err: any) {
         console.error('Error fetching report configurations:', err)
@@ -134,7 +114,7 @@ export function ReportConfigurationDialog({ action, isOpen, onClose, onDispatch 
     }
     
     fetchConfigurations()
-  }, [isOpen, selectedAccount?.id, selectedConfigId])
+  }, [isOpen, selectedAccount?.id])
   
   // Fetch full configuration when selected config changes
   useEffect(() => {
@@ -199,13 +179,6 @@ export function ReportConfigurationDialog({ action, isOpen, onClose, onDispatch 
       Object.entries(flattenedParameters).forEach(([key, value]) => {
         command += ` --param-${key}=${value}`
       })
-    }
-    
-    // Get additional metadata
-    const metadata = {
-      reportConfigurationId: selectedConfigId,
-      reportConfigurationName: selectedConfig?.name || 'Report',
-      parameters: flattenedParameters || {}
     }
     
     // Dispatch the task once and close only after dispatch attempt completes.

--- a/dashboard/components/task-dispatch/dialogs/ReportConfigurationDialog.tsx
+++ b/dashboard/components/task-dispatch/dialogs/ReportConfigurationDialog.tsx
@@ -267,13 +267,7 @@ export function ReportConfigurationDialog({ action, isOpen, onClose, onDispatch 
       {selectedConfig && selectedConfig.configuration && (
         <ConfigurableParametersDialog
           open={showParametersDialog}
-          onOpenChange={(open) => {
-            setShowParametersDialog(open)
-            if (!open) {
-              // User cancelled parameters - close main dialog too
-              onClose()
-            }
-          }}
+          onOpenChange={setShowParametersDialog}
           title={`Configure ${selectedConfig.name}`}
           description="Please provide the required parameters for this report"
           parameters={parseParametersFromYaml(selectedConfig.configuration)}

--- a/dashboard/components/ui/ConfigurableParametersDialog.tsx
+++ b/dashboard/components/ui/ConfigurableParametersDialog.tsx
@@ -19,6 +19,7 @@ import {
   NumberParameter,
   BooleanParameter,
   SelectParameter,
+  DateRangeParameter,
   ScorecardSelectParameter,
   ScoreSelectParameter,
   ScoreVersionSelectParameter,
@@ -118,6 +119,9 @@ export function ConfigurableParametersDialog({
       case 'text':
         return <TextParameter key={param.name} definition={param} value={value} onChange={onChange} error={error} />
 
+      case 'date':
+        return <TextParameter key={param.name} definition={param} value={value} onChange={onChange} error={error} />
+
       case 'number':
         return <NumberParameter key={param.name} definition={param} value={value} onChange={onChange} error={error} />
 
@@ -126,6 +130,9 @@ export function ConfigurableParametersDialog({
 
       case 'select':
         return <SelectParameter key={param.name} definition={param} value={value} onChange={onChange} error={error} />
+
+      case 'date_range':
+        return <DateRangeParameter key={param.name} definition={param} value={value} onChange={onChange} error={error} />
 
       case 'scorecard_select':
         return <ScorecardSelectParameter key={param.name} definition={param} value={value} onChange={onChange} error={error} />
@@ -200,5 +207,3 @@ export function ConfigurableParametersDialog({
     </Dialog>
   )
 }
-
-

--- a/dashboard/components/ui/ConfigurableParametersForm.tsx
+++ b/dashboard/components/ui/ConfigurableParametersForm.tsx
@@ -9,6 +9,7 @@ import {
   NumberParameter,
   BooleanParameter,
   SelectParameter,
+  DateRangeParameter,
   ScorecardSelectParameter,
   ScoreSelectParameter,
   ScoreVersionSelectParameter,
@@ -92,6 +93,8 @@ export function ConfigurableParametersForm({
         return <ScoreVersionSelectParameter {...commonProps} scoreId={scoreId} />
       case 'date':
         return <TextParameter {...commonProps} />
+      case 'date_range':
+        return <DateRangeParameter {...commonProps} />
       default:
         return <TextParameter {...commonProps} />
     }
@@ -111,4 +114,3 @@ export function ConfigurableParametersForm({
     </div>
   )
 }
-

--- a/dashboard/components/ui/ParametersDisplay.tsx
+++ b/dashboard/components/ui/ParametersDisplay.tsx
@@ -116,6 +116,14 @@ export function ParametersDisplay({
         } catch {
           return String(value)
         }
+      case 'date_range': {
+        const start = value?.start ? new Date(value.start).toLocaleDateString() : ''
+        const end = value?.end ? new Date(value.end).toLocaleDateString() : ''
+        if (start && end) return `${start} - ${end}`
+        if (start) return `${start} -`
+        if (end) return `- ${end}`
+        return '—'
+      }
       case 'select':
         // Find the option label if options are defined
         if (param.options) {
@@ -230,4 +238,3 @@ export function ParametersDisplay({
     </Card>
   )
 }
-

--- a/dashboard/components/ui/__tests__/ParametersDisplay.test.tsx
+++ b/dashboard/components/ui/__tests__/ParametersDisplay.test.tsx
@@ -170,6 +170,31 @@ describe('ParametersDisplay', () => {
     expect(screen.queryByText('2025-12-31')).not.toBeInTheDocument()
   })
 
+  it('renders date_range parameter formatted', () => {
+    const parameters: ParameterDefinition[] = [
+      {
+        name: 'window',
+        label: 'Analysis Window',
+        type: 'date_range',
+        required: true
+      }
+    ]
+
+    const values: ParameterValues = {
+      window: { start: '2026-01-01', end: '2026-01-31' }
+    }
+
+    render(
+      <ParametersDisplay
+        parameters={parameters}
+        values={values}
+      />
+    )
+
+    expect(screen.getByText('Analysis Window')).toBeInTheDocument()
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
+  })
+
   it('displays em dash for missing values', () => {
     const parameters: ParameterDefinition[] = [
       {
@@ -381,4 +406,3 @@ describe('ParametersDisplay', () => {
     expect(emDashes).toHaveLength(2)
   })
 })
-

--- a/dashboard/components/ui/calendar.tsx
+++ b/dashboard/components/ui/calendar.tsx
@@ -20,43 +20,46 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
+        months: "flex flex-col sm:flex-row gap-4",
+        month: "flex flex-col gap-4",
+        month_caption: "relative flex h-7 items-center justify-center px-1",
+        caption: "relative flex h-7 items-center justify-center",
         caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
-        nav_button: cn(
+        nav: "absolute inset-x-0 top-0 flex items-center justify-between",
+        button_previous: cn(
           buttonVariants({ variant: "outline" }),
           "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-y-1",
-        head_row: "flex",
-        head_cell:
+        button_next: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+        ),
+        month_grid: "w-full border-collapse space-y-1",
+        weekdays: "flex",
+        weekday:
           "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
-        cell: cn(
-          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected].day-range-end)]:rounded-r-md",
+        week: "mt-2 flex w-full",
+        day: cn(
+          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent/50 [&:has([aria-selected].outside)]:bg-accent/20",
           props.mode === "range"
-            ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
+            ? "[&:has(>.range-end)]:rounded-r-md [&:has(>.range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
             : "[&:has([aria-selected])]:rounded-md"
         ),
-        day: cn(
+        day_button: cn(
           buttonVariants({ variant: "ghost" }),
           "h-8 w-8 p-0 font-normal aria-selected:opacity-100"
         ),
-        day_range_start: "day-range-start",
-        day_range_end: "day-range-end",
-        day_selected:
+        range_start: "range-start",
+        range_end: "range-end",
+        selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        day_today: "bg-accent text-accent-foreground",
-        day_outside:
-          "day-outside text-muted-foreground opacity-50  aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
-        day_disabled: "text-muted-foreground opacity-50",
-        day_range_middle:
+        today: "bg-accent text-accent-foreground",
+        outside:
+          "outside text-muted-foreground opacity-50 aria-selected:bg-accent/30 aria-selected:text-muted-foreground aria-selected:opacity-80",
+        disabled: "text-muted-foreground opacity-50",
+        range_middle:
           "aria-selected:bg-accent aria-selected:text-accent-foreground",
-        day_hidden: "invisible",
+        hidden: "invisible",
         ...classNames,
       }}
       components={{

--- a/dashboard/components/ui/calendar.tsx
+++ b/dashboard/components/ui/calendar.tsx
@@ -18,21 +18,22 @@ function Calendar({
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
+      navLayout={props.navLayout ?? "around"}
       className={cn("p-3", className)}
       classNames={{
         months: "flex flex-col sm:flex-row gap-4",
-        month: "flex flex-col gap-4",
-        month_caption: "relative flex h-7 items-center justify-center px-1",
+        month: "relative flex flex-col gap-4",
+        month_caption: "relative flex h-7 items-center justify-center px-10",
         caption: "relative flex h-7 items-center justify-center",
         caption_label: "text-sm font-medium",
-        nav: "absolute inset-x-0 top-0 flex items-center justify-between",
+        nav: "flex items-center",
         button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "absolute left-1 top-0 z-20 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
         ),
         button_next: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "absolute right-1 top-0 z-20 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
         ),
         month_grid: "w-full border-collapse space-y-1",
         weekdays: "flex",
@@ -53,9 +54,10 @@ function Calendar({
         range_end: "range-end",
         selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        today: "bg-accent text-accent-foreground",
+        today:
+          "font-semibold text-foreground [&:not(:has([aria-selected]))>button]:ring-1 [&:not(:has([aria-selected]))>button]:ring-border",
         outside:
-          "outside text-muted-foreground opacity-50 aria-selected:bg-accent/30 aria-selected:text-muted-foreground aria-selected:opacity-80",
+          "outside invisible aria-selected:bg-transparent aria-selected:text-foreground",
         disabled: "text-muted-foreground opacity-50",
         range_middle:
           "aria-selected:bg-accent aria-selected:text-accent-foreground",

--- a/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
+++ b/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
@@ -59,7 +59,7 @@ export function DateRangeParameter({ definition, value, onChange, disabled, erro
       {definition.description && (
         <p className="text-xs text-muted-foreground">{definition.description}</p>
       )}
-      <Popover>
+      <Popover modal>
         <PopoverTrigger asChild>
           <Button
             id={`${definition.name}-range`}
@@ -89,7 +89,7 @@ export function DateRangeParameter({ definition, value, onChange, disabled, erro
         <PopoverContent className="w-auto p-0" align="start">
           <Calendar
             mode="range"
-            numberOfMonths={2}
+            numberOfMonths={1}
             selected={selectedRange}
             defaultMonth={selectedRange?.from}
             onSelect={handleRangeSelect}

--- a/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
+++ b/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
@@ -89,7 +89,7 @@ export function DateRangeParameter({ definition, value, onChange, disabled, erro
         <PopoverContent className="w-auto p-0" align="start">
           <Calendar
             mode="range"
-            numberOfMonths={1}
+            numberOfMonths={2}
             selected={selectedRange}
             defaultMonth={selectedRange?.from}
             onSelect={handleRangeSelect}

--- a/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
+++ b/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
@@ -1,8 +1,14 @@
 "use client"
 
 import React from "react"
-import { Input } from "@/components/ui/input"
+import { format, parseISO } from "date-fns"
+import { CalendarIcon } from "lucide-react"
+import { type DateRange } from "react-day-picker"
+import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
 import { Label } from "@/components/ui/label"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
 import { ParameterDefinition, DateRangeValue } from "@/types/parameters"
 
 interface DateRangeParameterProps {
@@ -16,46 +22,82 @@ interface DateRangeParameterProps {
 export function DateRangeParameter({ definition, value, onChange, disabled, error }: DateRangeParameterProps) {
   const start = value?.start || ""
   const end = value?.end || ""
+  const today = new Date()
+  today.setHours(23, 59, 59, 999)
+
+  const selectedRange: DateRange | undefined = start
+    ? {
+        from: parseISO(start),
+        to: end ? parseISO(end) : undefined,
+      }
+    : undefined
+
+  const handleRangeSelect = (range: DateRange | undefined) => {
+    if (!range?.from) {
+      onChange({ start: "", end: "" })
+      return
+    }
+
+    onChange({
+      start: format(range.from, "yyyy-MM-dd"),
+      end: range.to ? format(range.to, "yyyy-MM-dd") : "",
+    })
+  }
+
+  const formatLabelDate = (raw: string): string => {
+    const parsed = parseISO(raw)
+    if (Number.isNaN(parsed.getTime())) return raw
+    return format(parsed, "LLL dd, y")
+  }
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={`${definition.name}-start`}>
+      <Label htmlFor={`${definition.name}-range`}>
         {definition.label}
         {definition.required && <span className="text-destructive ml-1">*</span>}
       </Label>
       {definition.description && (
         <p className="text-xs text-muted-foreground">{definition.description}</p>
       )}
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground" htmlFor={`${definition.name}-start`}>
-            Start Date
-          </Label>
-          <Input
-            id={`${definition.name}-start`}
-            type="date"
-            value={start}
-            onChange={(e) => onChange({ start: e.target.value, end })}
-            max={end || undefined}
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id={`${definition.name}-range`}
+            type="button"
+            variant="outline"
             disabled={disabled}
-            className={error ? "border-destructive" : ""}
+            className={cn(
+              "w-full justify-start text-left font-normal",
+              !start && "text-muted-foreground",
+              error && "border-destructive"
+            )}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {start ? (
+              end ? (
+                <>
+                  {formatLabelDate(start)} - {formatLabelDate(end)}
+                </>
+              ) : (
+                formatLabelDate(start)
+              )
+            ) : (
+              "Pick date range"
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="range"
+            numberOfMonths={2}
+            selected={selectedRange}
+            defaultMonth={selectedRange?.from}
+            onSelect={handleRangeSelect}
+            disabled={(date) => date > today}
+            initialFocus
           />
-        </div>
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground" htmlFor={`${definition.name}-end`}>
-            End Date
-          </Label>
-          <Input
-            id={`${definition.name}-end`}
-            type="date"
-            value={end}
-            onChange={(e) => onChange({ start, end: e.target.value })}
-            min={start || undefined}
-            disabled={disabled}
-            className={error ? "border-destructive" : ""}
-          />
-        </div>
-      </div>
+        </PopoverContent>
+      </Popover>
       {error && <p className="text-xs text-destructive">{error}</p>}
     </div>
   )

--- a/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
+++ b/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
@@ -36,6 +36,7 @@ export function DateRangeParameter({ definition, value, onChange, disabled, erro
             type="date"
             value={start}
             onChange={(e) => onChange({ start: e.target.value, end })}
+            max={end || undefined}
             disabled={disabled}
             className={error ? "border-destructive" : ""}
           />
@@ -49,6 +50,7 @@ export function DateRangeParameter({ definition, value, onChange, disabled, erro
             type="date"
             value={end}
             onChange={(e) => onChange({ start, end: e.target.value })}
+            min={start || undefined}
             disabled={disabled}
             className={error ? "border-destructive" : ""}
           />

--- a/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
+++ b/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
@@ -90,6 +90,7 @@ export function DateRangeParameter({ definition, value, onChange, disabled, erro
           <Calendar
             mode="range"
             numberOfMonths={2}
+            showOutsideDays={false}
             selected={selectedRange}
             defaultMonth={selectedRange?.from}
             onSelect={handleRangeSelect}

--- a/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
+++ b/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import React from "react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ParameterDefinition, DateRangeValue } from "@/types/parameters"
+
+interface DateRangeParameterProps {
+  definition: ParameterDefinition
+  value: DateRangeValue | undefined
+  onChange: (value: DateRangeValue) => void
+  disabled?: boolean
+  error?: string
+}
+
+export function DateRangeParameter({ definition, value, onChange, disabled, error }: DateRangeParameterProps) {
+  const start = value?.start || ""
+  const end = value?.end || ""
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={`${definition.name}-start`}>
+        {definition.label}
+        {definition.required && <span className="text-destructive ml-1">*</span>}
+      </Label>
+      {definition.description && (
+        <p className="text-xs text-muted-foreground">{definition.description}</p>
+      )}
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground" htmlFor={`${definition.name}-start`}>
+            Start Date
+          </Label>
+          <Input
+            id={`${definition.name}-start`}
+            type="date"
+            value={start}
+            onChange={(e) => onChange({ start: e.target.value, end })}
+            disabled={disabled}
+            className={error ? "border-destructive" : ""}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground" htmlFor={`${definition.name}-end`}>
+            End Date
+          </Label>
+          <Input
+            id={`${definition.name}-end`}
+            type="date"
+            value={end}
+            onChange={(e) => onChange({ start, end: e.target.value })}
+            disabled={disabled}
+            className={error ? "border-destructive" : ""}
+          />
+        </div>
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  )
+}

--- a/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
+++ b/dashboard/components/ui/parameter-types/DateRangeParameter.tsx
@@ -90,7 +90,6 @@ export function DateRangeParameter({ definition, value, onChange, disabled, erro
           <Calendar
             mode="range"
             numberOfMonths={2}
-            showOutsideDays={false}
             selected={selectedRange}
             defaultMonth={selectedRange?.from}
             onSelect={handleRangeSelect}

--- a/dashboard/components/ui/parameter-types/index.ts
+++ b/dashboard/components/ui/parameter-types/index.ts
@@ -2,9 +2,9 @@ export { TextParameter } from './TextParameter'
 export { NumberParameter } from './NumberParameter'
 export { BooleanParameter } from './BooleanParameter'
 export { SelectParameter } from './SelectParameter'
+export { DateRangeParameter } from './DateRangeParameter'
 export { ScorecardSelectParameter } from './ScorecardSelectParameter'
 export { ScoreSelectParameter } from './ScoreSelectParameter'
 export { ScoreVersionSelectParameter } from './ScoreVersionSelectParameter'
-
 
 

--- a/dashboard/lib/__tests__/parameter-parser.test.ts
+++ b/dashboard/lib/__tests__/parameter-parser.test.ts
@@ -90,6 +90,31 @@ parameters:
       expect(result[1].depends_on).toBe('scorecard_id')
     })
 
+    it('should parse parameters from markdown report template header', () => {
+      const yaml = `
+parameters:
+  - name: window
+    label: Analysis Window
+    type: date_range
+    required: true
+
+---
+
+# Sample Report
+
+\`\`\`block name="Feedback Analysis"
+class: FeedbackAnalysis
+scorecard: 1481
+start_date: {{ window_start }}
+end_date: {{ window_end }}
+\`\`\`
+`
+      const result = parseParametersFromYaml(yaml)
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('window')
+      expect(result[0].type).toBe('date_range')
+    })
+
     it('should parse Tactus params mapping format', () => {
       const yaml = `
 params:

--- a/dashboard/lib/__tests__/parameter-parser.test.ts
+++ b/dashboard/lib/__tests__/parameter-parser.test.ts
@@ -120,6 +120,20 @@ params:
       expect(result[2].type).toBe('boolean')
       expect(result[2].default).toBe(false)
     })
+
+    it('should normalize date_range type in params mapping format', () => {
+      const yaml = `
+params:
+  window:
+    type: date_range
+    required: true
+`
+      const result = parseParametersFromYaml(yaml)
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('window')
+      expect(result[0].type).toBe('date_range')
+      expect(result[0].required).toBe(true)
+    })
   })
 
   describe('hasParameters', () => {
@@ -222,6 +236,31 @@ parameters:
       const result = validateParameters({ brief: 'hello' }, definitions)
       expect(result.valid).toBe(true)
     })
+
+    it('should validate date_range completeness and ordering', () => {
+      const definitions: ParameterDefinition[] = [
+        { name: 'window', label: 'Window', type: 'date_range', required: true }
+      ]
+
+      const missingEnd = validateParameters(
+        { window: { start: '2026-01-01', end: '' } },
+        definitions
+      )
+      expect(missingEnd.valid).toBe(false)
+
+      const outOfOrder = validateParameters(
+        { window: { start: '2026-02-01', end: '2026-01-01' } },
+        definitions
+      )
+      expect(outOfOrder.valid).toBe(false)
+      expect(outOfOrder.errors[0].message).toContain('before or equal')
+
+      const validRange = validateParameters(
+        { window: { start: '2026-01-01', end: '2026-02-01' } },
+        definitions
+      )
+      expect(validRange.valid).toBe(true)
+    })
   })
 
   describe('getDefaultValues', () => {
@@ -256,6 +295,15 @@ parameters:
       
       const result = getDefaultValues(definitions)
       expect(result.age).toBe(18)
+    })
+
+    it('should provide empty start/end for date_range defaults', () => {
+      const definitions: ParameterDefinition[] = [
+        { name: 'window', label: 'Window', type: 'date_range' }
+      ]
+
+      const result = getDefaultValues(definitions)
+      expect(result.window).toEqual({ start: '', end: '' })
     })
   })
 })

--- a/dashboard/lib/parameter-parser.ts
+++ b/dashboard/lib/parameter-parser.ts
@@ -48,44 +48,42 @@ function normalizeParameterDefinition(name: string, raw: any): ParameterDefiniti
   }
 }
 
+function extractDefinitionsFromParsedConfig(
+  config: ParameterConfig & { params?: Record<string, any> } | undefined
+): ParameterDefinition[] {
+  if (Array.isArray(config?.parameters)) {
+    return config.parameters
+  }
+  if (config?.params && typeof config.params === 'object') {
+    return Object.entries(config.params).map(([name, raw]) => normalizeParameterDefinition(name, raw))
+  }
+  return []
+}
+
 /**
  * Extract parameter definitions from YAML content
  * Supports frontmatter format: parameters section before --- separator
  */
 export function parseParametersFromYaml(yamlContent: string): ParameterDefinition[] {
   try {
-    // Check for YAML frontmatter: only split on --- when the document starts with ---
-    // (Jekyll/Hugo style). Tactus YAMLs are full YAML documents and may contain ---
-    // inside block scalars (e.g. Lua string literals), so splitting on any occurrence
-    // would truncate the YAML mid-value and cause parse errors.
-    const trimmed = yamlContent.trimStart()
-    if (trimmed.startsWith('---')) {
-      const parts = yamlContent.split('---')
-      if (parts.length >= 2) {
-        // First part is the frontmatter
-        const frontmatter = parts[0].trim()
-        if (frontmatter) {
-          const config = yaml.load(frontmatter) as ParameterConfig & { params?: Record<string, any> }
-          if (Array.isArray(config?.parameters)) {
-            return config.parameters
-          }
-          if (config?.params && typeof config.params === 'object') {
-            return Object.entries(config.params).map(([name, raw]) => normalizeParameterDefinition(name, raw))
-          }
-          return []
+    // Support "YAML header + --- + markdown body" templates used by reports.
+    // We only treat the section before the first line containing exactly '---'
+    // as candidate parameter config; everything after can be markdown/code fences.
+    const separatorMatch = yamlContent.match(/^\s*---\s*$/m)
+    if (separatorMatch && separatorMatch.index !== undefined) {
+      const header = yamlContent.slice(0, separatorMatch.index).trim()
+      if (header) {
+        const parsedHeader = yaml.load(header) as ParameterConfig & { params?: Record<string, any> }
+        const headerDefinitions = extractDefinitionsFromParsedConfig(parsedHeader)
+        if (headerDefinitions.length > 0) {
+          return headerDefinitions
         }
       }
     }
 
     // Parse the full YAML document
     const config = yaml.load(yamlContent) as ParameterConfig & { params?: Record<string, any> }
-    if (Array.isArray(config?.parameters)) {
-      return config.parameters
-    }
-    if (config?.params && typeof config.params === 'object') {
-      return Object.entries(config.params).map(([name, raw]) => normalizeParameterDefinition(name, raw))
-    }
-    return []
+    return extractDefinitionsFromParsedConfig(config)
   } catch (error) {
     console.error('Error parsing parameters from YAML:', error)
     return []

--- a/dashboard/lib/parameter-parser.ts
+++ b/dashboard/lib/parameter-parser.ts
@@ -3,9 +3,9 @@
  */
 
 import yaml from 'js-yaml'
-import { ParameterConfig, ParameterDefinition } from '@/types/parameters'
+import { ParameterConfig, ParameterDefinition, DateRangeValue } from '@/types/parameters'
 
-type RawParameterType = 'string' | 'text' | 'number' | 'boolean' | 'select' | string
+type RawParameterType = 'string' | 'text' | 'number' | 'boolean' | 'select' | 'date' | 'date_range' | string
 
 function toTitleCase(value: string): string {
   return value
@@ -20,6 +20,8 @@ function normalizeParameterType(type: RawParameterType): ParameterDefinition['ty
   if (type === 'number') return 'number'
   if (type === 'boolean') return 'boolean'
   if (type === 'select') return 'select'
+  if (type === 'date') return 'date'
+  if (type === 'date_range') return 'date_range'
   return 'text'
 }
 
@@ -160,6 +162,45 @@ export function validateParameters(
             })
           }
           break
+
+        case 'date':
+          if (typeof value !== 'string' || Number.isNaN(Date.parse(value))) {
+            errors.push({
+              parameter: def.name,
+              message: `${def.label} must be a valid date`
+            })
+          }
+          break
+
+        case 'date_range': {
+          const range = value as DateRangeValue
+          const start = typeof range?.start === 'string' ? range.start : ''
+          const end = typeof range?.end === 'string' ? range.end : ''
+
+          if (def.required && (!start || !end)) {
+            errors.push({
+              parameter: def.name,
+              message: `${def.label} requires both start and end dates`
+            })
+            break
+          }
+
+          if ((start && Number.isNaN(Date.parse(start))) || (end && Number.isNaN(Date.parse(end)))) {
+            errors.push({
+              parameter: def.name,
+              message: `${def.label} must include valid start and end dates`
+            })
+            break
+          }
+
+          if (start && end && new Date(start) > new Date(end)) {
+            errors.push({
+              parameter: def.name,
+              message: `${def.label} start date must be before or equal to end date`
+            })
+          }
+          break
+        }
       }
     }
 
@@ -209,6 +250,9 @@ export function getDefaultValues(definitions: ParameterDefinition[]): Record<str
           break
         case 'date':
           defaults[def.name] = ''
+          break
+        case 'date_range':
+          defaults[def.name] = { start: '', end: '' }
           break
       }
     }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,9 +6,9 @@
     "node": ">=18.17.0"
   },
   "scripts": {
-    "dev": "npx concurrently -n \"WEB,DISPATCH\" -c \"cyan,magenta\" \"npm run dev:web\" \"npm run dev:dispatcher\"",
+    "dev": "npm run dev:web",
     "dev:web": "bash -c 'set -a; [ -f ../.env ] && . ../.env; [ -f ./.env.local ] && . ./.env.local; set +a; for v in PLEXUS_API_URL PLEXUS_API_KEY PLEXUS_ACCOUNT_KEY; do if [ -z \"${!v:-}\" ]; then echo \"Missing $v for dev:web\" >&2; exit 1; fi; done; export NEXT_PUBLIC_PLEXUS_API_URL=\"$PLEXUS_API_URL\"; export NEXT_PUBLIC_PLEXUS_API_KEY=\"$PLEXUS_API_KEY\"; export NEXT_PUBLIC_PLEXUS_API_REGION=\"${PLEXUS_API_REGION:-${NEXT_PUBLIC_PLEXUS_API_REGION:-}}\"; export NEXT_PUBLIC_PLEXUS_ACCOUNT_KEY=\"$PLEXUS_ACCOUNT_KEY\"; NEXT_TYPESCRIPT_CHECK=0 next dev --webpack'",
-    "dev:dispatcher": "bash -c 'set -a; [ -f ../.env ] && . ../.env; [ -f ./.env.local ] && . ./.env.local; set +a; for v in PLEXUS_API_URL PLEXUS_API_KEY PLEXUS_ACCOUNT_KEY OPENAI_API_KEY; do if [ -z \"${!v:-}\" ]; then echo \"Missing $v for dev:dispatcher\" >&2; exit 1; fi; done; PLEXUS_FETCH_SCHEMA_FROM_TRANSPORT=false PLEXUS_DISPATCH_MODE=local python -m plexus.cli command dispatcher --interval 0.5 --loglevel INFO'",
+    "dev:dispatch": "bash -c 'set -a; [ -f ../.env ] && . ../.env; [ -f ./.env.local ] && . ./.env.local; set +a; for v in PLEXUS_API_URL PLEXUS_API_KEY PLEXUS_ACCOUNT_KEY OPENAI_API_KEY; do if [ -z \"${!v:-}\" ]; then echo \"Missing $v for dev:dispatch\" >&2; exit 1; fi; done; PLEXUS_FETCH_SCHEMA_FROM_TRANSPORT=false PLEXUS_DISPATCH_MODE=local python -m plexus.cli command dispatcher --interval 0.5 --loglevel INFO'",
     "build": "next build",
     "build:fast": "NEXT_TYPESCRIPT_CHECK=0 next build --webpack",
     "start": "next start",

--- a/dashboard/types/parameters.ts
+++ b/dashboard/types/parameters.ts
@@ -8,9 +8,15 @@ export type ParameterType =
   | 'boolean'
   | 'select'
   | 'date'
+  | 'date_range'
   | 'scorecard_select'
   | 'score_select'
   | 'score_version_select'
+
+export interface DateRangeValue {
+  start?: string
+  end?: string
+}
 
 export interface ParameterOption {
   value: string
@@ -45,5 +51,4 @@ export interface ParameterValidationError {
   parameter: string
   message: string
 }
-
 

--- a/dashboard/utils/report-configurations.ts
+++ b/dashboard/utils/report-configurations.ts
@@ -1,0 +1,69 @@
+import { getClient } from "@/utils/amplify-client"
+
+const LIST_REPORT_CONFIGURATIONS = `
+  query ListReportConfigurations(
+    $accountId: String!
+    $limit: Int
+    $nextToken: String
+    $sortDirection: ModelSortDirection
+  ) {
+    listReportConfigurationByAccountIdAndUpdatedAt(
+      accountId: $accountId
+      limit: $limit
+      nextToken: $nextToken
+      sortDirection: $sortDirection
+    ) {
+      items {
+        id
+        name
+        description
+        updatedAt
+        createdAt
+      }
+      nextToken
+    }
+  }
+`
+
+export type ReportConfigurationListItem = {
+  id: string
+  name?: string | null
+  description?: string | null
+  updatedAt?: string | null
+  createdAt?: string | null
+}
+
+export async function listAllReportConfigurationsByAccount(
+  accountId: string
+): Promise<ReportConfigurationListItem[]> {
+  const allConfigs: ReportConfigurationListItem[] = []
+  let nextToken: string | null = null
+
+  do {
+    const response = await getClient().graphql({
+      query: LIST_REPORT_CONFIGURATIONS,
+      variables: {
+        accountId,
+        limit: 100,
+        nextToken,
+        sortDirection: "DESC",
+      },
+    })
+
+    if (
+      "data" in response &&
+      response.data?.listReportConfigurationByAccountIdAndUpdatedAt?.items
+    ) {
+      const page = response.data.listReportConfigurationByAccountIdAndUpdatedAt
+      allConfigs.push(...page.items.filter(Boolean))
+      nextToken = page.nextToken ?? null
+    } else {
+      nextToken = null
+    }
+  } while (nextToken)
+
+  return allConfigs.filter(
+    (config, index, arr) =>
+      arr.findIndex((other) => other.id === config.id) === index
+  )
+}

--- a/dashboard/utils/report-configurations.ts
+++ b/dashboard/utils/report-configurations.ts
@@ -40,7 +40,7 @@ export async function listAllReportConfigurationsByAccount(
   let nextToken: string | null = null
 
   do {
-    const response = await getClient().graphql({
+    const response: any = await getClient().graphql({
       query: LIST_REPORT_CONFIGURATIONS,
       variables: {
         accountId,
@@ -54,7 +54,7 @@ export async function listAllReportConfigurationsByAccount(
       "data" in response &&
       response.data?.listReportConfigurationByAccountIdAndUpdatedAt?.items
     ) {
-      const page = response.data.listReportConfigurationByAccountIdAndUpdatedAt
+      const page: any = response.data.listReportConfigurationByAccountIdAndUpdatedAt
       allConfigs.push(...page.items.filter(Boolean))
       nextToken = page.nextToken ?? null
     } else {

--- a/plexus/cli/report/parameter_prompts.py
+++ b/plexus/cli/report/parameter_prompts.py
@@ -50,13 +50,33 @@ def collect_parameters_interactively(
         if not param_name:
             continue
         
+        param_type = param_def.get('type', 'text')
+
         # Skip if already provided
         if param_name in provided_params:
             value = provided_params[param_name]
             collected_params[param_name] = value
             console.print(f"[dim]✓ {param_def.get('label', param_name)}: {value} (provided)[/dim]")
             continue
-        
+
+        # date_range can be provided as companion keys: <name>_start / <name>_end
+        if param_type == 'date_range':
+            start_key = f"{param_name}_start"
+            end_key = f"{param_name}_end"
+            start_val = provided_params.get(start_key)
+            end_val = provided_params.get(end_key)
+            if start_val is not None or end_val is not None:
+                range_value = {
+                    'start': str(start_val or '').strip(),
+                    'end': str(end_val or '').strip(),
+                }
+                collected_params[param_name] = range_value
+                console.print(
+                    f"[dim]✓ {param_def.get('label', param_name)}: "
+                    f"{range_value['start']} to {range_value['end']} (provided)[/dim]"
+                )
+                continue
+
         # Prompt for value
         value = prompt_for_parameter(param_def)
         
@@ -98,6 +118,9 @@ def prompt_for_parameter(param_def: Dict[str, Any]) -> Any:
     elif param_type == 'select':
         return prompt_select(param_label, param_def, required, default)
     
+    elif param_type == 'date_range':
+        return prompt_date_range(param_label, required, default)
+
     elif param_type in ('scorecard_select', 'score_select', 'score_version_select'):
         # These would need API calls - for now, just collect as text/ID
         console.print(f"[yellow]Note: '{param_type}' requires manual entry in CLI mode[/yellow]")
@@ -224,6 +247,31 @@ def prompt_select(label: str, param_def: Dict[str, Any], required: bool = False,
             console.print("[red]Please enter a valid number[/red]")
 
 
+def prompt_date_range(label: str, required: bool = False, default: Any = None) -> Optional[Dict[str, str]]:
+    """Prompt for start/end dates as ISO date strings."""
+    default_start = ""
+    default_end = ""
+    if isinstance(default, dict):
+        default_start = str(default.get('start') or "")
+        default_end = str(default.get('end') or "")
+
+    while True:
+        start = Prompt.ask(f"{label} start (YYYY-MM-DD)", default=default_start)
+        end = Prompt.ask(f"{label} end (YYYY-MM-DD)", default=default_end)
+
+        start = str(start or "").strip()
+        end = str(end or "").strip()
+
+        if not start and not end and not required:
+            return None
+
+        if not start or not end:
+            console.print("[red]This parameter requires both start and end dates[/red]")
+            continue
+
+        return {"start": start, "end": end}
+
+
 def parse_cli_parameter_options(ctx_params: Dict[str, Any]) -> Dict[str, Any]:
     """
     Extract --param-* options from click context parameters.
@@ -260,4 +308,3 @@ def display_collected_parameters(parameters: Dict[str, Any]):
     for name, value in parameters.items():
         console.print(f"  [cyan]{name}[/cyan]: {value}")
     console.print()
-

--- a/plexus/reports/blocks/__init__.py
+++ b/plexus/reports/blocks/__init__.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 from .base import BaseReportBlock
 from .score_info import ScoreInfo
 from .feedback_alignment import FeedbackAlignment
+from .feedback_analysis import FeedbackAnalysis
 from .explanation_analysis import ExplanationAnalysis
 from .topic_analysis import TopicAnalysis
 from .cost_analysis import CostAnalysis
@@ -20,6 +21,7 @@ __all__ = [
     "BaseReportBlock",
     "ScoreInfo",
     "FeedbackAlignment",
+    "FeedbackAnalysis",
     "ExplanationAnalysis",
     "TopicAnalysis",
     "CostAnalysis",

--- a/plexus/reports/blocks/feedback_analysis.py
+++ b/plexus/reports/blocks/feedback_analysis.py
@@ -1,0 +1,12 @@
+from .feedback_alignment import FeedbackAlignment
+
+
+class FeedbackAnalysis(FeedbackAlignment):
+    """
+    Backward-compatible alias for FeedbackAlignment.
+
+    Report configurations that reference `class: FeedbackAnalysis` should execute
+    with the same behavior and config contract as FeedbackAlignment, including
+    support for `days` and explicit `start_date` / `end_date` windows.
+    """
+

--- a/plexus/reports/parameter_utils.py
+++ b/plexus/reports/parameter_utils.py
@@ -7,6 +7,8 @@ This module provides functions for:
 - Rendering configuration content with Jinja2 templates
 """
 
+import json
+from datetime import datetime
 import yaml
 from typing import Dict, Any, List, Optional
 from jinja2 import StrictUndefined, TemplateError
@@ -119,6 +121,36 @@ def validate_parameter_value(param_def: Dict[str, Any], value: Any) -> tuple[boo
             valid_values = [opt['value'] if isinstance(opt, dict) else opt for opt in options]
             if value not in valid_values:
                 return False, f"Parameter '{param_name}' must be one of: {', '.join(map(str, valid_values))}"
+
+    elif param_type == 'date_range':
+        if not isinstance(value, dict):
+            return False, f"Parameter '{param_name}' must be an object with start and end"
+
+        start = str(value.get('start') or '').strip()
+        end = str(value.get('end') or '').strip()
+
+        if required and (not start or not end):
+            return False, f"Parameter '{param_name}' requires both start and end dates"
+
+        if not start and not end:
+            return True, None
+
+        def _parse_iso(raw: str) -> Optional[datetime]:
+            if not raw:
+                return None
+            try:
+                return datetime.fromisoformat(raw.replace('Z', '+00:00'))
+            except ValueError:
+                return None
+
+        start_dt = _parse_iso(start)
+        end_dt = _parse_iso(end)
+
+        if (start and start_dt is None) or (end and end_dt is None):
+            return False, f"Parameter '{param_name}' must include valid ISO date values"
+
+        if start_dt is not None and end_dt is not None and start_dt > end_dt:
+            return False, f"Parameter '{param_name}' start must be before or equal to end"
     
     # All other types (text, date, etc.) - just check it's not empty if required
     return True, None
@@ -248,7 +280,37 @@ def normalize_parameter_value(param_def: Dict[str, Any], value: str) -> Any:
         if isinstance(value, str):
             return value.lower() in ('true', 'yes', 'y', '1')
         return bool(value)
-    
+
+    elif param_type == 'date_range':
+        if isinstance(value, dict):
+            return {
+                'start': str(value.get('start') or '').strip(),
+                'end': str(value.get('end') or '').strip(),
+            }
+
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return {'start': '', 'end': ''}
+
+            # Accept JSON object value for convenience in CLI usage.
+            try:
+                parsed = json.loads(stripped)
+                if isinstance(parsed, dict):
+                    return {
+                        'start': str(parsed.get('start') or '').strip(),
+                        'end': str(parsed.get('end') or '').strip(),
+                    }
+            except Exception:
+                pass
+
+            # Accept "start,end" shorthand.
+            if ',' in stripped:
+                start, end = stripped.split(',', 1)
+                return {'start': start.strip(), 'end': end.strip()}
+
+            return {'start': stripped, 'end': ''}
+
     else:
         # text, date, select, and others - keep as string
         return str(value)

--- a/plexus/reports/service.py
+++ b/plexus/reports/service.py
@@ -2133,14 +2133,32 @@ def generate_report_with_parameters(
     if param_defs:
         logger.info(f"{log_prefix} Configuration requires {len(param_defs)} parameters")
 
+        # Allow date_range companion inputs (<name>_start/<name>_end) and map
+        # them into the canonical <name> object expected by parameter definitions.
+        raw_parameters = dict(parameters)
+        for param_def in param_defs:
+            param_name = param_def.get('name')
+            if not param_name or param_def.get('type') != 'date_range':
+                continue
+            if param_name in raw_parameters:
+                continue
+
+            start_key = f"{param_name}_start"
+            end_key = f"{param_name}_end"
+            if start_key in raw_parameters or end_key in raw_parameters:
+                raw_parameters[param_name] = {
+                    'start': raw_parameters.get(start_key, ''),
+                    'end': raw_parameters.get(end_key, ''),
+                }
+
         # Normalize parameter values to correct types
         normalized_params = {}
         for param_def in param_defs:
             param_name = param_def.get('name')
-            if param_name and param_name in parameters:
+            if param_name and param_name in raw_parameters:
                 normalized_params[param_name] = normalize_parameter_value(
                     param_def,
-                    parameters[param_name]
+                    raw_parameters[param_name]
                 )
             elif param_name:
                 # Check if required but missing
@@ -2160,6 +2178,18 @@ def generate_report_with_parameters(
 
         # Enrich parameters with resolved names for scorecard_select and score_select
         enriched_params = enrich_parameters_with_names(param_defs, normalized_params, client)
+
+        # Expose companion variables for date_range definitions so templates can
+        # reference either `window.start/end` or `window_start/window_end`.
+        for param_def in param_defs:
+            param_name = param_def.get('name')
+            if not param_name or param_def.get('type') != 'date_range':
+                continue
+            value = normalized_params.get(param_name)
+            if isinstance(value, dict):
+                enriched_params.setdefault(f"{param_name}_start", str(value.get('start') or ''))
+                enriched_params.setdefault(f"{param_name}_end", str(value.get('end') or ''))
+
         logger.info(f"{log_prefix} Parameters enriched with names: {enriched_params}")
 
         # Render configuration with Jinja2 using enriched parameters

--- a/plexus/reports/tests/test_feedback_analysis_alias.py
+++ b/plexus/reports/tests/test_feedback_analysis_alias.py
@@ -1,0 +1,8 @@
+from plexus.reports import service
+from plexus.reports import blocks
+
+
+def test_feedback_analysis_block_class_registered() -> None:
+    assert "FeedbackAnalysis" in service.BLOCK_CLASSES
+    assert service.BLOCK_CLASSES["FeedbackAnalysis"] is blocks.FeedbackAnalysis
+

--- a/plexus/reports/tests/test_parameter_utils.py
+++ b/plexus/reports/tests/test_parameter_utils.py
@@ -192,6 +192,26 @@ class TestParameterValidation:
         assert is_valid is False
         assert len(errors) == 2
 
+    def test_validate_date_range_valid(self):
+        """Test date_range validation accepts valid start/end range."""
+        param_def = {'name': 'window', 'type': 'date_range', 'required': True}
+        is_valid, error = validate_parameter_value(
+            param_def,
+            {'start': '2026-03-01', 'end': '2026-04-20'}
+        )
+        assert is_valid is True
+        assert error is None
+
+    def test_validate_date_range_ordering(self):
+        """Test date_range validation rejects end before start."""
+        param_def = {'name': 'window', 'type': 'date_range', 'required': True}
+        is_valid, error = validate_parameter_value(
+            param_def,
+            {'start': '2026-04-20', 'end': '2026-03-01'}
+        )
+        assert is_valid is False
+        assert 'before or equal' in error
+
 
 class TestJinja2Rendering:
     """Test Jinja2 template rendering with parameters."""
@@ -292,6 +312,24 @@ class TestParameterHelpers:
         
         assert normalize_parameter_value(param_def, 'hello') == 'hello'
         assert normalize_parameter_value(param_def, 123) == '123'
+
+    def test_normalize_date_range_from_dict(self):
+        """Test normalizing date_range from dictionary input."""
+        param_def = {'name': 'window', 'type': 'date_range'}
+        value = normalize_parameter_value(
+            param_def,
+            {'start': '2026-03-01', 'end': '2026-04-20'}
+        )
+        assert value == {'start': '2026-03-01', 'end': '2026-04-20'}
+
+    def test_normalize_date_range_from_json(self):
+        """Test normalizing date_range from JSON string input."""
+        param_def = {'name': 'window', 'type': 'date_range'}
+        value = normalize_parameter_value(
+            param_def,
+            '{"start":"2026-03-01","end":"2026-04-20"}'
+        )
+        assert value == {'start': '2026-03-01', 'end': '2026-04-20'}
 
 
 class TestParameterEnrichment:
@@ -515,4 +553,3 @@ class TestParameterEnrichment:
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])
-

--- a/project/events/2026-04-21T16:23:14.537Z__de8139d6-a50c-4a3c-852a-0c8b25890bb8.json
+++ b/project/events/2026-04-21T16:23:14.537Z__de8139d6-a50c-4a3c-852a-0c8b25890bb8.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "de8139d6-a50c-4a3c-852a-0c8b25890bb8",
+  "issue_id": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T16:23:14.537Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "initiative",
+    "labels": [],
+    "parent": null,
+    "priority": 2,
+    "status": "open",
+    "title": "Report parameter UX improvements"
+  }
+}

--- a/project/events/2026-04-21T16:23:20.515Z__1bf08fcd-f4f3-4153-84b4-2fb056988a68.json
+++ b/project/events/2026-04-21T16:23:20.515Z__1bf08fcd-f4f3-4153-84b4-2fb056988a68.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "1bf08fcd-f4f3-4153-84b4-2fb056988a68",
+  "issue_id": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T16:23:20.515Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+    "priority": 2,
+    "status": "open",
+    "title": "Add configurable date range parameter type for reports"
+  }
+}

--- a/project/events/2026-04-21T16:23:23.628Z__83ba21ee-4d98-4ca1-bcf4-3eca9d08d769.json
+++ b/project/events/2026-04-21T16:23:23.628Z__83ba21ee-4d98-4ca1-bcf4-3eca9d08d769.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "83ba21ee-4d98-4ca1-bcf4-3eca9d08d769",
+  "issue_id": "plx-c9cfb739-cbbf-4669-9927-f94bfd6ebdca",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T16:23:23.628Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+    "priority": 2,
+    "status": "open",
+    "title": "Report run dialog supports date range parameter entry"
+  }
+}

--- a/project/events/2026-04-21T16:23:23.632Z__5cbc3ce4-a079-4e09-9a65-45d1ef73b2eb.json
+++ b/project/events/2026-04-21T16:23:23.632Z__5cbc3ce4-a079-4e09-9a65-45d1ef73b2eb.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "5cbc3ce4-a079-4e09-9a65-45d1ef73b2eb",
+  "issue_id": "plx-126e5c60-3a78-4fba-b26d-91f10918092d",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T16:23:23.632Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+    "priority": 2,
+    "status": "open",
+    "title": "Implement date_range parameter parsing, UI rendering, validation, and dispatch flattening"
+  }
+}

--- a/project/events/2026-04-21T16:23:30.771Z__ccd2fff5-9a84-433c-bf18-56ce0c991231.json
+++ b/project/events/2026-04-21T16:23:30.771Z__ccd2fff5-9a84-433c-bf18-56ce0c991231.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ccd2fff5-9a84-433c-bf18-56ce0c991231",
+  "issue_id": "plx-c9cfb739-cbbf-4669-9927-f94bfd6ebdca",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T16:23:30.771Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "66d6dd48-2ebd-4f79-818c-2d30e094ff6c"
+  }
+}

--- a/project/events/2026-04-21T16:23:30.845Z__a87fe3b7-e148-4fb2-a8c5-4e2bf02f2cab.json
+++ b/project/events/2026-04-21T16:23:30.845Z__a87fe3b7-e148-4fb2-a8c5-4e2bf02f2cab.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a87fe3b7-e148-4fb2-a8c5-4e2bf02f2cab",
+  "issue_id": "plx-126e5c60-3a78-4fba-b26d-91f10918092d",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T16:23:30.845Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-21T16:23:30.851Z__3df9cc0a-cfb2-4fc6-a914-30025f4dca83.json
+++ b/project/events/2026-04-21T16:23:30.851Z__3df9cc0a-cfb2-4fc6-a914-30025f4dca83.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3df9cc0a-cfb2-4fc6-a914-30025f4dca83",
+  "issue_id": "plx-126e5c60-3a78-4fba-b26d-91f10918092d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T16:23:30.851Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "24de20ea-640b-4145-b592-7ce249f08662"
+  }
+}

--- a/project/events/2026-04-21T16:25:29.767Z__758483b3-c118-41bf-8663-4f6936205ea1.json
+++ b/project/events/2026-04-21T16:25:29.767Z__758483b3-c118-41bf-8663-4f6936205ea1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "758483b3-c118-41bf-8663-4f6936205ea1",
+  "issue_id": "plx-126e5c60-3a78-4fba-b26d-91f10918092d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T16:25:29.767Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "c093e0f4-bdc0-4de4-be61-346a8d8643e2"
+  }
+}

--- a/project/events/2026-04-21T16:32:28.480Z__7de74431-0e94-4940-8c2c-a32b719bbc8b.json
+++ b/project/events/2026-04-21T16:32:28.480Z__7de74431-0e94-4940-8c2c-a32b719bbc8b.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "7de74431-0e94-4940-8c2c-a32b719bbc8b",
+  "issue_id": "plx-db2235c8-febb-4dcc-8673-e80abf6de509",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T16:32:28.480Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+    "priority": 2,
+    "status": "open",
+    "title": "Support FeedbackAnalysis block class as date-window-capable alias"
+  }
+}

--- a/project/events/2026-04-21T16:32:28.545Z__eac47371-ea08-41ae-884e-b0e069e52ab5.json
+++ b/project/events/2026-04-21T16:32:28.545Z__eac47371-ea08-41ae-884e-b0e069e52ab5.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "eac47371-ea08-41ae-884e-b0e069e52ab5",
+  "issue_id": "plx-126e5c60-3a78-4fba-b26d-91f10918092d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T16:32:28.545Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "dc6e782b-a5a1-49c0-91fa-9b4db980efe4"
+  }
+}

--- a/project/events/2026-04-21T16:32:31.599Z__56f0b3be-96bf-497c-9363-eefeeb4a9e06.json
+++ b/project/events/2026-04-21T16:32:31.599Z__56f0b3be-96bf-497c-9363-eefeeb4a9e06.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "56f0b3be-96bf-497c-9363-eefeeb4a9e06",
+  "issue_id": "plx-db2235c8-febb-4dcc-8673-e80abf6de509",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T16:32:31.599Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-21T16:33:22.739Z__1e913274-9b9c-4b1a-8976-7978dc74fdbf.json
+++ b/project/events/2026-04-21T16:33:22.739Z__1e913274-9b9c-4b1a-8976-7978dc74fdbf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1e913274-9b9c-4b1a-8976-7978dc74fdbf",
+  "issue_id": "plx-db2235c8-febb-4dcc-8673-e80abf6de509",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T16:33:22.739Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "936bc307-16f1-4501-a6ab-3f9469661b66"
+  }
+}

--- a/project/events/2026-04-21T17:51:25.227Z__21db682f-0c74-4376-9533-a787654d5a3c.json
+++ b/project/events/2026-04-21T17:51:25.227Z__21db682f-0c74-4376-9533-a787654d5a3c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "21db682f-0c74-4376-9533-a787654d5a3c",
+  "issue_id": "plx-126e5c60-3a78-4fba-b26d-91f10918092d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T17:51:25.227Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "cf0efaf6-4cb6-4d5f-859d-b7dd9d46ec1e"
+  }
+}

--- a/project/events/2026-04-21T17:51:25.258Z__4ea951fa-4f0d-4ba2-8925-aaf73da38da8.json
+++ b/project/events/2026-04-21T17:51:25.258Z__4ea951fa-4f0d-4ba2-8925-aaf73da38da8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4ea951fa-4f0d-4ba2-8925-aaf73da38da8",
+  "issue_id": "plx-db2235c8-febb-4dcc-8673-e80abf6de509",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T17:51:25.258Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "0734b615-805c-4dcc-833d-0bc592e62e52"
+  }
+}

--- a/project/events/2026-04-21T17:51:25.264Z__0d6d9bd0-19b7-4444-bc1c-7c05a1e27710.json
+++ b/project/events/2026-04-21T17:51:25.264Z__0d6d9bd0-19b7-4444-bc1c-7c05a1e27710.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0d6d9bd0-19b7-4444-bc1c-7c05a1e27710",
+  "issue_id": "plx-c9cfb739-cbbf-4669-9927-f94bfd6ebdca",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T17:51:25.264Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "23ad05d2-26bc-47c3-a98e-cc21ea99eb02"
+  }
+}

--- a/project/events/2026-04-21T17:51:25.265Z__f9dad9d5-4108-4e15-87c7-88edb922b20e.json
+++ b/project/events/2026-04-21T17:51:25.265Z__f9dad9d5-4108-4e15-87c7-88edb922b20e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f9dad9d5-4108-4e15-87c7-88edb922b20e",
+  "issue_id": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T17:51:25.265Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "cffb33e0-6419-440c-8cb4-8810d8cf8170"
+  }
+}

--- a/project/events/2026-04-21T17:51:32.617Z__1c7c19e2-5407-47a3-afa2-cc64cf6a0bda.json
+++ b/project/events/2026-04-21T17:51:32.617Z__1c7c19e2-5407-47a3-afa2-cc64cf6a0bda.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1c7c19e2-5407-47a3-afa2-cc64cf6a0bda",
+  "issue_id": "plx-126e5c60-3a78-4fba-b26d-91f10918092d",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T17:51:32.617Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T17:51:32.620Z__2b7715a7-8aae-4982-82f6-79ac68375381.json
+++ b/project/events/2026-04-21T17:51:32.620Z__2b7715a7-8aae-4982-82f6-79ac68375381.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2b7715a7-8aae-4982-82f6-79ac68375381",
+  "issue_id": "plx-db2235c8-febb-4dcc-8673-e80abf6de509",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T17:51:32.620Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T17:51:32.654Z__c08c3841-a15e-418d-869c-546319179733.json
+++ b/project/events/2026-04-21T17:51:32.654Z__c08c3841-a15e-418d-869c-546319179733.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c08c3841-a15e-418d-869c-546319179733",
+  "issue_id": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T17:51:32.654Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-21T17:51:32.656Z__376a3485-d5e7-43ca-9b48-6f8c26c5b8e1.json
+++ b/project/events/2026-04-21T17:51:32.656Z__376a3485-d5e7-43ca-9b48-6f8c26c5b8e1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "376a3485-d5e7-43ca-9b48-6f8c26c5b8e1",
+  "issue_id": "plx-c9cfb739-cbbf-4669-9927-f94bfd6ebdca",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T17:51:32.656Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T17:54:51.922Z__75b9617c-ab28-47e6-ac7d-6f66716b04d4.json
+++ b/project/events/2026-04-21T17:54:51.922Z__75b9617c-ab28-47e6-ac7d-6f66716b04d4.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "75b9617c-ab28-47e6-ac7d-6f66716b04d4",
+  "issue_id": "plx-0c45b58c-0425-4935-8b2e-58d1042b42a8",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T17:54:51.922Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+    "priority": 2,
+    "status": "open",
+    "title": "Make dashboard dev script web-only and require explicit dispatcher start"
+  }
+}

--- a/project/events/2026-04-21T17:55:01.079Z__7e057dbf-be54-4f84-8730-62a374ea6566.json
+++ b/project/events/2026-04-21T17:55:01.079Z__7e057dbf-be54-4f84-8730-62a374ea6566.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7e057dbf-be54-4f84-8730-62a374ea6566",
+  "issue_id": "plx-0c45b58c-0425-4935-8b2e-58d1042b42a8",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T17:55:01.079Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "4afd818b-3515-4507-a34c-26eb78269f6b"
+  }
+}

--- a/project/events/2026-04-21T17:55:13.034Z__159a9ffb-9fbc-4331-96a8-d7d16959299a.json
+++ b/project/events/2026-04-21T17:55:13.034Z__159a9ffb-9fbc-4331-96a8-d7d16959299a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "159a9ffb-9fbc-4331-96a8-d7d16959299a",
+  "issue_id": "plx-0c45b58c-0425-4935-8b2e-58d1042b42a8",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T17:55:13.034Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-21T17:55:42.111Z__29efffce-f85f-4159-87a1-531616f8d62a.json
+++ b/project/events/2026-04-21T17:55:42.111Z__29efffce-f85f-4159-87a1-531616f8d62a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "29efffce-f85f-4159-87a1-531616f8d62a",
+  "issue_id": "plx-0c45b58c-0425-4935-8b2e-58d1042b42a8",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T17:55:42.111Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T17:55:42.573Z__eddf85d7-f7a7-4a5f-9d7a-e7723a08c513.json
+++ b/project/events/2026-04-21T17:55:42.573Z__eddf85d7-f7a7-4a5f-9d7a-e7723a08c513.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "eddf85d7-f7a7-4a5f-9d7a-e7723a08c513",
+  "issue_id": "plx-0c45b58c-0425-4935-8b2e-58d1042b42a8",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T17:55:42.573Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "1d588ce8-0861-4615-ae4e-deede730da31"
+  }
+}

--- a/project/events/2026-04-21T18:06:30.920Z__0ce231e6-9bb6-42df-b893-6effd0375d89.json
+++ b/project/events/2026-04-21T18:06:30.920Z__0ce231e6-9bb6-42df-b893-6effd0375d89.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "0ce231e6-9bb6-42df-b893-6effd0375d89",
+  "issue_id": "plx-ae2aca2d-5613-4dd5-9dfa-499a1bde9fbd",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T18:06:30.920Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+    "priority": 2,
+    "status": "open",
+    "title": "Upgrade report date_range UI to calendar range picker with no-future constraint"
+  }
+}

--- a/project/events/2026-04-21T18:06:38.191Z__71ec813c-f9bc-45eb-820c-e5fc4c48a79f.json
+++ b/project/events/2026-04-21T18:06:38.191Z__71ec813c-f9bc-45eb-820c-e5fc4c48a79f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "71ec813c-f9bc-45eb-820c-e5fc4c48a79f",
+  "issue_id": "plx-ae2aca2d-5613-4dd5-9dfa-499a1bde9fbd",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:06:38.191Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "a9403286-bf69-49ae-b3e9-415886219a23"
+  }
+}

--- a/project/events/2026-04-21T18:06:38.192Z__c8887bf6-37c4-49e0-9ae2-d2f61381de14.json
+++ b/project/events/2026-04-21T18:06:38.192Z__c8887bf6-37c4-49e0-9ae2-d2f61381de14.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c8887bf6-37c4-49e0-9ae2-d2f61381de14",
+  "issue_id": "plx-ae2aca2d-5613-4dd5-9dfa-499a1bde9fbd",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:06:38.192Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-21T18:07:25.259Z__e06c5594-3499-46e4-8943-17d29e115448.json
+++ b/project/events/2026-04-21T18:07:25.259Z__e06c5594-3499-46e4-8943-17d29e115448.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e06c5594-3499-46e4-8943-17d29e115448",
+  "issue_id": "plx-ae2aca2d-5613-4dd5-9dfa-499a1bde9fbd",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:07:25.259Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "c8bfa0c5-6d9a-45f4-a52e-7a13e64f4dce"
+  }
+}

--- a/project/events/2026-04-21T18:07:25.261Z__4dc07f7b-8bd2-466e-8524-cc92259519b0.json
+++ b/project/events/2026-04-21T18:07:25.261Z__4dc07f7b-8bd2-466e-8524-cc92259519b0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4dc07f7b-8bd2-466e-8524-cc92259519b0",
+  "issue_id": "plx-ae2aca2d-5613-4dd5-9dfa-499a1bde9fbd",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:07:25.261Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T18:08:36.861Z__a68658d4-768e-47c9-bd8c-0df5c3d129d3.json
+++ b/project/events/2026-04-21T18:08:36.861Z__a68658d4-768e-47c9-bd8c-0df5c3d129d3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a68658d4-768e-47c9-bd8c-0df5c3d129d3",
+  "issue_id": "plx-0c45b58c-0425-4935-8b2e-58d1042b42a8",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:08:36.861Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "ed440631-6ae5-4053-bbb6-daa0e69a1696"
+  }
+}

--- a/project/events/2026-04-21T18:11:05.484Z__6f344524-294e-49af-a649-596bc9507fb8.json
+++ b/project/events/2026-04-21T18:11:05.484Z__6f344524-294e-49af-a649-596bc9507fb8.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "6f344524-294e-49af-a649-596bc9507fb8",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T18:11:05.484Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+    "priority": 2,
+    "status": "open",
+    "title": "Fix date-range popover interaction inside report parameter dialog"
+  }
+}

--- a/project/events/2026-04-21T18:11:10.230Z__71d16074-0854-4444-9ff4-b5942aacc100.json
+++ b/project/events/2026-04-21T18:11:10.230Z__71d16074-0854-4444-9ff4-b5942aacc100.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "71d16074-0854-4444-9ff4-b5942aacc100",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:11:10.230Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-21T18:11:10.242Z__0ab8af17-ebd8-4287-a952-9194624810ed.json
+++ b/project/events/2026-04-21T18:11:10.242Z__0ab8af17-ebd8-4287-a952-9194624810ed.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0ab8af17-ebd8-4287-a952-9194624810ed",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:11:10.242Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "992cb48a-582d-44e4-8d6a-ad8ae1459a96"
+  }
+}

--- a/project/events/2026-04-21T18:11:28.661Z__0ea36393-ab13-47ad-936b-d36da910b62a.json
+++ b/project/events/2026-04-21T18:11:28.661Z__0ea36393-ab13-47ad-936b-d36da910b62a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0ea36393-ab13-47ad-936b-d36da910b62a",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:11:28.661Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "e2033c62-1683-419b-9d25-5a283ce5fa2e"
+  }
+}

--- a/project/events/2026-04-21T18:11:34.781Z__16c36c49-30ef-48e1-9cbb-561aca255034.json
+++ b/project/events/2026-04-21T18:11:34.781Z__16c36c49-30ef-48e1-9cbb-561aca255034.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "16c36c49-30ef-48e1-9cbb-561aca255034",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:11:34.781Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T18:15:28.164Z__ea208dd7-deba-4c12-b610-3139e4290c40.json
+++ b/project/events/2026-04-21T18:15:28.164Z__ea208dd7-deba-4c12-b610-3139e4290c40.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ea208dd7-deba-4c12-b610-3139e4290c40",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:15:28.164Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "1a554a67-a429-43cd-9c77-1151b16c4e0a"
+  }
+}

--- a/project/events/2026-04-21T18:15:57.368Z__969fb84d-6178-432c-9e59-b8f31125f3f7.json
+++ b/project/events/2026-04-21T18:15:57.368Z__969fb84d-6178-432c-9e59-b8f31125f3f7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "969fb84d-6178-432c-9e59-b8f31125f3f7",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:15:57.368Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "closed",
+    "to_status": "open"
+  }
+}

--- a/project/events/2026-04-21T18:15:57.380Z__53a737bc-1428-4cd3-ade8-e9cb69e39d86.json
+++ b/project/events/2026-04-21T18:15:57.380Z__53a737bc-1428-4cd3-ade8-e9cb69e39d86.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "53a737bc-1428-4cd3-ade8-e9cb69e39d86",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:15:57.380Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "74ed7ca0-e668-4e82-8eee-e42ccd0fa085"
+  }
+}

--- a/project/events/2026-04-21T18:16:03.758Z__bddb725e-127d-4c89-9e97-b623907a521c.json
+++ b/project/events/2026-04-21T18:16:03.758Z__bddb725e-127d-4c89-9e97-b623907a521c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bddb725e-127d-4c89-9e97-b623907a521c",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:16:03.758Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T18:18:40.321Z__1d7935c7-157c-49b2-9723-6ff333f4d480.json
+++ b/project/events/2026-04-21T18:18:40.321Z__1d7935c7-157c-49b2-9723-6ff333f4d480.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1d7935c7-157c-49b2-9723-6ff333f4d480",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:18:40.321Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "closed",
+    "to_status": "open"
+  }
+}

--- a/project/events/2026-04-21T18:18:40.332Z__870fb5b4-0abb-4677-b17e-b539b23c3924.json
+++ b/project/events/2026-04-21T18:18:40.332Z__870fb5b4-0abb-4677-b17e-b539b23c3924.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "870fb5b4-0abb-4677-b17e-b539b23c3924",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:18:40.332Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "355af5e2-031b-4873-8dd0-a0f3ea6e03d3"
+  }
+}

--- a/project/events/2026-04-21T18:18:58.701Z__ed2d72c5-9304-4171-bbae-ee3b5b7fca66.json
+++ b/project/events/2026-04-21T18:18:58.701Z__ed2d72c5-9304-4171-bbae-ee3b5b7fca66.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ed2d72c5-9304-4171-bbae-ee3b5b7fca66",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:18:58.701Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "c7867c52-e2e1-4729-a200-8e0c4dc7a600"
+  }
+}

--- a/project/events/2026-04-21T18:18:58.713Z__aae5902e-f4c3-4dbf-9ab6-3a802032732b.json
+++ b/project/events/2026-04-21T18:18:58.713Z__aae5902e-f4c3-4dbf-9ab6-3a802032732b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "aae5902e-f4c3-4dbf-9ab6-3a802032732b",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:18:58.713Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T18:26:27.880Z__c8accb4d-8cf8-40fb-878a-dce8b93fa868.json
+++ b/project/events/2026-04-21T18:26:27.880Z__c8accb4d-8cf8-40fb-878a-dce8b93fa868.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c8accb4d-8cf8-40fb-878a-dce8b93fa868",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:26:27.880Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "closed",
+    "to_status": "open"
+  }
+}

--- a/project/events/2026-04-21T18:26:27.892Z__9669b044-d0ae-44b3-a01b-0e63645dfd92.json
+++ b/project/events/2026-04-21T18:26:27.892Z__9669b044-d0ae-44b3-a01b-0e63645dfd92.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9669b044-d0ae-44b3-a01b-0e63645dfd92",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:26:27.892Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "139eb3cf-2c98-4d2c-bc66-46f5fed87f5e"
+  }
+}

--- a/project/events/2026-04-21T18:29:28.823Z__9c71a42b-2090-415d-baa4-5ec1f82ef49b.json
+++ b/project/events/2026-04-21T18:29:28.823Z__9c71a42b-2090-415d-baa4-5ec1f82ef49b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9c71a42b-2090-415d-baa4-5ec1f82ef49b",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T18:29:28.823Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "cf694abc-e974-424d-ab8d-e9535bdfc309"
+  }
+}

--- a/project/events/2026-04-21T18:29:28.835Z__54e1e5b1-1741-4e11-83ab-c84295468c7b.json
+++ b/project/events/2026-04-21T18:29:28.835Z__54e1e5b1-1741-4e11-83ab-c84295468c7b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "54e1e5b1-1741-4e11-83ab-c84295468c7b",
+  "issue_id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T18:29:28.835Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-0c45b58c-0425-4935-8b2e-58d1042b42a8.json
+++ b/project/issues/plx-0c45b58c-0425-4935-8b2e-58d1042b42a8.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-0c45b58c-0425-4935-8b2e-58d1042b42a8",
+  "title": "Make dashboard dev script web-only and require explicit dispatcher start",
+  "description": "",
+  "type": "task",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "4afd818b-3515-4507-a34c-26eb78269f6b",
+      "author": "derek",
+      "text": "Starting implementation. Plan: change dashboard npm scripts so dev starts web only, add explicit dispatcher script (dev:dispatch), and update local-dev docs to match. Then run targeted validation and push.",
+      "created_at": "2026-04-21T17:55:01.078195557Z"
+    },
+    {
+      "id": "1d588ce8-0861-4615-ae4e-deede730da31",
+      "author": "derek",
+      "text": "Implemented. Updated dashboard scripts so  now runs web only and dispatcher requires explicit . Updated dashboard/README.md and root README.md to document the new local workflow and avoid accidental local dispatcher collisions.",
+      "created_at": "2026-04-21T17:55:42.573150014Z"
+    }
+  ],
+  "created_at": "2026-04-21T17:54:51.922012328Z",
+  "updated_at": "2026-04-21T17:55:42.573150014Z",
+  "closed_at": "2026-04-21T17:55:42.111195137Z",
+  "custom": {}
+}

--- a/project/issues/plx-0c45b58c-0425-4935-8b2e-58d1042b42a8.json
+++ b/project/issues/plx-0c45b58c-0425-4935-8b2e-58d1042b42a8.json
@@ -22,10 +22,16 @@
       "author": "derek",
       "text": "Implemented. Updated dashboard scripts so  now runs web only and dispatcher requires explicit . Updated dashboard/README.md and root README.md to document the new local workflow and avoid accidental local dispatcher collisions.",
       "created_at": "2026-04-21T17:55:42.573150014Z"
+    },
+    {
+      "id": "ed440631-6ae5-4053-bbb6-daa0e69a1696",
+      "author": "derek",
+      "text": "Follow-up CI fix: added explicit typing for GraphQL response/page in dashboard/utils/report-configurations.ts to resolve TS7022 implicit-any failure in dashboard typecheck workflow.",
+      "created_at": "2026-04-21T18:08:36.861321619Z"
     }
   ],
   "created_at": "2026-04-21T17:54:51.922012328Z",
-  "updated_at": "2026-04-21T17:55:42.573150014Z",
+  "updated_at": "2026-04-21T18:08:36.861321619Z",
   "closed_at": "2026-04-21T17:55:42.111195137Z",
   "custom": {}
 }

--- a/project/issues/plx-126e5c60-3a78-4fba-b26d-91f10918092d.json
+++ b/project/issues/plx-126e5c60-3a78-4fba-b26d-91f10918092d.json
@@ -1,0 +1,43 @@
+{
+  "id": "plx-126e5c60-3a78-4fba-b26d-91f10918092d",
+  "title": "Implement date_range parameter parsing, UI rendering, validation, and dispatch flattening",
+  "description": "",
+  "type": "task",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "24de20ea-640b-4145-b592-7ce249f08662",
+      "author": "derek",
+      "text": "Starting implementation on feature/report-date-range-parameter. Scope: add date_range ParameterType, parser normalization/validation/default handling, parameter form/dialog rendering with date-range control, and flattening to <name>_start/<name>_end in report dispatch command.",
+      "created_at": "2026-04-21T16:23:30.850949993Z"
+    },
+    {
+      "id": "c093e0f4-bdc0-4de4-be61-346a8d8643e2",
+      "author": "derek",
+      "text": "Implemented date_range support in dashboard parameter system: added ParameterType/date-range value shape, parser normalization + validation + defaults, new DateRangeParameter control, dialog/form render wiring, report dispatch flattening to <name>_start/<name>_end, and display formatting updates. Added/updated tests in parameter-parser and ParametersDisplay. Local quality gate: npm test -- parameter-parser.test.ts ParametersDisplay.test.tsx --runInBand (pass).",
+      "created_at": "2026-04-21T16:25:29.767574425Z"
+    },
+    {
+      "id": "dc6e782b-a5a1-49c0-91fa-9b4db980efe4",
+      "author": "derek",
+      "text": "Follow-up requested by user: task requires FeedbackAnalysis block class support specifically. Plan: add FeedbackAnalysis backend block alias to FeedbackAlignment, register frontend block type alias, and add tests confirming class registration and inherited date-window behavior (start_date/end_date). No push until user asks.",
+      "created_at": "2026-04-21T16:32:28.545229461Z"
+    },
+    {
+      "id": "cf0efaf6-4cb6-4d5f-859d-b7dd9d46ec1e",
+      "author": "derek",
+      "text": "Completed implementation and DRY cleanup. Added shared report-configuration pagination helper used by ReportConfigurationSelector and ReportConfigurationDialog, date_range parser/frontmatter support, UI date-range bounds, backend date_range normalization/validation + companion key mapping, FeedbackAnalysis alias class registration, and tests. Verification: npm test -- --runTestsByPath lib/__tests__/parameter-parser.test.ts (pass); python -m pytest -q plexus/reports/tests/test_parameter_utils.py plexus/reports/tests/test_feedback_analysis_alias.py (pass). Note: dashboard typecheck currently fails in existing generated file .next/dev/types/routes.d.ts with TS1128/TS1434 unrelated to this change.",
+      "created_at": "2026-04-21T17:51:25.226415920Z"
+    }
+  ],
+  "created_at": "2026-04-21T16:23:23.632488557Z",
+  "updated_at": "2026-04-21T17:51:32.617056914Z",
+  "closed_at": "2026-04-21T17:51:32.617056914Z",
+  "custom": {}
+}

--- a/project/issues/plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0.json
+++ b/project/issues/plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0.json
@@ -46,10 +46,22 @@
       "author": "derek",
       "text": "Implemented hide-outside-days tweak on DateRangeParameter calendar () per UX feedback; this removes prior/next month day bleed in each month panel.",
       "created_at": "2026-04-21T18:18:58.701277848Z"
+    },
+    {
+      "id": "139eb3cf-2c98-4d2c-bc66-46f5fed87f5e",
+      "author": "derek",
+      "text": "UX polish: adjust Calendar today styling so non-selected today is visually distinct (subtle ring/text emphasis) while selected/range states remain blue. This reduces confusion between 'today' and 'selected'.",
+      "created_at": "2026-04-21T18:26:27.892253758Z"
+    },
+    {
+      "id": "cf694abc-e974-424d-ab8d-e9535bdfc309",
+      "author": "derek",
+      "text": "Finalized per user validation: month-nav click targets fixed (left/right), outside-day bleed removed while preserving grid alignment, and today styling differentiated from selection. Ready for commit/push.",
+      "created_at": "2026-04-21T18:29:28.823238451Z"
     }
   ],
   "created_at": "2026-04-21T18:11:05.483970112Z",
-  "updated_at": "2026-04-21T18:18:58.713163872Z",
-  "closed_at": "2026-04-21T18:18:58.713163872Z",
+  "updated_at": "2026-04-21T18:29:28.835105330Z",
+  "closed_at": "2026-04-21T18:29:28.835105330Z",
   "custom": {}
 }

--- a/project/issues/plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0.json
+++ b/project/issues/plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0.json
@@ -22,10 +22,22 @@
       "author": "derek",
       "text": "Applied fixes: (1) DateRange popover now uses modal mode and single-month layout to avoid overlay spill/interaction conflicts; (2) closing ConfigurableParametersDialog no longer auto-closes parent Run Report dialog. This prevents 'click date closes everything' failure mode.",
       "created_at": "2026-04-21T18:11:28.660976097Z"
+    },
+    {
+      "id": "1a554a67-a429-43cd-9c77-1151b16c4e0a",
+      "author": "derek",
+      "text": "Follow-up: current calendar UI still malformed (weekday header spacing, nav placement, missing range highlight). Root cause appears to be outdated className keys for react-day-picker v9 in shared ui/calendar.tsx. Implementing class map correction and restoring 2-month range view.",
+      "created_at": "2026-04-21T18:15:28.164728766Z"
+    },
+    {
+      "id": "74ed7ca0-e668-4e82-8eee-e42ccd0fa085",
+      "author": "derek",
+      "text": "Applied follow-up styling fix in shared Calendar component: migrated classNames to react-day-picker v9 keys (weekday/week/day_button/range_start/range_middle/range_end/button_previous/button_next/month_grid). Restored 2-month range view in DateRangeParameter. This addresses misaligned weekdays/nav and missing range highlight.",
+      "created_at": "2026-04-21T18:15:57.379927452Z"
     }
   ],
   "created_at": "2026-04-21T18:11:05.483970112Z",
-  "updated_at": "2026-04-21T18:11:34.781399457Z",
-  "closed_at": "2026-04-21T18:11:34.781399457Z",
+  "updated_at": "2026-04-21T18:16:03.758189020Z",
+  "closed_at": "2026-04-21T18:16:03.758189020Z",
   "custom": {}
 }

--- a/project/issues/plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0.json
+++ b/project/issues/plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0",
+  "title": "Fix date-range popover interaction inside report parameter dialog",
+  "description": "",
+  "type": "bug",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "992cb48a-582d-44e4-8d6a-ad8ae1459a96",
+      "author": "derek",
+      "text": "Reproduced from user screenshot: date-range popover in ConfigurableParametersDialog is causing parent modal dismissal on date click. Applying fix to keep parent dialog open and make popover interaction modal-safe inside dialog.",
+      "created_at": "2026-04-21T18:11:10.242614444Z"
+    },
+    {
+      "id": "e2033c62-1683-419b-9d25-5a283ce5fa2e",
+      "author": "derek",
+      "text": "Applied fixes: (1) DateRange popover now uses modal mode and single-month layout to avoid overlay spill/interaction conflicts; (2) closing ConfigurableParametersDialog no longer auto-closes parent Run Report dialog. This prevents 'click date closes everything' failure mode.",
+      "created_at": "2026-04-21T18:11:28.660976097Z"
+    }
+  ],
+  "created_at": "2026-04-21T18:11:05.483970112Z",
+  "updated_at": "2026-04-21T18:11:34.781399457Z",
+  "closed_at": "2026-04-21T18:11:34.781399457Z",
+  "custom": {}
+}

--- a/project/issues/plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0.json
+++ b/project/issues/plx-1e78121d-f9c6-4a98-9ba4-cafddbfce0d0.json
@@ -34,10 +34,22 @@
       "author": "derek",
       "text": "Applied follow-up styling fix in shared Calendar component: migrated classNames to react-day-picker v9 keys (weekday/week/day_button/range_start/range_middle/range_end/button_previous/button_next/month_grid). Restored 2-month range view in DateRangeParameter. This addresses misaligned weekdays/nav and missing range highlight.",
       "created_at": "2026-04-21T18:15:57.379927452Z"
+    },
+    {
+      "id": "355af5e2-031b-4873-8dd0-a0f3ea6e03d3",
+      "author": "derek",
+      "text": "Final UX tweak requested: hide outside days in date-range calendar so each month shows only in-month dates (no previous/next month bleed). Applying in DateRangeParameter.",
+      "created_at": "2026-04-21T18:18:40.332904531Z"
+    },
+    {
+      "id": "c7867c52-e2e1-4729-a200-8e0c4dc7a600",
+      "author": "derek",
+      "text": "Implemented hide-outside-days tweak on DateRangeParameter calendar () per UX feedback; this removes prior/next month day bleed in each month panel.",
+      "created_at": "2026-04-21T18:18:58.701277848Z"
     }
   ],
   "created_at": "2026-04-21T18:11:05.483970112Z",
-  "updated_at": "2026-04-21T18:16:03.758189020Z",
-  "closed_at": "2026-04-21T18:16:03.758189020Z",
+  "updated_at": "2026-04-21T18:18:58.713163872Z",
+  "closed_at": "2026-04-21T18:18:58.713163872Z",
   "custom": {}
 }

--- a/project/issues/plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7.json
+++ b/project/issues/plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "title": "Add configurable date range parameter type for reports",
+  "description": "",
+  "type": "epic",
+  "status": "in_progress",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "cffb33e0-6419-440c-8cb4-8810d8cf8170",
+      "author": "derek",
+      "text": "Epic progress: delivered date_range support across dashboard parameter parsing/rendering/validation, report dispatch flattening, backend parameter ingestion/validation, and FeedbackAnalysis compatibility alias. Pending only final review/merge.",
+      "created_at": "2026-04-21T17:51:25.265668358Z"
+    }
+  ],
+  "created_at": "2026-04-21T16:23:20.515463843Z",
+  "updated_at": "2026-04-21T17:51:32.654179424Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-ae2aca2d-5613-4dd5-9dfa-499a1bde9fbd.json
+++ b/project/issues/plx-ae2aca2d-5613-4dd5-9dfa-499a1bde9fbd.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-ae2aca2d-5613-4dd5-9dfa-499a1bde9fbd",
+  "title": "Upgrade report date_range UI to calendar range picker with no-future constraint",
+  "description": "",
+  "type": "task",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "a9403286-bf69-49ae-b3e9-415886219a23",
+      "author": "derek",
+      "text": "Implementing DateRangeParameter UI upgrade to popover range calendar using existing shadcn calendar primitives. Constraints: disable future dates, preserve emitted  format and existing flattening/dispatch behavior.",
+      "created_at": "2026-04-21T18:06:38.190365663Z"
+    },
+    {
+      "id": "c8bfa0c5-6d9a-45f4-a52e-7a13e64f4dce",
+      "author": "derek",
+      "text": "Implemented calendar-based date range picker in dashboard DateRangeParameter. Behavior: range selection via popover calendar, disallow selecting dates after today, preserve emitted value format as {start,end} in YYYY-MM-DD for existing dispatch flattening.",
+      "created_at": "2026-04-21T18:07:25.259838799Z"
+    }
+  ],
+  "created_at": "2026-04-21T18:06:30.920709556Z",
+  "updated_at": "2026-04-21T18:07:25.260951701Z",
+  "closed_at": "2026-04-21T18:07:25.260951701Z",
+  "custom": {}
+}

--- a/project/issues/plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd.json
+++ b/project/issues/plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+  "title": "Report parameter UX improvements",
+  "description": "",
+  "type": "initiative",
+  "status": "open",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-21T16:23:14.536962814Z",
+  "updated_at": "2026-04-21T16:23:14.536962814Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-c9cfb739-cbbf-4669-9927-f94bfd6ebdca.json
+++ b/project/issues/plx-c9cfb739-cbbf-4669-9927-f94bfd6ebdca.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-c9cfb739-cbbf-4669-9927-f94bfd6ebdca",
+  "title": "Report run dialog supports date range parameter entry",
+  "description": "",
+  "type": "story",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "66d6dd48-2ebd-4f79-818c-2d30e094ff6c",
+      "author": "derek",
+      "text": "As a report operator, I want to choose a start and end date in the run dialog, so that I can run analyses over precise windows without manual parameter math.\n\nFeature: Report run date range parameter\nScenario: Provide a valid date range before running a report\nGiven a report configuration defines a required parameter named window of type date_range\nWhen I open Run Report and choose both a start date and end date where start is before or equal to end\nThen the dialog accepts the input\nAnd dispatches the run with scalar parameters window_start and window_end in YYYY-MM-DD format\n\nScenario: Reject invalid date range\nGiven a report configuration defines a required parameter named window of type date_range\nWhen I provide an end date earlier than the start date\nThen the dialog shows a validation error and blocks submission",
+      "created_at": "2026-04-21T16:23:30.770744604Z"
+    },
+    {
+      "id": "23ad05d2-26bc-47c3-a98e-cc21ea99eb02",
+      "author": "derek",
+      "text": "Story behavior implemented and verified. Run Report dialog now supports required date_range entry with start/end controls, client-side ordering guard (end cannot be before start), and dispatch flattening to window_start/window_end. Parsing supports markdown report templates with YAML parameter header.",
+      "created_at": "2026-04-21T17:51:25.262040412Z"
+    }
+  ],
+  "created_at": "2026-04-21T16:23:23.628006536Z",
+  "updated_at": "2026-04-21T17:51:32.655926708Z",
+  "closed_at": "2026-04-21T17:51:32.655926708Z",
+  "custom": {}
+}

--- a/project/issues/plx-db2235c8-febb-4dcc-8673-e80abf6de509.json
+++ b/project/issues/plx-db2235c8-febb-4dcc-8673-e80abf6de509.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-db2235c8-febb-4dcc-8673-e80abf6de509",
+  "title": "Support FeedbackAnalysis block class as date-window-capable alias",
+  "description": "",
+  "type": "task",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "936bc307-16f1-4501-a6ab-3f9469661b66",
+      "author": "derek",
+      "text": "Implemented locally (not pushed): added backend block alias class FeedbackAnalysis inheriting FeedbackAlignment, exported in blocks __init__, and registered dashboard alias FeedbackAnalysis -> FeedbackAlignment component. Added backend test ensuring service.BLOCK_CLASSES includes FeedbackAnalysis alias. Validation run: poetry run pytest -q plexus/reports/tests/test_feedback_analysis_alias.py (pass); dashboard npm test -- ParametersDisplay.test.tsx --runInBand (pass).",
+      "created_at": "2026-04-21T16:33:22.739381119Z"
+    },
+    {
+      "id": "0734b615-805c-4dcc-833d-0bc592e62e52",
+      "author": "derek",
+      "text": "Completed: FeedbackAnalysis alias now implemented end-to-end. Backend class alias added and exported, service BLOCK_CLASSES registration verified by test, and dashboard block registry maps FeedbackAnalysis to existing FeedbackAlignment renderer for UI parity.",
+      "created_at": "2026-04-21T17:51:25.258558407Z"
+    }
+  ],
+  "created_at": "2026-04-21T16:32:28.480058503Z",
+  "updated_at": "2026-04-21T17:51:32.620242984Z",
+  "closed_at": "2026-04-21T17:51:32.620242984Z",
+  "custom": {}
+}


### PR DESCRIPTION
**Summary**
- Add first-class `date_range` support for report parameters across dashboard + backend report execution.
- Update report parameter parsing to support YAML header + markdown report templates and normalize `date_range` values.
- Add `FeedbackAnalysis` block alias support (backend registration + dashboard renderer alias) for compatibility with existing configs.
- Add shared paginated report-configuration loader used by both report selectors to avoid partial lists.
- Upgrade report date-range UI to an interactive calendar range picker with:
- no future date selection
- stable in-dialog interaction (no parent dialog auto-close)
- corrected `react-day-picker` v9 class mapping/layout
- proper month nav button behavior and outside-day handling for cleaner month presentation.
- Change dashboard local dev scripts so `npm run dev` runs web only, and dispatcher is explicit via `npm run dev:dispatch`.

**Why**
- Report authors needed explicit start/end windows instead of only `days`.
- Existing `FeedbackAnalysis` configurations needed to continue working while adding date-window capability.
- Report selection and run UX had multiple regressions (pagination, dialog dismissal, broken calendar styling) that blocked local and production-like validation.
- Separating web and dispatcher startup in local dev prevents accidental dual dispatchers and confusing task routing behavior.

**Validation**
- `npm test -- --runTestsByPath lib/__tests__/parameter-parser.test.ts`
- `python -m pytest -q plexus/reports/tests/test_parameter_utils.py plexus/reports/tests/test_feedback_analysis_alias.py`
- Direct CLI report run with date params succeeds using `--param-window_start` / `--param-window_end`.
- GitHub Actions CI/CD Pipeline succeeded on latest branch runs:
- `24739545270`
- `24739526140`

**Expected Outcome**
- Report configurations can define `type: date_range` and dispatch to backend as `window_start` / `window_end` without interactive prompt stalls.
- Users can select valid date ranges in the run dialog with clear calendar UX and without modal interaction glitches.
- Report configuration dropdowns load full account-scoped lists (pagination-safe).
- Local dashboard developers can run UI without implicitly starting a dispatcher.

**Kanbus / Task Tracking**
- `plx-88d8f8` (epic)
- `plx-c9cfb7` (story)
- `plx-126e5c` (task)
- `plx-db2235` (task)
- `plx-0c45b5` (task)
- `plx-ae2aca` (task)
- `plx-1e7812` (bug)
