### PR TITLE
fix(reports): handle date_range YAML date values in FeedbackAnalysis

### DIFF
--- a/plexus/reports/blocks/feedback_alignment.py
+++ b/plexus/reports/blocks/feedback_alignment.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional, Tuple, List
 import logging
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from collections import Counter
 import json # Ensure json import at the top
 import yaml # For YAML formatted output with contextual comments
@@ -114,6 +114,61 @@ class FeedbackAlignment(BaseReportBlock):
         except Exception:
             return scores
 
+    @staticmethod
+    def _parse_window_date(
+        raw_value: Any,
+        *,
+        is_end: bool,
+        default_value: datetime,
+    ) -> datetime:
+        """Parse a configured date window value into UTC datetime.
+
+        Accepts YAML/templated inputs that may come through as:
+        - str (YYYY-MM-DD or ISO datetime)
+        - datetime.date
+        - datetime.datetime
+        """
+        if raw_value is None or raw_value == "":
+            dt = default_value
+        elif isinstance(raw_value, datetime):
+            dt = raw_value
+        elif isinstance(raw_value, date):
+            if is_end:
+                dt = datetime(
+                    raw_value.year,
+                    raw_value.month,
+                    raw_value.day,
+                    23,
+                    59,
+                    59,
+                    999999,
+                )
+            else:
+                dt = datetime(raw_value.year, raw_value.month, raw_value.day, 0, 0, 0, 0)
+        else:
+            value_str = str(raw_value).strip()
+            if not value_str:
+                dt = default_value
+            else:
+                date_only = len(value_str) == 10 and value_str[4] == "-" and value_str[7] == "-"
+                normalized = value_str.replace("Z", "+00:00")
+                try:
+                    dt = datetime.fromisoformat(normalized)
+                except ValueError:
+                    dt = datetime.strptime(value_str, "%Y-%m-%d")
+                    date_only = True
+                if date_only:
+                    if is_end:
+                        dt = dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+                    else:
+                        dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt
+
     async def generate(self) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
         """Fetches feedback data and performs agreement analysis."""
         self.log_messages = []
@@ -181,23 +236,22 @@ class FeedbackAlignment(BaseReportBlock):
                 _s = str(cc_question_id_param).strip()
                 cc_question_id_param = None if not _s or _s.lower() == "none" else _s
 
-            # Parse date strings
-            if start_date_str:
-                start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
-            else:
-                start_date = datetime.now() - timedelta(days=days)
-            # Make start_date UTC aware (assuming naive datetime is intended as UTC)
-            start_date = start_date.replace(tzinfo=timezone.utc)
-            
-            if end_date_str:
-                end_date = datetime.strptime(end_date_str, "%Y-%m-%d")
-            else:
-                end_date = datetime.now()
-            
-            # Ensure end_date is at the end of the day for correct filtering
-            end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
-            # Make end_date UTC aware (assuming naive datetime is intended as UTC)
-            end_date = end_date.replace(tzinfo=timezone.utc)
+            now_utc = datetime.now(tz=timezone.utc)
+            start_default = now_utc - timedelta(days=days)
+            end_default = now_utc.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+            start_date = self._parse_window_date(
+                start_date_str,
+                is_end=False,
+                default_value=start_default,
+            )
+            end_date = self._parse_window_date(
+                end_date_str,
+                is_end=True,
+                default_value=end_default,
+            )
+            if end_date < start_date:
+                raise ValueError("'end_date' must be on or after 'start_date'.")
 
             self._log(f"Effective date range for filtering FeedbackItems: {start_date.isoformat()} to {end_date.isoformat()}")
             if cc_question_id_param:

--- a/plexus/reports/blocks/feedback_alignment_test.py
+++ b/plexus/reports/blocks/feedback_alignment_test.py
@@ -2,7 +2,7 @@ import pytest
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 import yaml
 
 from plexus.reports.blocks.feedback_alignment import FeedbackAlignment
@@ -213,6 +213,21 @@ class TestFeedbackAlignment:
                 assert parsed_output is not None
                 assert parsed_output["scores"][0]["score_id"] == "score1"
                 assert parsed_output["scores"][1]["score_id"] == "score2"
+
+    def test_parse_window_date_accepts_date_type(self):
+        start = FeedbackAlignment._parse_window_date(
+            date(2026, 4, 9),
+            is_end=False,
+            default_value=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        end = FeedbackAlignment._parse_window_date(
+            date(2026, 4, 9),
+            is_end=True,
+            default_value=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+        assert start == datetime(2026, 4, 9, 0, 0, 0, 0, tzinfo=timezone.utc)
+        assert end == datetime(2026, 4, 9, 23, 59, 59, 999999, tzinfo=timezone.utc)
     
     @pytest.mark.asyncio
     async def test_generate_with_no_data(self, mock_api_client):

--- a/project/events/2026-04-23T20:19:20.136Z__8fe420d0-2028-4536-af34-cb7cda0ca3b0.json
+++ b/project/events/2026-04-23T20:19:20.136Z__8fe420d0-2028-4536-af34-cb7cda0ca3b0.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "8fe420d0-2028-4536-af34-cb7cda0ca3b0",
+  "issue_id": "plx-b62e8310-838d-42ef-a517-58cd12237c24",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-23T20:19:20.136Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+    "priority": 2,
+    "status": "open",
+    "title": "Fix FeedbackAnalysis date_range handling for YAML date objects"
+  }
+}

--- a/project/events/2026-04-23T20:21:29.319Z__b731fe24-8f0a-4696-bce4-27c40a2b0b25.json
+++ b/project/events/2026-04-23T20:21:29.319Z__b731fe24-8f0a-4696-bce4-27c40a2b0b25.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b731fe24-8f0a-4696-bce4-27c40a2b0b25",
+  "issue_id": "plx-b62e8310-838d-42ef-a517-58cd12237c24",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-23T20:21:29.319Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/issues/plx-b62e8310-838d-42ef-a517-58cd12237c24.json
+++ b/project/issues/plx-b62e8310-838d-42ef-a517-58cd12237c24.json
@@ -1,0 +1,21 @@
+{
+  "id": "plx-b62e8310-838d-42ef-a517-58cd12237c24",
+  "title": "Fix FeedbackAnalysis date_range handling for YAML date objects",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-bdf46225-f6cd-441e-907f-ae08bfceb3bd",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-23T20:19:20.135922519Z",
+  "updated_at": "2026-04-23T20:21:29.319103731Z",
+  "closed_at": null,
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
+}


### PR DESCRIPTION
## Summary
- fix FeedbackAnalysis/FeedbackAlignment date-window parsing to accept YAML date objects (`datetime.date`) in addition to strings
- normalize all parsed window values to UTC datetimes
- preserve day-boundary behavior for date-only values (start=00:00:00, end=23:59:59.999999)
- add regression test for date-object parsing

## Validation
- `poetry run pytest -q plexus/reports/blocks/feedback_alignment_test.py -q`

## Problem
Date-range report configs can render unquoted dates, which YAML loads as `datetime.date`. The block previously called `datetime.strptime()` directly and crashed with:
`strptime() argument 1 must be str, not datetime.date`.
