### PR TITLE
fix(dashboard): map feedback detail files by score identity

### DIFF
--- a/dashboard/components/ui/scorecard-evaluation.tsx
+++ b/dashboard/components/ui/scorecard-evaluation.tsx
@@ -156,19 +156,22 @@ export const ScorecardReportEvaluation: React.FC<ScorecardReportEvaluationProps>
 
   const scoreDetailsFileName = `score-${scoreIndex + 1}-results.json`;
   const scoreDetailsFile = useMemo(() => {
-    // First try to find in parsedAttachedFiles
-    let file = parsedAttachedFiles.find(f => f.name === scoreDetailsFileName);
-    
-    // If not found and score has indexed_items_file, create a file entry
-    if (!file && (score as any).indexed_items_file) {
-      const indexedFile = (score as any).indexed_items_file;
-      file = {
-        name: indexedFile,
-        path: indexedFile // The backend should provide the full path
-      };
+    const indexedFile = (score as any).indexed_items_file;
+
+    // Prefer explicit per-score file mapping from backend.
+    // This avoids cross-score detail mismatches when score rows are re-ordered.
+    if (typeof indexedFile === 'string' && indexedFile.trim()) {
+      const indexedName = indexedFile.trim();
+      const matched = parsedAttachedFiles.find((f) => f.name === indexedName);
+      if (matched) return matched;
+      return {
+        name: indexedName,
+        path: indexedName, // Legacy fallback when only filename is present
+      } as DetailFile;
     }
-    
-    return file;
+
+    // Legacy fallback for old payloads that only supported index-based filenames.
+    return parsedAttachedFiles.find((f) => f.name === scoreDetailsFileName);
   }, [parsedAttachedFiles, scoreDetailsFileName, score]);
 
   const fetchScoreDetailsContent = useCallback(async () => {

--- a/project/events/2026-04-24T17:47:31.513Z__3b957e51-05f8-4b11-8423-fa42f053ed9f.json
+++ b/project/events/2026-04-24T17:47:31.513Z__3b957e51-05f8-4b11-8423-fa42f053ed9f.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "3b957e51-05f8-4b11-8423-fa42f053ed9f",
+  "issue_id": "plx-4c0861eb-480f-4d28-9934-40db52b8466b",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-24T17:47:31.513Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 2,
+    "status": "open",
+    "title": "Investigate feedback-score misassociation in analysis reports"
+  }
+}

--- a/project/events/2026-04-24T17:47:33.063Z__740ad0e9-c220-432d-a8a0-5e94a8bc0186.json
+++ b/project/events/2026-04-24T17:47:33.063Z__740ad0e9-c220-432d-a8a0-5e94a8bc0186.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "740ad0e9-c220-432d-a8a0-5e94a8bc0186",
+  "issue_id": "plx-9e8215e2-a74a-4fbc-89b1-d21882454048",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-24T17:47:33.063Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-4c0861eb-480f-4d28-9934-40db52b8466b",
+    "priority": 2,
+    "status": "open",
+    "title": "Debug and fix cross-repo feedback score linkage for Appropriate Rebuttal- AI"
+  }
+}

--- a/project/events/2026-04-24T17:47:35.219Z__bd51e9bc-5dfb-48ea-89fe-18e37cb10c53.json
+++ b/project/events/2026-04-24T17:47:35.219Z__bd51e9bc-5dfb-48ea-89fe-18e37cb10c53.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bd51e9bc-5dfb-48ea-89fe-18e37cb10c53",
+  "issue_id": "plx-9e8215e2-a74a-4fbc-89b1-d21882454048",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-24T17:47:35.219Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-24T17:47:35.231Z__66f26e70-0bbe-440a-9b67-416363fb990a.json
+++ b/project/events/2026-04-24T17:47:35.231Z__66f26e70-0bbe-440a-9b67-416363fb990a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "66f26e70-0bbe-440a-9b67-416363fb990a",
+  "issue_id": "plx-9e8215e2-a74a-4fbc-89b1-d21882454048",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-24T17:47:35.231Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "c83a3998-7b78-4ea9-90c1-96048ad4b438"
+  }
+}

--- a/project/events/2026-04-24T17:50:23.647Z__a8504a39-a5b0-470e-a057-8031b8b00e15.json
+++ b/project/events/2026-04-24T17:50:23.647Z__a8504a39-a5b0-470e-a057-8031b8b00e15.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a8504a39-a5b0-470e-a057-8031b8b00e15",
+  "issue_id": "plx-9e8215e2-a74a-4fbc-89b1-d21882454048",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-24T17:50:23.647Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "2ec277f7-9c84-434c-9150-16b41347d0a3"
+  }
+}

--- a/project/events/2026-04-24T17:50:47.784Z__a04f952b-db88-42a1-9a58-138587beab72.json
+++ b/project/events/2026-04-24T17:50:47.784Z__a04f952b-db88-42a1-9a58-138587beab72.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a04f952b-db88-42a1-9a58-138587beab72",
+  "issue_id": "plx-9e8215e2-a74a-4fbc-89b1-d21882454048",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-24T17:50:47.784Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "2909cb2c-a448-47c4-aad6-69106381d37c"
+  }
+}

--- a/project/issues/plx-4c0861eb-480f-4d28-9934-40db52b8466b.json
+++ b/project/issues/plx-4c0861eb-480f-4d28-9934-40db52b8466b.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-4c0861eb-480f-4d28-9934-40db52b8466b",
+  "title": "Investigate feedback-score misassociation in analysis reports",
+  "description": "",
+  "type": "epic",
+  "status": "open",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-24T17:47:31.513540883Z",
+  "updated_at": "2026-04-24T17:47:31.513540883Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-9e8215e2-a74a-4fbc-89b1-d21882454048.json
+++ b/project/issues/plx-9e8215e2-a74a-4fbc-89b1-d21882454048.json
@@ -1,0 +1,37 @@
+{
+  "id": "plx-9e8215e2-a74a-4fbc-89b1-d21882454048",
+  "title": "Debug and fix cross-repo feedback score linkage for Appropriate Rebuttal- AI",
+  "description": "",
+  "type": "story",
+  "status": "in_progress",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-4c0861eb-480f-4d28-9934-40db52b8466b",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "c83a3998-7b78-4ea9-90c1-96048ad4b438",
+      "author": "derek",
+      "text": "Started investigation. Scope: trace feedback capture in Call-Criteria-Python and feedback analysis/reporting in Plexus; verify score_id/score_name mapping path and isolate where mismap occurs.",
+      "created_at": "2026-04-24T17:47:35.231595102Z"
+    },
+    {
+      "id": "2ec277f7-9c84-434c-9150-16b41347d0a3",
+      "author": "derek",
+      "text": "Root cause candidate found in dashboard rendering: Score detail file selection in dashboard/components/ui/scorecard-evaluation.tsx prefers scoreIndex-derived filename (score-N-results.json). Backend sorts scores after generating files, so index-based lookup can bind a score to another score's detail file/comment set. Plan: prioritize score.indexed_items_file mapping, fallback to index only for legacy payloads.",
+      "created_at": "2026-04-24T17:50:23.647030114Z"
+    },
+    {
+      "id": "2909cb2c-a448-47c4-aad6-69106381d37c",
+      "author": "derek",
+      "text": "Implemented fix in dashboard/components/ui/scorecard-evaluation.tsx: detail-file resolution now prefers score.indexed_items_file (identity-based), and only falls back to scoreIndex filename for legacy payloads. This prevents comments/details from being sourced from another score when backend sorts score rows.",
+      "created_at": "2026-04-24T17:50:47.784282234Z"
+    }
+  ],
+  "created_at": "2026-04-24T17:47:33.063711111Z",
+  "updated_at": "2026-04-24T17:50:47.784282234Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- fix score detail file resolution in Feedback Alignment UI to prioritize per-score `indexed_items_file`
- keep index-based `score-N-results.json` as legacy fallback only
- prevent cross-score comment/detail mismatches after backend score sorting
- include required Kanbus artifact sync commit generated during issue tracking

## Validation
- `npm exec -- tsc --noEmit` (in `dashboard/`)
