### PR TITLE
fix(code-quality): remove unused symbols flagged on promotion PR

### DIFF
--- a/dashboard/components/scorecards-dashboard.tsx
+++ b/dashboard/components/scorecards-dashboard.tsx
@@ -366,11 +366,6 @@ export default function ScorecardsComponent({
     setIsTaskViewActive(false);
   };
 
-  // Handle closing feedback alignment panel
-  const handleCloseFeedbackAlignment = () => {
-    setFeedbackAlignmentPanel(null);
-  };
-
   // Handle task closure
   const handleCloseTask = () => {
     setSelectedTask(null);

--- a/dashboard/stories/blocks/FeedbackAlignment.stories.tsx
+++ b/dashboard/stories/blocks/FeedbackAlignment.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { BlockRenderer } from '@/components/blocks/BlockRegistry';
-import FeedbackAlignment from '@/components/blocks/FeedbackAlignment';
 import { type ClassDistribution } from '@/components/ClassDistributionVisualizer';
 import { type ConfusionMatrixData } from '@/components/confusion-matrix';
 

--- a/plexus/Scorecard_test.py
+++ b/plexus/Scorecard_test.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch, MagicMock, AsyncMock
+from unittest.mock import Mock, MagicMock, AsyncMock
 from plexus.Scorecard import Scorecard
 import pytest
 import logging

--- a/project/events/2026-04-21T19:04:06.607Z__9e7ea76f-7352-4bf7-89fa-446381fe5615.json
+++ b/project/events/2026-04-21T19:04:06.607Z__9e7ea76f-7352-4bf7-89fa-446381fe5615.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "9e7ea76f-7352-4bf7-89fa-446381fe5615",
+  "issue_id": "plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-21T19:04:06.607Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+    "priority": 2,
+    "status": "open",
+    "title": "Resolve github-code-quality unused symbol findings on develop->main promotion PR"
+  }
+}

--- a/project/events/2026-04-21T19:04:10.613Z__0fa0f913-5c50-47f7-84cd-3091c4d8d6d4.json
+++ b/project/events/2026-04-21T19:04:10.613Z__0fa0f913-5c50-47f7-84cd-3091c4d8d6d4.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0fa0f913-5c50-47f7-84cd-3091c4d8d6d4",
+  "issue_id": "plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T19:04:10.613Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-21T19:04:10.625Z__8507f51c-e84a-47e9-9e4a-4bf3be6d0d44.json
+++ b/project/events/2026-04-21T19:04:10.625Z__8507f51c-e84a-47e9-9e4a-4bf3be6d0d44.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8507f51c-e84a-47e9-9e4a-4bf3be6d0d44",
+  "issue_id": "plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T19:04:10.625Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "3277de35-da1e-4e6b-802c-6eca7ec745ea"
+  }
+}

--- a/project/events/2026-04-21T19:05:04.556Z__e39a7647-6f37-4210-97f2-f39c7d54f754.json
+++ b/project/events/2026-04-21T19:05:04.556Z__e39a7647-6f37-4210-97f2-f39c7d54f754.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e39a7647-6f37-4210-97f2-f39c7d54f754",
+  "issue_id": "plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T19:05:04.556Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "d3cc4493-a57d-46a8-a936-947c0f52dac2"
+  }
+}

--- a/project/issues/plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b.json
+++ b/project/issues/plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b",
+  "title": "Resolve github-code-quality unused symbol findings on develop->main promotion PR",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "3277de35-da1e-4e6b-802c-6eca7ec745ea",
+      "author": "derek",
+      "text": "Addressing github-code-quality review findings from PR #193: remove unused function in dashboard/components/scorecards-dashboard.tsx, remove unused import in dashboard/stories/blocks/FeedbackAlignment.stories.tsx, and remove unused patch import in plexus/Scorecard_test.py. Using a dedicated fix branch from develop.",
+      "created_at": "2026-04-21T19:04:10.624991498Z"
+    },
+    {
+      "id": "d3cc4493-a57d-46a8-a936-947c0f52dac2",
+      "author": "derek",
+      "text": "Implemented fixes on bugfix/code-quality-unused-symbols: removed unused handleCloseFeedbackAlignment function, removed unused FeedbackAlignment import in story, and removed unused patch import in plexus/Scorecard_test.py. Validation: npm test -- --runTestsByPath lib/__tests__/parameter-parser.test.ts (pass); python -m pytest -q plexus/Scorecard_test.py -k 'not integration' (9 passed).",
+      "created_at": "2026-04-21T19:05:04.556272235Z"
+    }
+  ],
+  "created_at": "2026-04-21T19:04:06.607182990Z",
+  "updated_at": "2026-04-21T19:05:04.556272235Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
**Summary**
- Remove unused `handleCloseFeedbackAlignment` in `dashboard/components/scorecards-dashboard.tsx`.
- Remove unused `FeedbackAlignment` import in `dashboard/stories/blocks/FeedbackAlignment.stories.tsx`.
- Remove unused `patch` import from `plexus/Scorecard_test.py`.

**Why**
- `github-code-quality` left unresolved review threads on PR #193 for unused symbols/imports.
- These are no-behavior-change cleanups needed to clear code-quality review comments before `develop -> main` promotion.

**Validation**
- `npm test -- --runTestsByPath lib/__tests__/parameter-parser.test.ts`
- `python -m pytest -q plexus/Scorecard_test.py -k "not integration"`

**Expected Outcome**
- Code-quality review threads about unused symbols are resolved.
- No runtime behavior changes.
- `develop -> main` PR can proceed without these review blockers.

**Kanbus / Task Tracking**
- `plx-9ae05c`
