### PR TITLE
chore(kanbus): persist report initiative closeout artifacts

### DIFF
--- a/project/events/2026-04-21T19:22:35.015Z__db4c72ff-2e82-497f-a613-51c2ad5f9b83.json
+++ b/project/events/2026-04-21T19:22:35.015Z__db4c72ff-2e82-497f-a613-51c2ad5f9b83.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "db4c72ff-2e82-497f-a613-51c2ad5f9b83",
+  "issue_id": "plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T19:22:35.015Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "13ea96d2-dd96-4268-813c-012455b9340c"
+  }
+}

--- a/project/events/2026-04-21T19:22:35.027Z__c36e27be-d69c-4129-a42a-809112365995.json
+++ b/project/events/2026-04-21T19:22:35.027Z__c36e27be-d69c-4129-a42a-809112365995.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c36e27be-d69c-4129-a42a-809112365995",
+  "issue_id": "plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T19:22:35.027Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T19:22:35.087Z__fb88f5d7-b0de-4d5a-aba7-a5fcce4e2bf8.json
+++ b/project/events/2026-04-21T19:22:35.087Z__fb88f5d7-b0de-4d5a-aba7-a5fcce4e2bf8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "fb88f5d7-b0de-4d5a-aba7-a5fcce4e2bf8",
+  "issue_id": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T19:22:35.087Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "e87821b9-5110-4e01-8381-b8df785d073d"
+  }
+}

--- a/project/events/2026-04-21T19:22:35.098Z__60c86137-1d26-4c0c-a951-888f9b082af2.json
+++ b/project/events/2026-04-21T19:22:35.098Z__60c86137-1d26-4c0c-a951-888f9b082af2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "60c86137-1d26-4c0c-a951-888f9b082af2",
+  "issue_id": "plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T19:22:35.098Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-21T19:22:35.099Z__445521ca-89dd-4be6-8682-929d699f4fb1.json
+++ b/project/events/2026-04-21T19:22:35.099Z__445521ca-89dd-4be6-8682-929d699f4fb1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "445521ca-89dd-4be6-8682-929d699f4fb1",
+  "issue_id": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-21T19:22:35.099Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "8d0ad492-dbbf-4d5c-9dfd-8b5acb84df0b"
+  }
+}

--- a/project/events/2026-04-21T19:22:35.111Z__793d8e17-f78e-47ad-b60b-7e9a500d9aed.json
+++ b/project/events/2026-04-21T19:22:35.111Z__793d8e17-f78e-47ad-b60b-7e9a500d9aed.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "793d8e17-f78e-47ad-b60b-7e9a500d9aed",
+  "issue_id": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-21T19:22:35.111Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7.json
+++ b/project/issues/plx-88d8f8c6-72b2-4f34-8a65-9818f9673ab7.json
@@ -3,7 +3,7 @@
   "title": "Add configurable date range parameter type for reports",
   "description": "",
   "type": "epic",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 2,
   "assignee": null,
   "creator": null,
@@ -28,10 +28,16 @@
       "author": "derek",
       "text": "Added semantic-release safeguard: creating a final Conventional Commit (feat(reports): add date-range report parameters and calendar UX) on this branch so bump intent is explicit when changes eventually reach main.",
       "created_at": "2026-04-21T18:51:54.304550910Z"
+    },
+    {
+      "id": "e87821b9-5110-4e01-8381-b8df785d073d",
+      "author": "derek",
+      "text": "Epic deliverables completed and submitted via PR #192, with release promotion PR #193 and code-quality follow-up PR #194. Moving epic to closed.",
+      "created_at": "2026-04-21T19:22:35.087136334Z"
     }
   ],
   "created_at": "2026-04-21T16:23:20.515463843Z",
-  "updated_at": "2026-04-21T18:51:54.304550910Z",
-  "closed_at": null,
+  "updated_at": "2026-04-21T19:22:35.098687592Z",
+  "closed_at": "2026-04-21T19:22:35.098687592Z",
   "custom": {}
 }

--- a/project/issues/plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b.json
+++ b/project/issues/plx-9ae05c29-6849-4d3c-b646-b9f3715b0d1b.json
@@ -3,7 +3,7 @@
   "title": "Resolve github-code-quality unused symbol findings on develop->main promotion PR",
   "description": "",
   "type": "bug",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 2,
   "assignee": null,
   "creator": null,
@@ -28,10 +28,16 @@
       "author": "derek",
       "text": "Opened fix PR to develop: https://github.com/AnthusAI/Plexus/pull/194 . This branch contains only the three unused-symbol removals requested by github-code-quality plus Kanbus artifacts.",
       "created_at": "2026-04-21T19:05:41.191859245Z"
+    },
+    {
+      "id": "13ea96d2-dd96-4268-813c-012455b9340c",
+      "author": "derek",
+      "text": "Work completed and submitted: fix PR #194 (bugfix/code-quality-unused-symbols) addresses all github-code-quality findings cited on promotion PR #193. Moving issue to closed.",
+      "created_at": "2026-04-21T19:22:35.015511720Z"
     }
   ],
   "created_at": "2026-04-21T19:04:06.607182990Z",
-  "updated_at": "2026-04-21T19:05:41.191859245Z",
-  "closed_at": null,
+  "updated_at": "2026-04-21T19:22:35.027672267Z",
+  "closed_at": "2026-04-21T19:22:35.027672267Z",
   "custom": {}
 }

--- a/project/issues/plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd.json
+++ b/project/issues/plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd.json
@@ -3,16 +3,23 @@
   "title": "Report parameter UX improvements",
   "description": "",
   "type": "initiative",
-  "status": "open",
+  "status": "closed",
   "priority": 2,
   "assignee": null,
   "creator": null,
   "parent": null,
   "labels": [],
   "dependencies": [],
-  "comments": [],
+  "comments": [
+    {
+      "id": "8d0ad492-dbbf-4d5c-9dfd-8b5acb84df0b",
+      "author": "derek",
+      "text": "Initiative scope delivered through PR #192, PR #193 (develop->main promotion), and PR #194 (code-quality follow-up). Closing initiative.",
+      "created_at": "2026-04-21T19:22:35.098997768Z"
+    }
+  ],
   "created_at": "2026-04-21T16:23:14.536962814Z",
-  "updated_at": "2026-04-21T16:23:14.536962814Z",
-  "closed_at": null,
+  "updated_at": "2026-04-21T19:22:35.111734378Z",
+  "closed_at": "2026-04-21T19:22:35.111734378Z",
   "custom": {}
 }


### PR DESCRIPTION
**Summary**
- Persist final Kanbus status updates and event artifacts for the report date-range initiative closeout.
- Includes issue state transitions to closed for:
- `plx-bdf462`
- `plx-88d8f8`
- `plx-9ae05c`

**Why**
- These status/event artifacts were generated locally and need to be committed to `develop` so the active `develop -> main` promotion PR includes the final project-management state.

**Validation**
- Artifact-only change (no runtime code paths modified).
- Verified branch is clean after commit and push.

**Expected Outcome**
- `develop` contains the final Kanbus issue/event records for this initiative.
- Existing `develop -> main` PR will automatically include these artifacts after merge.

**Kanbus / Task Tracking**
- `plx-bdf462`
- `plx-88d8f8`
- `plx-9ae05c`
