### PR TITLE
Add evaluation rate gauge to procedures dashboard

### DIFF
--- a/dashboard/components/EvaluationTask.tsx
+++ b/dashboard/components/EvaluationTask.tsx
@@ -1983,6 +1983,8 @@ const EvaluationTask = React.memo(function EvaluationTaskComponent({
   const [currentBaselineAccuracy, setCurrentBaselineAccuracy] = useState<number | null>(null);
 
   const data = task.data ?? {} as EvaluationTaskData
+  const hasInlineActionMenu = Boolean(onShare || onDelete)
+  const hasGridActions = variant === 'grid' && (Boolean(controlButtons) || hasInlineActionMenu)
 
   const evaluationNotes = useMemo(() => {
     try {
@@ -2528,9 +2530,17 @@ ${categoryLines}${mechanicalLines}
               {/* Grid variant: show all metadata inline in header */}
               {variant !== 'detail' && (
                 <>
-                  {props.task.name && (
-                    <div className="font-semibold text-sm truncate">{props.task.name}</div>
-                  )}
+                  {props.task.name ? (
+                    <div className="font-semibold text-sm min-w-0 flex items-center gap-1.5">
+                      {hasGridActions && <FlaskConical className="h-4 w-4 flex-shrink-0 text-muted-foreground" />}
+                      <span className="truncate">{props.task.name}</span>
+                    </div>
+                  ) : hasGridActions ? (
+                    <div className="font-semibold text-sm min-w-0 flex items-center gap-1.5">
+                      <FlaskConical className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                      <span className="truncate">{props.task.type}</span>
+                    </div>
+                  ) : null}
                   {props.task.description && (
                     <div className="text-sm text-muted-foreground truncate">
                       {props.task.description}
@@ -2560,10 +2570,13 @@ ${categoryLines}${mechanicalLines}
               {variant === 'grid' ? (
                 <div className="flex flex-col items-center gap-1">
                   <div className="flex items-center gap-2">
-                    <div className="text-muted-foreground">
-                      <FlaskConical className="h-[2.25rem] w-[2.25rem]" strokeWidth={1.25} />
-                    </div>
-                    {(onShare || onDelete) && (
+                    {!hasGridActions && (
+                      <div className="text-muted-foreground">
+                        <FlaskConical className="h-[2.25rem] w-[2.25rem]" strokeWidth={1.25} />
+                      </div>
+                    )}
+                    {controlButtons}
+                    {hasInlineActionMenu && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <CardButton
@@ -2598,17 +2611,19 @@ ${categoryLines}${mechanicalLines}
                       </DropdownMenu>
                     )}
                   </div>
-                  <div className="text-xs text-muted-foreground text-center">
-                    {(() => {
-                      const [firstWord, ...restWords] = props.task.type.split(/\s+/);
-                      return (
-                        <>
-                          {firstWord}<br />
-                          {restWords.join(' ')}
-                        </>
-                      );
-                    })()}
-                  </div>
+                  {!hasGridActions && (
+                    <div className="text-xs text-muted-foreground text-center">
+                      {(() => {
+                        const [firstWord, ...restWords] = props.task.type.split(/\s+/);
+                        return (
+                          <>
+                            {firstWord}<br />
+                            {restWords.join(' ')}
+                          </>
+                        );
+                      })()}
+                    </div>
+                  )}
                 </div>
               ) : (
                 <div className="flex gap-2">

--- a/dashboard/components/ProcedureTask.tsx
+++ b/dashboard/components/ProcedureTask.tsx
@@ -1117,11 +1117,18 @@ export default function ProcedureTask({
         </div>
       )
     } else {
+      const hasGridActions = Boolean(controlButtons)
       // Custom header for grid view with bold scorecard/score
       return (
         <div className="space-y-1.5 p-0 flex flex-col items-start w-full max-w-full">
           <div className="flex justify-between items-start w-full max-w-full gap-3 overflow-hidden">
             <div className="flex flex-col pb-1 leading-none min-w-0 flex-1 overflow-hidden">
+              {hasGridActions && (
+                <div className="mb-1 flex items-center gap-1.5 text-sm font-semibold min-w-0">
+                  <Waypoints className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                  <span className="truncate">{props.task.type || 'Procedure'}</span>
+                </div>
+              )}
               {props.task.scorecard && props.task.scorecard.trim() !== '' && (
                 <div className="flex items-center gap-1.5 font-semibold text-sm min-w-0">
                   <span className="truncate">{props.task.scorecard}</span>
@@ -1143,9 +1150,11 @@ export default function ProcedureTask({
             </div>
             <div className="flex flex-col items-end flex-shrink-0">
               <div className="flex items-center gap-2">
-                <div className="text-muted-foreground">
-                  <Waypoints className="h-[2.25rem] w-[2.25rem]" strokeWidth={1.25} />
-                </div>
+                {!hasGridActions && (
+                  <div className="text-muted-foreground">
+                    <Waypoints className="h-[2.25rem] w-[2.25rem]" strokeWidth={1.25} />
+                  </div>
+                )}
                 {controlButtons}
               </div>
             </div>

--- a/dashboard/components/ProceduresGauges.tsx
+++ b/dashboard/components/ProceduresGauges.tsx
@@ -14,21 +14,21 @@ type ProceduresChartPoint = {
 
 // Configuration for procedures-specific gauges.
 const proceduresGaugesConfig: BaseGaugesConfig = {
-  // Use grid layout to match ItemsGauges pattern
+  // Match EvaluationTasksGauges: two gauges side-by-side with the histogram filling the remaining space.
   layout: 'grid',
   gridCols: {
-    base: 1,
-    sm: 2,
-    md: 3,
-    lg: 4,
-    xl: 5
+    base: 2,
+    sm: 3,
+    md: 4,
+    lg: 5,
+    xl: 6
   },
   chartSpan: {
-    base: 1,
+    base: 2,
     sm: 1,
-    md: 1,
-    lg: 2,
-    xl: 3
+    md: 2,
+    lg: 3,
+    xl: 4
   },
   
   gauges: [
@@ -108,17 +108,23 @@ export function ProceduresGauges({
   disableEmergenceAnimation = false,
   onErrorClick
 }: ProceduresGaugesProps) {
+  const [timeRange, setTimeRange] = React.useState<{ start: Date; end: Date; period: 'hour' | 'day' | 'week' } | null>(null)
+
   // Use procedures and evaluations metrics for the Procedures dashboard.
   const { 
     metrics: proceduresMetrics, 
     isLoading: isProceduresLoading, 
     error: proceduresError 
-  } = useProceduresMetrics()
+  } = useProceduresMetrics({
+    timeRange: timeRange || undefined
+  })
   const {
     metrics: evaluationsMetrics,
     isLoading: isEvaluationsLoading,
     error: evaluationsError
-  } = useEvaluationsMetrics()
+  } = useEvaluationsMetrics({
+    timeRange: timeRange || undefined
+  })
 
   const chartDataByTime = new Map<string, ProceduresChartPoint>()
 
@@ -179,6 +185,8 @@ export function ProceduresGauges({
       useRealData={useRealData}
       disableEmergenceAnimation={disableEmergenceAnimation}
       onErrorClick={onErrorClick}
+      enableTimeNavigation={true}
+      onTimeRangeChange={setTimeRange}
     />
   )
 }

--- a/dashboard/components/ProceduresGauges.tsx
+++ b/dashboard/components/ProceduresGauges.tsx
@@ -2,7 +2,15 @@
 
 import React from 'react'
 import { BaseGauges, BaseGaugesConfig, BaseGaugesData } from './BaseGauges'
-import { useProceduresMetrics } from '../hooks/useUnifiedMetrics'
+import { useEvaluationsMetrics, useProceduresMetrics } from '../hooks/useUnifiedMetrics'
+
+type ProceduresChartPoint = {
+  time: string
+  procedures?: number
+  evaluations?: number
+  bucketStart?: string
+  bucketEnd?: string
+}
 
 // Configuration for procedures-specific gauges.
 const proceduresGaugesConfig: BaseGaugesConfig = {
@@ -18,9 +26,9 @@ const proceduresGaugesConfig: BaseGaugesConfig = {
   chartSpan: {
     base: 1,
     sm: 1,
-    md: 2,
-    lg: 3,
-    xl: 4
+    md: 1,
+    lg: 2,
+    xl: 3
   },
   
   gauges: [
@@ -38,6 +46,21 @@ const proceduresGaugesConfig: BaseGaugesConfig = {
         { start: 0, end: 90, color: 'var(--neutral)' },
         { start: 90, end: 100, color: 'var(--false)' }
       ]
+    },
+    {
+      key: 'evaluations',
+      title: 'Evaluations / hour',
+      valueKey: 'evaluationsPerHour',
+      averageKey: 'evaluationsAveragePerHour',
+      peakKey: 'evaluationsPeakHourly',
+      totalKey: 'evaluationsTotal24h',
+      color: 'hsl(var(--chart-2))',
+      unit: '',
+      decimalPlaces: 0,
+      segments: [
+        { start: 0, end: 90, color: 'var(--neutral)' },
+        { start: 90, end: 100, color: 'var(--false)' }
+      ]
     }
   ],
   chartAreas: [
@@ -46,12 +69,22 @@ const proceduresGaugesConfig: BaseGaugesConfig = {
       label: 'Procedures',
       color: 'var(--primary)',
       fillOpacity: 0.8
+    },
+    {
+      dataKey: 'evaluations',
+      label: 'Evaluations',
+      color: 'var(--secondary)',
+      fillOpacity: 0.8
     }
   ],
   chartConfig: {
     procedures: {
       label: 'Procedures',
       color: 'hsl(var(--chart-1))',
+    },
+    evaluations: {
+      label: 'Evaluations',
+      color: 'hsl(var(--chart-2))',
     },
   }
 }
@@ -75,29 +108,63 @@ export function ProceduresGauges({
   disableEmergenceAnimation = false,
   onErrorClick
 }: ProceduresGaugesProps) {
-  // Use procedures metrics.
+  // Use procedures and evaluations metrics for the Procedures dashboard.
   const { 
-    metrics: metricsData, 
-    isLoading, 
-    error 
+    metrics: proceduresMetrics, 
+    isLoading: isProceduresLoading, 
+    error: proceduresError 
   } = useProceduresMetrics()
+  const {
+    metrics: evaluationsMetrics,
+    isLoading: isEvaluationsLoading,
+    error: evaluationsError
+  } = useEvaluationsMetrics()
 
-  // Transform metrics data to BaseGaugesData format
-  const data: BaseGaugesData | null = metricsData ? {
-    // Procedures data
-    proceduresPerHour: metricsData.itemsPerHour || 0,
-    proceduresAveragePerHour: metricsData.itemsAveragePerHour || 0,
-    proceduresPeakHourly: metricsData.itemsPeakHourly || 10, // Use higher baseline for procedures
-    proceduresTotal24h: metricsData.itemsTotal24h || 0,
-    chartData: metricsData.chartData?.map((point: any) => ({
+  const chartDataByTime = new Map<string, ProceduresChartPoint>()
+
+  proceduresMetrics?.chartData?.forEach((point: any) => {
+    chartDataByTime.set(point.time, {
       time: point.time,
-      procedures: point.items || 0, // Map items to procedures for chart display
+      procedures: point.items || 0,
       bucketStart: point.bucketStart,
       bucketEnd: point.bucketEnd
-    })) || [],
-    lastUpdated: metricsData.lastUpdated || new Date(),
-    hasErrorsLast24h: metricsData.hasErrorsLast24h || false,
-    totalErrors24h: metricsData.totalErrors24h || 0
+    })
+  })
+
+  evaluationsMetrics?.chartData?.forEach((point: any) => {
+    const existing: ProceduresChartPoint = chartDataByTime.get(point.time) || { time: point.time }
+    chartDataByTime.set(point.time, {
+      ...existing,
+      evaluations: point.items || 0,
+      bucketStart: existing.bucketStart || point.bucketStart,
+      bucketEnd: existing.bucketEnd || point.bucketEnd
+    })
+  })
+
+  const chartData = Array.from(chartDataByTime.values()).map((point) => ({
+    procedures: 0,
+    evaluations: 0,
+    ...point
+  }))
+
+  // Transform metrics data to BaseGaugesData format
+  const data: BaseGaugesData | null = proceduresMetrics || evaluationsMetrics ? {
+    // Procedures data
+    proceduresPerHour: proceduresMetrics?.itemsPerHour || 0,
+    proceduresAveragePerHour: proceduresMetrics?.itemsAveragePerHour || 0,
+    proceduresPeakHourly: proceduresMetrics?.itemsPeakHourly || 10, // Use higher baseline for procedures
+    proceduresTotal24h: proceduresMetrics?.itemsTotal24h || 0,
+
+    // Evaluations data
+    evaluationsPerHour: evaluationsMetrics?.itemsPerHour || 0,
+    evaluationsAveragePerHour: evaluationsMetrics?.itemsAveragePerHour || 0,
+    evaluationsPeakHourly: evaluationsMetrics?.itemsPeakHourly || 10,
+    evaluationsTotal24h: evaluationsMetrics?.itemsTotal24h || 0,
+
+    chartData,
+    lastUpdated: proceduresMetrics?.lastUpdated || evaluationsMetrics?.lastUpdated || new Date(),
+    hasErrorsLast24h: proceduresMetrics?.hasErrorsLast24h || evaluationsMetrics?.hasErrorsLast24h || false,
+    totalErrors24h: (proceduresMetrics?.totalErrors24h || 0) + (evaluationsMetrics?.totalErrors24h || 0)
   } : null
 
   return (
@@ -105,8 +172,8 @@ export function ProceduresGauges({
       className={className}
       config={proceduresGaugesConfig}
       data={useRealData ? data : null}
-      isLoading={isLoading}
-      error={error}
+      isLoading={isProceduresLoading || isEvaluationsLoading}
+      error={proceduresError || evaluationsError}
       title="Procedures"
       overrideData={overrideData}
       useRealData={useRealData}

--- a/dashboard/components/__tests__/EvaluationTask.memo.test.tsx
+++ b/dashboard/components/__tests__/EvaluationTask.memo.test.tsx
@@ -61,6 +61,32 @@ describe('EvaluationTask memo behavior', () => {
     expect(screen.getByText(/Processing 1 of 4 items/)).toBeInTheDocument()
   })
 
+  test('grid header hides split type label when control actions are present', () => {
+    const data = makeData()
+    const { container } = render(
+      <EvaluationTask
+        variant="grid"
+        task={{ id:'id', type:'Accuracy Evaluation', scorecard:'', score:'', time:new Date().toISOString(), data }}
+        controlButtons={<button type="button" aria-label="Evaluation actions">actions</button>}
+      />
+    )
+
+    expect(screen.getByLabelText('Evaluation actions')).toBeInTheDocument()
+    expect(container.querySelectorAll('br').length).toBe(0)
+  })
+
+  test('grid header keeps split type label when no actions are present', () => {
+    const data = makeData()
+    const { container } = render(
+      <EvaluationTask
+        variant="grid"
+        task={{ id:'id', type:'Accuracy Evaluation', scorecard:'', score:'', time:new Date().toISOString(), data }}
+      />
+    )
+
+    expect(container.querySelectorAll('br').length).toBeGreaterThan(0)
+  })
+
   test('DetailContent re-renders on stage change', () => {
     const stages = {
       items: [

--- a/dashboard/components/__tests__/ProcedureTask.optimizer-auth.test.tsx
+++ b/dashboard/components/__tests__/ProcedureTask.optimizer-auth.test.tsx
@@ -167,6 +167,22 @@ describe('ProcedureTask optimizer auth flow', () => {
     )
   })
 
+  it('shows compact left icon/title in grid header when action controls are present', () => {
+    render(
+      <ProcedureTask
+        variant="grid"
+        procedure={{
+          ...baseProcedure,
+          description: 'Procedure note for action layout',
+        } as any}
+        controlButtons={<button type="button" aria-label="Procedure actions">actions</button>}
+      />
+    )
+
+    expect(screen.getByLabelText('Procedure actions')).toBeInTheDocument()
+    expect(screen.getByText(/^Procedure$/)).toBeInTheDocument()
+  })
+
   it('hydrates offloaded optimizer state from Amplify Storage procedures path', async () => {
     const metadataState = {
       state: {

--- a/dashboard/components/__tests__/ProceduresGauges.test.tsx
+++ b/dashboard/components/__tests__/ProceduresGauges.test.tsx
@@ -77,7 +77,10 @@ describe('ProceduresGauges', () => {
 
     const call = mockBaseGauges.mock.calls[0][0]
     expect(call.config.gauges).toHaveLength(2)
+    expect(call.config.gridCols).toEqual({ base: 2, sm: 3, md: 4, lg: 5, xl: 6 })
+    expect(call.config.chartSpan).toEqual({ base: 2, sm: 1, md: 2, lg: 3, xl: 4 })
     expect(call.config.chartAreas.map((area: any) => area.dataKey)).toEqual(['procedures', 'evaluations'])
+    expect(call.enableTimeNavigation).toBe(true)
     expect(call.data.proceduresPerHour).toBe(2)
     expect(call.data.evaluationsPerHour).toBe(3)
     expect(call.data.chartData).toEqual([

--- a/dashboard/components/__tests__/ProceduresGauges.test.tsx
+++ b/dashboard/components/__tests__/ProceduresGauges.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ProceduresGauges } from '../ProceduresGauges'
+import { BaseGauges } from '../BaseGauges'
+import { useEvaluationsMetrics, useProceduresMetrics } from '@/hooks/useUnifiedMetrics'
+
+jest.mock('../BaseGauges', () => ({
+  BaseGauges: jest.fn(({ config, data }) => (
+    <div data-testid="base-gauges">
+      <div>{config.gauges.map((gauge: any) => gauge.title).join('|')}</div>
+      <pre data-testid="base-gauges-data">{JSON.stringify(data)}</pre>
+    </div>
+  )),
+}))
+
+jest.mock('@/hooks/useUnifiedMetrics', () => ({
+  useProceduresMetrics: jest.fn(),
+  useEvaluationsMetrics: jest.fn(),
+}))
+
+const mockUseProceduresMetrics = useProceduresMetrics as jest.Mock
+const mockUseEvaluationsMetrics = useEvaluationsMetrics as jest.Mock
+const mockBaseGauges = BaseGauges as jest.Mock
+
+describe('ProceduresGauges', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseProceduresMetrics.mockReturnValue({
+      metrics: {
+        itemsPerHour: 2,
+        itemsAveragePerHour: 1,
+        itemsPeakHourly: 10,
+        itemsTotal24h: 12,
+        chartData: [
+          {
+            time: '10:00',
+            items: 2,
+            bucketStart: '2026-04-27T10:00:00.000Z',
+            bucketEnd: '2026-04-27T11:00:00.000Z',
+          },
+        ],
+        lastUpdated: new Date('2026-04-27T11:00:00.000Z'),
+        hasErrorsLast24h: false,
+        totalErrors24h: 0,
+      },
+      isLoading: false,
+      error: null,
+    })
+    mockUseEvaluationsMetrics.mockReturnValue({
+      metrics: {
+        itemsPerHour: 3,
+        itemsAveragePerHour: 2,
+        itemsPeakHourly: 10,
+        itemsTotal24h: 18,
+        chartData: [
+          {
+            time: '10:00',
+            items: 3,
+            bucketStart: '2026-04-27T10:00:00.000Z',
+            bucketEnd: '2026-04-27T11:00:00.000Z',
+          },
+        ],
+        lastUpdated: new Date('2026-04-27T11:00:00.000Z'),
+        hasErrorsLast24h: false,
+        totalErrors24h: 0,
+      },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('renders procedures and evaluations rate gauges from one chart payload', () => {
+    render(<ProceduresGauges />)
+
+    expect(screen.getByText('Procedures / hour|Evaluations / hour')).toBeInTheDocument()
+
+    const call = mockBaseGauges.mock.calls[0][0]
+    expect(call.config.gauges).toHaveLength(2)
+    expect(call.config.chartAreas.map((area: any) => area.dataKey)).toEqual(['procedures', 'evaluations'])
+    expect(call.data.proceduresPerHour).toBe(2)
+    expect(call.data.evaluationsPerHour).toBe(3)
+    expect(call.data.chartData).toEqual([
+      expect.objectContaining({
+        time: '10:00',
+        procedures: 2,
+        evaluations: 3,
+      }),
+    ])
+  })
+})

--- a/dashboard/components/ui/__tests__/score-evaluation-list.test.tsx
+++ b/dashboard/components/ui/__tests__/score-evaluation-list.test.tsx
@@ -112,6 +112,7 @@ describe('ScoreEvaluationList', () => {
   })
 
   it('renders score-scoped evaluations with metrics and actions', async () => {
+    const user = userEvent.setup()
     render(<ScoreEvaluationList scoreId="score-1" scope="score" />)
 
     await waitFor(() => {
@@ -120,7 +121,10 @@ describe('ScoreEvaluationList', () => {
 
     expect(screen.getAllByText(/Feedback · COMPLETED/i).length).toBeGreaterThan(0)
     expect(screen.getByTestId('notes-eval-1')).toHaveTextContent('Evaluation note 1')
-    expect(screen.getAllByRole('link', { name: /^Open$/i })[0]).toHaveAttribute('href', '/lab/evaluations/eval-1')
+    await user.click(screen.getAllByRole('button', { name: /more options/i })[0])
+    expect(screen.getByRole('menuitem', { name: /open evaluation/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /copy evaluation path/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /copy evaluation id/i })).toBeInTheDocument()
   })
 
   it('filters version-scoped evaluations to the selected version', async () => {

--- a/dashboard/components/ui/score-evaluation-list.tsx
+++ b/dashboard/components/ui/score-evaluation-list.tsx
@@ -2,10 +2,11 @@
 
 import * as React from 'react'
 import { generateClient } from 'aws-amplify/api'
-import { Copy, ExternalLink } from 'lucide-react'
+import { Copy, ExternalLink, MoreHorizontal } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import EvaluationTask, { type EvaluationTaskData } from '@/components/EvaluationTask'
 import { cn } from '@/lib/utils'
 import {
@@ -518,22 +519,38 @@ export function ScoreEvaluationList({
                   data: toEvaluationTaskData(evaluation),
                 }}
                 controlButtons={
-                  <div className="flex flex-wrap items-center justify-end gap-2">
-                    <Button variant="secondary" size="sm" asChild>
-                      <a href={`/lab/evaluations/${evaluation.id}`} target="_blank" rel="noreferrer">
-                        <ExternalLink className="mr-2 h-3.5 w-3.5" />
-                        Open
-                      </a>
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => void copyText(`/lab/evaluations/${evaluation.id}`, 'Evaluation path copied')}
-                    >
-                      <Copy className="mr-2 h-3.5 w-3.5" />
-                      Path
-                    </Button>
-                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 rounded-md bg-border"
+                        aria-label="More options"
+                      >
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem asChild>
+                        <a href={`/lab/evaluations/${evaluation.id}`} target="_blank" rel="noreferrer">
+                          <ExternalLink className="mr-2 h-3.5 w-3.5" />
+                          Open evaluation
+                        </a>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onSelect={() => void copyText(`/lab/evaluations/${evaluation.id}`, 'Evaluation path copied')}
+                      >
+                        <Copy className="mr-2 h-3.5 w-3.5" />
+                        Copy evaluation path
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onSelect={() => void copyText(evaluation.id, 'Evaluation ID copied')}
+                      >
+                        <Copy className="mr-2 h-3.5 w-3.5" />
+                        Copy evaluation ID
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 }
               />
             </div>

--- a/dashboard/hooks/useUnifiedMetrics.ts
+++ b/dashboard/hooks/useUnifiedMetrics.ts
@@ -694,11 +694,22 @@ export function useTaskMetrics(config: MetricsConfig = {}): UseUnifiedMetricsRes
 /**
  * Hook for procedures metrics.
  */
-export function useProceduresMetrics(): UseUnifiedMetricsResult {
+export function useProceduresMetrics(config: MetricsConfig = {}): UseUnifiedMetricsResult {
   const { selectedAccount } = useAccount()
   const [metrics, setMetrics] = useState<UnifiedMetricsData | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  const memoizedConfig = useMemo(() => config, [
+    JSON.stringify({
+      ...config,
+      timeRange: config.timeRange ? {
+        start: config.timeRange.start.getTime(),
+        end: config.timeRange.end.getTime(),
+        period: config.timeRange.period
+      } : undefined
+    })
+  ])
 
   const fetchMetrics = useCallback(async () => {
     if (!selectedAccount) {
@@ -713,19 +724,23 @@ export function useProceduresMetrics(): UseUnifiedMetricsResult {
 
     try {
       const now = new Date()
-      const last24h = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-      const last60min = new Date(now.getTime() - 60 * 60 * 1000)
+      const chartEnd = memoizedConfig.timeRange?.end || now
+      const chartStart = memoizedConfig.timeRange?.start || new Date(chartEnd.getTime() - 24 * 60 * 60 * 1000)
+      const gaugeEnd = chartEnd
+      const gaugeStart = new Date(gaugeEnd.getTime() - 60 * 60 * 1000)
+      const dailyStart = new Date(chartEnd.getTime() - 24 * 60 * 60 * 1000)
+      const dailyEnd = chartEnd
 
-      const proceduresRecords = await queryAggregatedMetrics(selectedAccount.id, 'procedures', last24h, now)
+      const proceduresRecords = await queryAggregatedMetrics(selectedAccount.id, 'procedures', chartStart, chartEnd)
 
       // Calculate hourly metrics (last 60 minutes)
-      const proceduresHourly = calculateMetricsFromRecords(proceduresRecords, last60min, now)
+      const proceduresHourly = calculateMetricsFromRecords(proceduresRecords, gaugeStart, gaugeEnd)
 
       // Calculate 24h totals
-      const procedures24h = calculateMetricsFromRecords(proceduresRecords, last24h, now)
+      const procedures24h = calculateMetricsFromRecords(proceduresRecords, dailyStart, dailyEnd)
 
       // Generate chart data
-      const chartData = generateChartData(proceduresRecords, [], last24h, now, 'day')
+      const chartData = generateChartData(proceduresRecords, [], chartStart, chartEnd, memoizedConfig.timeRange?.period || 'day')
 
       // Calculate peaks with higher baselines for procedures
       const itemsPeak = Math.max(...chartData.map(point => point.items), 10) // Minimum 10 for procedures
@@ -750,7 +765,7 @@ export function useProceduresMetrics(): UseUnifiedMetricsResult {
         scoreResultsTotal24h: 0,
 
         chartData,
-        lastUpdated: now,
+        lastUpdated: chartEnd,
         hasErrorsLast24h,
         totalErrors24h
       }
@@ -762,7 +777,7 @@ export function useProceduresMetrics(): UseUnifiedMetricsResult {
       setError(err instanceof Error ? err.message : 'Failed to fetch metrics')
       setIsLoading(false)
     }
-  }, [selectedAccount])
+  }, [selectedAccount, memoizedConfig])
 
   // Initial fetch and periodic refresh
   useEffect(() => {

--- a/infrastructure/lambda_functions/metrics_aggregator/README.md
+++ b/infrastructure/lambda_functions/metrics_aggregator/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This Lambda function replaces the client-side metrics aggregation system with a serverless cloud-based solution. It provides **real-time** aggregation of counts for Items, Score Results, Tasks, and Evaluations with minimal latency.
+This Lambda function replaces the client-side metrics aggregation system with a serverless cloud-based solution. It provides **real-time** aggregation of counts for Items, Score Results, Tasks, Evaluations, and Procedures with minimal latency.
 
 ## Architecture
 
@@ -38,6 +38,7 @@ Update AggregatedMetrics table
   - Score Results: 100 records or 15 seconds
   - Tasks: 1 record or 15 seconds
   - Evaluations: 1 record or 15 seconds
+  - Procedures: 1 record or 15 seconds
 
 ### 4. **Hierarchical Buckets**
 - **1-minute**: Most granular, directly counted
@@ -211,4 +212,3 @@ Processing items for account acc-abc123...
 3. **Verify**: Compare counts with client-side system during transition period
 4. **Disable**: Once verified, remove client-side aggregation code
 5. **Optimize**: If needed, add caching or reduce query window based on actual usage patterns
-

--- a/infrastructure/lambda_functions/metrics_aggregator/aggregator.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/aggregator.py
@@ -84,7 +84,7 @@ class MetricsAggregator:
             event_source_arn: DynamoDB stream ARN
             
         Returns:
-            Record type string ('items', 'scoreResults', 'tasks', 'evaluations')
+            Record type string ('items', 'scoreResults', 'tasks', 'evaluations', 'procedures')
         """
         arn_lower = event_source_arn.lower()
         
@@ -96,6 +96,8 @@ class MetricsAggregator:
             return 'tasks'
         elif 'evaluation' in arn_lower:
             return 'evaluations'
+        elif 'procedure' in arn_lower:
+            return 'procedures'
         
         return ''
     
@@ -227,4 +229,3 @@ def process_stream_batch(records: List[Dict[str, Any]]) -> Dict[str, List[Dict[s
     """
     aggregator = MetricsAggregator()
     return aggregator.process_stream_records(records)
-

--- a/infrastructure/lambda_functions/metrics_aggregator/bucket_counter.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/bucket_counter.py
@@ -27,7 +27,7 @@ class BucketCounter:
         
         Args:
             account_id: Account ID for these metrics
-            record_type: Type of records ('items', 'scoreResults', 'tasks', 'evaluations')
+            record_type: Type of records ('items', 'scoreResults', 'tasks', 'evaluations', 'procedures')
         """
         self.account_id = account_id
         self.record_type = record_type
@@ -213,4 +213,3 @@ def parse_iso_datetime(timestamp_str: str) -> datetime:
     except (ValueError, AttributeError):
         # Fall back to current time if parsing fails
         return datetime.now(timezone.utc)
-

--- a/infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py
@@ -1,4 +1,5 @@
 import sys
+import importlib.util
 from pathlib import Path
 
 
@@ -8,8 +9,28 @@ sys.path.insert(0, str(METRICS_DIR))
 sys.path.insert(0, str(INFRA_DIR))
 
 from handler import determine_record_type
-from stacks.metrics_aggregation_stack import METRICS_STREAM_CONFIGS, METRICS_TABLE_TYPES
-from stacks.shared.amplify_discovery import METRICS_TABLE_PATTERNS
+
+
+def load_module_from_path(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+metrics_config = load_module_from_path(
+    "metrics_aggregation_config",
+    INFRA_DIR / "stacks" / "metrics_aggregation_config.py",
+)
+amplify_discovery = load_module_from_path(
+    "amplify_discovery",
+    INFRA_DIR / "stacks" / "shared" / "amplify_discovery.py",
+)
+
+METRICS_STREAM_CONFIGS = metrics_config.METRICS_STREAM_CONFIGS
+METRICS_TABLE_TYPES = metrics_config.METRICS_TABLE_TYPES
+METRICS_TABLE_PATTERNS = amplify_discovery.METRICS_TABLE_PATTERNS
 
 
 def test_procedure_streams_are_classified_as_procedures():

--- a/infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+
+METRICS_DIR = Path(__file__).resolve().parent
+INFRA_DIR = METRICS_DIR.parents[1]
+sys.path.insert(0, str(METRICS_DIR))
+sys.path.insert(0, str(INFRA_DIR))
+
+from handler import determine_record_type
+from stacks.metrics_aggregation_stack import METRICS_STREAM_CONFIGS, METRICS_TABLE_TYPES
+from stacks.shared.amplify_discovery import METRICS_TABLE_PATTERNS
+
+
+def test_procedure_streams_are_classified_as_procedures():
+    arn = "arn:aws:dynamodb:us-west-2:123456789012:table/Procedure-abc123/stream/2026-04-27T00:00:00.000"
+
+    assert determine_record_type(arn) == "procedures"
+
+
+def test_metrics_stack_subscribes_to_procedure_table_stream():
+    assert "procedure" in METRICS_TABLE_TYPES
+    assert METRICS_STREAM_CONFIGS["procedure"] == {"batch_size": 1, "batch_window": 15}
+
+
+def test_amplify_discovery_includes_procedure_table():
+    assert METRICS_TABLE_PATTERNS["procedure"] == "Procedure"

--- a/infrastructure/scripts/create-secrets-production.sh
+++ b/infrastructure/scripts/create-secrets-production.sh
@@ -48,7 +48,10 @@ SECRET_VALUE=$(cat <<EOF
   "table-task-stream-arn": "${TABLE_TASK_STREAM_ARN:-}",
   "table-evaluation-name": "${TABLE_EVALUATION_NAME:-}",
   "table-evaluation-arn": "${TABLE_EVALUATION_ARN:-}",
-  "table-evaluation-stream-arn": "${TABLE_EVALUATION_STREAM_ARN:-}"
+  "table-evaluation-stream-arn": "${TABLE_EVALUATION_STREAM_ARN:-}",
+  "table-procedure-name": "${TABLE_PROCEDURE_NAME:-}",
+  "table-procedure-arn": "${TABLE_PROCEDURE_ARN:-}",
+  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}"
 }
 EOF
 )

--- a/infrastructure/scripts/create-secrets-staging.sh
+++ b/infrastructure/scripts/create-secrets-staging.sh
@@ -48,7 +48,10 @@ SECRET_VALUE=$(cat <<EOF
   "table-task-stream-arn": "${TABLE_TASK_STREAM_ARN:-}",
   "table-evaluation-name": "${TABLE_EVALUATION_NAME:-}",
   "table-evaluation-arn": "${TABLE_EVALUATION_ARN:-}",
-  "table-evaluation-stream-arn": "${TABLE_EVALUATION_STREAM_ARN:-}"
+  "table-evaluation-stream-arn": "${TABLE_EVALUATION_STREAM_ARN:-}",
+  "table-procedure-name": "${TABLE_PROCEDURE_NAME:-}",
+  "table-procedure-arn": "${TABLE_PROCEDURE_ARN:-}",
+  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}"
 }
 EOF
 )

--- a/infrastructure/stacks/metrics_aggregation_config.py
+++ b/infrastructure/stacks/metrics_aggregation_config.py
@@ -1,0 +1,9 @@
+METRICS_TABLE_TYPES = ['item', 'scoreresult', 'task', 'evaluation', 'procedure']
+
+METRICS_STREAM_CONFIGS = {
+    'item': {'batch_size': 10, 'batch_window': 15},
+    'scoreresult': {'batch_size': 100, 'batch_window': 15},
+    'task': {'batch_size': 1, 'batch_window': 15},
+    'evaluation': {'batch_size': 1, 'batch_window': 15},
+    'procedure': {'batch_size': 1, 'batch_window': 15},
+}

--- a/infrastructure/stacks/metrics_aggregation_stack.py
+++ b/infrastructure/stacks/metrics_aggregation_stack.py
@@ -22,6 +22,17 @@ from .shared.naming import get_resource_name
 from .shared.config import EnvironmentConfig
 
 
+METRICS_TABLE_TYPES = ['item', 'scoreresult', 'task', 'evaluation', 'procedure']
+
+METRICS_STREAM_CONFIGS = {
+    'item': {'batch_size': 10, 'batch_window': 15},
+    'scoreresult': {'batch_size': 100, 'batch_window': 15},
+    'task': {'batch_size': 1, 'batch_window': 15},
+    'evaluation': {'batch_size': 1, 'batch_window': 15},
+    'procedure': {'batch_size': 1, 'batch_window': 15},
+}
+
+
 class MetricsAggregationStack(Stack):
     """
     CDK Stack for metrics aggregation Lambda function.
@@ -65,7 +76,7 @@ class MetricsAggregationStack(Stack):
 
         # Build tables dict from Secrets Manager configuration
         tables = {}
-        table_types = ['item', 'scoreresult', 'task', 'evaluation']
+        table_types = METRICS_TABLE_TYPES
 
         for table_type in table_types:
             secret_prefix = f"table-{table_type.lower()}"
@@ -184,12 +195,7 @@ class MetricsAggregationStack(Stack):
         )
         
         # Configure stream event sources with table-specific batch settings
-        stream_configs = {
-            'item': {'batch_size': 10, 'batch_window': 15},
-            'scoreresult': {'batch_size': 100, 'batch_window': 15},  # Fixed: lowercase to match table_types
-            'task': {'batch_size': 1, 'batch_window': 15},
-            'evaluation': {'batch_size': 1, 'batch_window': 15}
-        }
+        stream_configs = METRICS_STREAM_CONFIGS
         
         # Add event sources for each discovered table
         for table_key, table_info in tables.items():
@@ -225,4 +231,3 @@ class MetricsAggregationStack(Stack):
             print(f"Added stream event source for {table_key}: "
                   f"batch_size={config_data['batch_size']}, "
                   f"batch_window={config_data['batch_window']}s")
-

--- a/infrastructure/stacks/metrics_aggregation_stack.py
+++ b/infrastructure/stacks/metrics_aggregation_stack.py
@@ -20,17 +20,7 @@ import os
 
 from .shared.naming import get_resource_name
 from .shared.config import EnvironmentConfig
-
-
-METRICS_TABLE_TYPES = ['item', 'scoreresult', 'task', 'evaluation', 'procedure']
-
-METRICS_STREAM_CONFIGS = {
-    'item': {'batch_size': 10, 'batch_window': 15},
-    'scoreresult': {'batch_size': 100, 'batch_window': 15},
-    'task': {'batch_size': 1, 'batch_window': 15},
-    'evaluation': {'batch_size': 1, 'batch_window': 15},
-    'procedure': {'batch_size': 1, 'batch_window': 15},
-}
+from .metrics_aggregation_config import METRICS_STREAM_CONFIGS, METRICS_TABLE_TYPES
 
 
 class MetricsAggregationStack(Stack):

--- a/infrastructure/stacks/shared/amplify_discovery.py
+++ b/infrastructure/stacks/shared/amplify_discovery.py
@@ -10,6 +10,15 @@ from typing import Dict, Optional, List
 from botocore.exceptions import ClientError
 
 
+METRICS_TABLE_PATTERNS = {
+    'item': 'Item',
+    'scoreResult': 'ScoreResult',
+    'task': 'Task',
+    'evaluation': 'Evaluation',
+    'procedure': 'Procedure'
+}
+
+
 class AmplifyTableDiscovery:
     """
     Discovers DynamoDB table ARNs from Amplify CloudFormation stacks.
@@ -119,7 +128,7 @@ class AmplifyTableDiscovery:
                            resource['ResourceType'] == 'Custom::AmplifyDynamoDBTable')
                 
                 # Match pattern in logical ID - look for exact match with "Table" suffix
-                # e.g., "ItemTable", "ScoreResultTable", "TaskTable", "EvaluationTable"
+                # e.g., "ItemTable", "ScoreResultTable", "TaskTable", "EvaluationTable", "ProcedureTable"
                 matches_pattern = (f"{logical_id_pattern}Table" == resource['LogicalResourceId'])
                 
                 if is_table and matches_pattern:
@@ -248,7 +257,7 @@ def discover_tables_for_metrics_aggregation(region: str = 'us-west-2',
                       If not provided, will use AMPLIFY_STACK_PATTERN env var.
         
     Returns:
-        Dict with 'item', 'scoreResult', 'task', 'evaluation' table information
+        Dict with 'item', 'scoreResult', 'task', 'evaluation', and 'procedure' table information
         
     Raises:
         ValueError: If stack_pattern is not provided and AMPLIFY_STACK_PATTERN env var is not set
@@ -266,14 +275,7 @@ def discover_tables_for_metrics_aggregation(region: str = 'us-west-2',
     
     discovery = AmplifyTableDiscovery(region=region)
     
-    table_patterns = {
-        'item': 'Item',
-        'scoreResult': 'ScoreResult',
-        'task': 'Task',
-        'evaluation': 'Evaluation'
-    }
-    
-    return discovery.discover_amplify_tables(table_patterns, stack_pattern)
+    return discovery.discover_amplify_tables(METRICS_TABLE_PATTERNS, stack_pattern)
 
 
 if __name__ == '__main__':
@@ -287,4 +289,3 @@ if __name__ == '__main__':
         print(f"  Table Name: {info['table_name']}")
         print(f"  Table ARN: {info['table_arn']}")
         print(f"  Stream ARN: {info['stream_arn']}")
-

--- a/project/events/2026-04-27T15:07:53.197Z__090368fc-1724-4a92-ab4f-268279ae036a.json
+++ b/project/events/2026-04-27T15:07:53.197Z__090368fc-1724-4a92-ab4f-268279ae036a.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "090368fc-1724-4a92-ab4f-268279ae036a",
+  "issue_id": "plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T15:07:53.197Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Replace removed graph-node gauge slot with evaluations-rate gauge on Procedures dashboard, and validate/fix AggregatedMetrics procedure counting so procedure-rate gauge is accurate.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "task Add evaluations rate gauge to procedures dashboard and verify procedures aggregation"
+  }
+}

--- a/project/events/2026-04-27T16:06:56.311Z__524b3f7f-5d2d-4fbd-8976-b84ba6361fc8.json
+++ b/project/events/2026-04-27T16:06:56.311Z__524b3f7f-5d2d-4fbd-8976-b84ba6361fc8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "524b3f7f-5d2d-4fbd-8976-b84ba6361fc8",
+  "issue_id": "plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-27T16:06:56.311Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-27T16:22:17.766Z__5880a12b-4443-41f4-87aa-64daad3d4f58.json
+++ b/project/events/2026-04-27T16:22:17.766Z__5880a12b-4443-41f4-87aa-64daad3d4f58.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5880a12b-4443-41f4-87aa-64daad3d4f58",
+  "issue_id": "plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T16:22:17.766Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e11f02ea-a86a-4f26-b2e2-9acbd985aa95"
+  }
+}

--- a/project/events/2026-04-27T16:38:18.324Z__d2fa8634-bf03-4275-8493-ce86d8529ff5.json
+++ b/project/events/2026-04-27T16:38:18.324Z__d2fa8634-bf03-4275-8493-ce86d8529ff5.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d2fa8634-bf03-4275-8493-ce86d8529ff5",
+  "issue_id": "plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T16:38:18.324Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "239cd11c-4a5e-454a-b0af-2721f0b7651b"
+  }
+}

--- a/project/events/2026-04-27T17:06:56.013Z__c3870e2e-cc1a-4116-b1fe-4ef45d0fde98.json
+++ b/project/events/2026-04-27T17:06:56.013Z__c3870e2e-cc1a-4116-b1fe-4ef45d0fde98.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c3870e2e-cc1a-4116-b1fe-4ef45d0fde98",
+  "issue_id": "plx-f5ecc301-2d85-430d-8d66-611a8d6e364c",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T17:06:56.013Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": null,
+    "priority": 2,
+    "status": "open",
+    "title": "Unify procedure and evaluation card actions/icon placement"
+  }
+}

--- a/project/events/2026-04-27T17:07:03.919Z__551be688-ab81-4530-a0e1-8a3367462f71.json
+++ b/project/events/2026-04-27T17:07:03.919Z__551be688-ab81-4530-a0e1-8a3367462f71.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "551be688-ab81-4530-a0e1-8a3367462f71",
+  "issue_id": "plx-f5ecc301-2d85-430d-8d66-611a8d6e364c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-27T17:07:03.919Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-27T17:10:11.876Z__51f02f3c-a588-4a74-affd-fd9a8311ccd1.json
+++ b/project/events/2026-04-27T17:10:11.876Z__51f02f3c-a588-4a74-affd-fd9a8311ccd1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "51f02f3c-a588-4a74-affd-fd9a8311ccd1",
+  "issue_id": "plx-f5ecc301-2d85-430d-8d66-611a8d6e364c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T17:10:11.876Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "33a9632b-9f35-4ba2-9744-69ffe473a744"
+  }
+}

--- a/project/issues/plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7.json
+++ b/project/issues/plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7.json
@@ -16,10 +16,16 @@
       "author": "ryan",
       "text": "Implemented first pass: ProceduresGauges now displays Procedures/hour plus Evaluations/hour from AggregatedMetrics, and metrics aggregation infra now discovers/subscribes to the Procedure table stream. Local validation passing: ProceduresGauges Jest test, metrics aggregator pytest, dashboard typecheck, and metrics CDK synth.",
       "created_at": "2026-04-27T16:22:17.765841Z"
+    },
+    {
+      "id": "239cd11c-4a5e-454a-b0af-2721f0b7651b",
+      "author": "ryan",
+      "text": "Adjusted Procedures dashboard gauges to mirror the Evaluations dashboard two-gauge plus histogram layout and added time-range support to procedure metrics so both procedures and evaluations series navigate together.",
+      "created_at": "2026-04-27T16:38:18.323679Z"
     }
   ],
   "created_at": "2026-04-27T15:07:53.196191Z",
-  "updated_at": "2026-04-27T16:22:17.765841Z",
+  "updated_at": "2026-04-27T16:38:18.323679Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7.json
+++ b/project/issues/plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-c2025a41-fc9e-4312-ae9c-1ebdab2ab4a7",
+  "title": "task Add evaluations rate gauge to procedures dashboard and verify procedures aggregation",
+  "description": "Replace removed graph-node gauge slot with evaluations-rate gauge on Procedures dashboard, and validate/fix AggregatedMetrics procedure counting so procedure-rate gauge is accurate.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "e11f02ea-a86a-4f26-b2e2-9acbd985aa95",
+      "author": "ryan",
+      "text": "Implemented first pass: ProceduresGauges now displays Procedures/hour plus Evaluations/hour from AggregatedMetrics, and metrics aggregation infra now discovers/subscribes to the Procedure table stream. Local validation passing: ProceduresGauges Jest test, metrics aggregator pytest, dashboard typecheck, and metrics CDK synth.",
+      "created_at": "2026-04-27T16:22:17.765841Z"
+    }
+  ],
+  "created_at": "2026-04-27T15:07:53.196191Z",
+  "updated_at": "2026-04-27T16:22:17.765841Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-f5ecc301-2d85-430d-8d66-611a8d6e364c.json
+++ b/project/issues/plx-f5ecc301-2d85-430d-8d66-611a8d6e364c.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-f5ecc301-2d85-430d-8d66-611a8d6e364c",
+  "title": "Unify procedure and evaluation card actions/icon placement",
+  "description": "",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "33a9632b-9f35-4ba2-9744-69ffe473a744",
+      "author": "ryan",
+      "text": "Implemented score evaluation list action menu, unified grid icon placement behavior for ProcedureTask/EvaluationTask when actions are present, and added focused tests for menu behavior plus grid header action/icon state.",
+      "created_at": "2026-04-27T17:10:11.875441Z"
+    }
+  ],
+  "created_at": "2026-04-27T17:06:56.013494Z",
+  "updated_at": "2026-04-27T17:10:11.875441Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- add an `Evaluations / hour` gauge to the Procedures dashboard alongside `Procedures / hour`
- merge procedure and evaluation AggregatedMetrics series into one Procedures dashboard chart
- wire Procedure table streams into the metrics aggregation CDK stack so `recordType="procedures"` can actually be populated
- add focused dashboard and metrics aggregator tests

## Validation
- `npm test -- ProceduresGauges.test.tsx --runInBand` in `dashboard`
- `npm run typecheck` in `dashboard`
- `pytest infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py -q`
- `npx cdk synth --app "python3 deploy_metrics_only.py" plexus-metrics-aggregation-production` in `infrastructure`

## Notes
- CDK synth confirmed the generated template includes a Procedure table `AWS::Lambda::EventSourceMapping` using `table-procedure-stream-arn`.
- Synth emitted existing local Node/CDK and pip dependency warnings, but completed successfully.
