### PR TITLE
fix(reports): disable optional memory fanout for FeedbackAnalysis by default

### DIFF
--- a/plexus/reports/blocks/feedback_analysis.py
+++ b/plexus/reports/blocks/feedback_analysis.py
@@ -10,3 +10,9 @@ class FeedbackAnalysis(FeedbackAlignment):
     support for `days` and explicit `start_date` / `end_date` windows.
     """
 
+    async def generate(self):
+        # Keep legacy FeedbackAnalysis execution lightweight/safe by default.
+        # Memory analysis remains available as an explicit opt-in.
+        if "memory_analysis" not in self.config:
+            self.config["memory_analysis"] = False
+        return await super().generate()

--- a/plexus/reports/tests/test_feedback_analysis_alias.py
+++ b/plexus/reports/tests/test_feedback_analysis_alias.py
@@ -1,8 +1,41 @@
 from plexus.reports import service
 from plexus.reports import blocks
+from unittest.mock import patch
+import pytest
 
 
 def test_feedback_analysis_block_class_registered() -> None:
     assert "FeedbackAnalysis" in service.BLOCK_CLASSES
     assert service.BLOCK_CLASSES["FeedbackAnalysis"] is blocks.FeedbackAnalysis
 
+
+@pytest.mark.asyncio
+async def test_feedback_analysis_defaults_memory_analysis_disabled() -> None:
+    instance = blocks.FeedbackAnalysis(config={"scorecard": "1481"}, params={}, api_client=None)
+
+    async def _fake_generate(self):
+        return {"ok": True}, "log"
+
+    with patch.object(blocks.FeedbackAlignment, "generate", _fake_generate):
+        output, _log = await instance.generate()
+
+    assert output == {"ok": True}
+    assert instance.config["memory_analysis"] is False
+
+
+@pytest.mark.asyncio
+async def test_feedback_analysis_preserves_explicit_memory_analysis_setting() -> None:
+    instance = blocks.FeedbackAnalysis(
+        config={"scorecard": "1481", "memory_analysis": True},
+        params={},
+        api_client=None,
+    )
+
+    async def _fake_generate(self):
+        return {"ok": True}, "log"
+
+    with patch.object(blocks.FeedbackAlignment, "generate", _fake_generate):
+        output, _log = await instance.generate()
+
+    assert output == {"ok": True}
+    assert instance.config["memory_analysis"] is True

--- a/project/events/2026-04-23T20:35:06.303Z__42ac435e-146e-4d21-97ec-2efe1dacf4d0.json
+++ b/project/events/2026-04-23T20:35:06.303Z__42ac435e-146e-4d21-97ec-2efe1dacf4d0.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "42ac435e-146e-4d21-97ec-2efe1dacf4d0",
+  "issue_id": "plx-e36b0657-325a-46c7-a3ad-c05a9db416e8",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-23T20:35:06.303Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "FeedbackAnalysis days mode crashes with 'pop from an empty deque'"
+  }
+}

--- a/project/events/2026-04-23T20:37:22.736Z__3f3a1c70-45a9-4398-912a-7ffa88824dd7.json
+++ b/project/events/2026-04-23T20:37:22.736Z__3f3a1c70-45a9-4398-912a-7ffa88824dd7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3f3a1c70-45a9-4398-912a-7ffa88824dd7",
+  "issue_id": "plx-e36b0657-325a-46c7-a3ad-c05a9db416e8",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-23T20:37:22.736Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/issues/plx-e36b0657-325a-46c7-a3ad-c05a9db416e8.json
+++ b/project/issues/plx-e36b0657-325a-46c7-a3ad-c05a9db416e8.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-e36b0657-325a-46c7-a3ad-c05a9db416e8",
+  "title": "FeedbackAnalysis days mode crashes with 'pop from an empty deque'",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-23T20:35:06.303621402Z",
+  "updated_at": "2026-04-23T20:37:22.736117681Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
**Summary**
- Update `FeedbackAnalysis` (legacy alias) to default `memory_analysis` to `false` unless explicitly configured.
- Keep `FeedbackAlignment` behavior unchanged.
- Add tests to verify:
- default memory analysis is disabled for `FeedbackAnalysis`
- explicit `memory_analysis: true` is preserved

**Why**
- A production report using `class: FeedbackAnalysis` with `days` failed after score-result attachments with:
- `IndexError: pop from an empty deque`
- The failure occurs in async execution after heavy per-score processing; this change keeps legacy FeedbackAnalysis runs on the lightweight path by default and avoids optional memory-analysis fanout unless requested.

**Validation**
- `poetry run pytest -q plexus/reports/tests/test_feedback_analysis_alias.py -q`
- `poetry run pytest -q plexus/reports/blocks/feedback_alignment_test.py -q`

**Expected Outcome**
- Existing `FeedbackAnalysis` reports (days/date-window) complete without invoking memory analysis unless explicitly opted in.
- Users who want memory outputs can still enable them via `memory_analysis: true`.

**Kanbus / Task Tracking**
- `plx-e36b06`
