### PR TITLE
fix(code-quality): narrow exception handling in procedure chat parsing

### DIFF
--- a/MCP/tools/procedure/procedures.py
+++ b/MCP/tools/procedure/procedures.py
@@ -654,7 +654,7 @@ def register_procedure_tools(mcp):
                     try:
                         if raw_content.startswith('{') and raw_content.endswith('}'):
                             parsed_content = json.loads(raw_content)
-                    except:
+                    except (json.JSONDecodeError, TypeError, ValueError):
                         pass  # Keep as string if not valid JSON
 
                     processed_msg = {
@@ -682,7 +682,7 @@ def register_procedure_tools(mcp):
                             try:
                                 if tool_response_raw.startswith('{') and tool_response_raw.endswith('}'):
                                     tool_response_parsed = json.loads(tool_response_raw)
-                            except:
+                            except (json.JSONDecodeError, TypeError, ValueError):
                                 pass
                             processed_msg["tool_response"] = tool_response_parsed
                             session_tool_responses.append(msg["id"])


### PR DESCRIPTION
## Summary
- replace broad `except:` blocks in procedure chat message JSON parsing
- catch only expected parse/type errors: `json.JSONDecodeError`, `TypeError`, `ValueError`
- preserve existing fallback behavior (keep raw string when parsing fails)

## Why
- resolves github-code-quality finding on PR #193 for broad exception handling

## Validation
- `poetry run pytest MCP/tools/procedure/procedures_test.py -q`

## Tracking
- Kanbus: `plx-c0fb8d`
