### PR TITLE
Add ScoreVersion metadata and featured index

### DIFF
--- a/dashboard/amplify/data/resource.ts
+++ b/dashboard/amplify/data/resource.ts
@@ -202,6 +202,7 @@ const schema = a.schema({
             updatedAt: a.datetime().required(),
             note: a.string(),
             branch: a.string(),
+            metadata: a.json(),
             scoreResults: a.hasMany('ScoreResult', 'scoreVersionId'),
             scoresAsChampion: a.hasMany('Score', 'championVersionId'),
             parentVersionId: a.string(),
@@ -216,7 +217,8 @@ const schema = a.schema({
             allow.authenticated()
         ])
         .secondaryIndexes((idx) => [
-            idx("scoreId").sortKeys(["createdAt"])
+            idx("scoreId").sortKeys(["createdAt"]),
+            idx("scoreId").sortKeys(["isFeatured", "createdAt"]).name("byScoreIdAndIsFeaturedAndCreatedAt")
         ]),
 
     Evaluation: a

--- a/project/events/2026-04-27T18:14:11.622Z__fe2d63ea-82b0-4bda-ac6b-e8d8b3931dd1.json
+++ b/project/events/2026-04-27T18:14:11.622Z__fe2d63ea-82b0-4bda-ac6b-e8d8b3931dd1.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "fe2d63ea-82b0-4bda-ac6b-e8d8b3931dd1",
+  "issue_id": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T18:14:11.622Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "ScoreVersion management: pinning, diffs, and champion history"
+  }
+}

--- a/project/events/2026-04-27T18:14:17.813Z__9628a7fe-5c15-4093-895d-59c7155c7948.json
+++ b/project/events/2026-04-27T18:14:17.813Z__9628a7fe-5c15-4093-895d-59c7155c7948.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9628a7fe-5c15-4093-895d-59c7155c7948",
+  "issue_id": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-27T18:14:17.813Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-27T18:14:17.839Z__5c5358ec-9cf3-46e8-92b5-63614055ff61.json
+++ b/project/events/2026-04-27T18:14:17.839Z__5c5358ec-9cf3-46e8-92b5-63614055ff61.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5c5358ec-9cf3-46e8-92b5-63614055ff61",
+  "issue_id": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T18:14:17.839Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "ac1db483-912e-4f2f-80f6-521a67f05070"
+  }
+}

--- a/project/events/2026-04-27T18:14:23.121Z__5b99a92b-ddb3-4f53-9b2a-c3c9066390bb.json
+++ b/project/events/2026-04-27T18:14:23.121Z__5b99a92b-ddb3-4f53-9b2a-c3c9066390bb.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "5b99a92b-ddb3-4f53-9b2a-c3c9066390bb",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T18:14:23.121Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Implement ScoreVersion management schema and tools"
+  }
+}

--- a/project/events/2026-04-27T18:14:23.121Z__c58d1a07-8bda-4257-8bfc-912099bb78c8.json
+++ b/project/events/2026-04-27T18:14:23.121Z__c58d1a07-8bda-4257-8bfc-912099bb78c8.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c58d1a07-8bda-4257-8bfc-912099bb78c8",
+  "issue_id": "plx-e2dbaa5b-91fc-4b3d-a8cb-e1d77c836bf4",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T18:14:23.121Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Track champion production history"
+  }
+}

--- a/project/events/2026-04-27T18:14:23.121Z__dc18b6db-0060-4781-a888-24c50b9431bb.json
+++ b/project/events/2026-04-27T18:14:23.121Z__dc18b6db-0060-4781-a888-24c50b9431bb.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "dc18b6db-0060-4781-a888-24c50b9431bb",
+  "issue_id": "plx-ad6b3884-24c3-4c0e-a699-753f3cf7729b",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T18:14:23.121Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Compare arbitrary score versions"
+  }
+}

--- a/project/events/2026-04-27T18:14:23.121Z__f7293646-010d-4937-b2e4-875a7fef268a.json
+++ b/project/events/2026-04-27T18:14:23.121Z__f7293646-010d-4937-b2e4-875a7fef268a.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "f7293646-010d-4937-b2e4-875a7fef268a",
+  "issue_id": "plx-fb52fc85-7e60-4999-a558-96e3b5bae143",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T18:14:23.121Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Star important score versions"
+  }
+}

--- a/project/events/2026-04-27T18:14:34.849Z__5e226fbf-7809-4ea3-9fa1-c7590c7dbc5d.json
+++ b/project/events/2026-04-27T18:14:34.849Z__5e226fbf-7809-4ea3-9fa1-c7590c7dbc5d.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "5e226fbf-7809-4ea3-9fa1-c7590c7dbc5d",
+  "issue_id": "plx-fb52fc85-7e60-4999-a558-96e3b5bae143",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-27T18:14:34.849Z",
+  "actor_id": "ryan",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "",
+        "to": "Feature: Star important score versions\n\nAs a lab worker, I want to mark score versions as versions of interest, so that important human-reviewed versions stay visible above optimizer-generated noise.\n\nScenario: Starred versions are prioritized\nGiven a score has many generated versions\nWhen a version is starred\nThen it appears in the pinned section above recent unstarred versions and remains distinct from champion status."
+      }
+    }
+  }
+}

--- a/project/events/2026-04-27T18:14:34.849Z__82f74a81-2cc2-492a-b853-621722bea8cb.json
+++ b/project/events/2026-04-27T18:14:34.849Z__82f74a81-2cc2-492a-b853-621722bea8cb.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "82f74a81-2cc2-492a-b853-621722bea8cb",
+  "issue_id": "plx-ad6b3884-24c3-4c0e-a699-753f3cf7729b",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-27T18:14:34.849Z",
+  "actor_id": "ryan",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "",
+        "to": "Feature: Compare arbitrary score versions\n\nAs a lab worker, I want to compare any two score versions, so that I can understand code and guideline changes before promotion or client reporting.\n\nScenario: Compare two versions\nGiven two score versions exist for a score\nWhen I choose them in the compare UI or tool\nThen I see code and guideline diffs for the selected left and right versions."
+      }
+    }
+  }
+}

--- a/project/events/2026-04-27T18:14:34.863Z__70759403-1aaf-48b6-ba46-2c60f8e5b556.json
+++ b/project/events/2026-04-27T18:14:34.863Z__70759403-1aaf-48b6-ba46-2c60f8e5b556.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "70759403-1aaf-48b6-ba46-2c60f8e5b556",
+  "issue_id": "plx-e2dbaa5b-91fc-4b3d-a8cb-e1d77c836bf4",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-27T18:14:34.863Z",
+  "actor_id": "ryan",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "",
+        "to": "Feature: Track champion production history\n\nAs a lab worker, I want to see which score versions were champion over time, so that production changes are auditable.\n\nScenario: Promotion records production transition\nGiven a score has a current champion\nWhen a new version is promoted\nThen the incoming and outgoing ScoreVersion metadata record the production transition with timestamps and linked predecessor/successor IDs."
+      }
+    }
+  }
+}

--- a/project/events/2026-04-27T18:14:34.874Z__c3d60921-3378-4505-bebe-2b59e1e6d20f.json
+++ b/project/events/2026-04-27T18:14:34.874Z__c3d60921-3378-4505-bebe-2b59e1e6d20f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c3d60921-3378-4505-bebe-2b59e1e6d20f",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-27T18:14:34.874Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-27T18:14:34.874Z__e6b1a7dd-c466-414d-9ac4-f4a165af0619.json
+++ b/project/events/2026-04-27T18:14:34.874Z__e6b1a7dd-c466-414d-9ac4-f4a165af0619.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "e6b1a7dd-c466-414d-9ac4-f4a165af0619",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-27T18:14:34.874Z",
+  "actor_id": "ryan",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "",
+        "to": "Implement the ScoreVersion management feature: schema field/index, frontend pin/diff/history UI, CLI and MCP tools, and champion promotion metadata updates. Keep the GraphQL schema delta limited to ScoreVersion.metadata plus one featured-version index."
+      }
+    }
+  }
+}

--- a/project/events/2026-04-27T18:15:17.524Z__8edabdf9-01c2-4316-b85c-e388ba239058.json
+++ b/project/events/2026-04-27T18:15:17.524Z__8edabdf9-01c2-4316-b85c-e388ba239058.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8edabdf9-01c2-4316-b85c-e388ba239058",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T18:15:17.524Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "de67b267-477a-427a-9f1b-64aff5335bf5"
+  }
+}

--- a/project/issues/plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7.json
+++ b/project/issues/plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "title": "ScoreVersion management: pinning, diffs, and champion history",
+  "description": "",
+  "type": "epic",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "ac1db483-912e-4f2f-80f6-521a67f05070",
+      "author": "ryan",
+      "text": "Starting implementation. First priority is the urgent GraphQL schema slice: add ScoreVersion.metadata as JSON and one featured-version lookup index, with no other table/index changes. Follow-up implementation will add frontend, CLI, MCP, and champion-history promotion wiring on the same feature branch.",
+      "created_at": "2026-04-27T18:14:17.839783Z"
+    }
+  ],
+  "created_at": "2026-04-27T18:14:11.621385Z",
+  "updated_at": "2026-04-27T18:14:17.839783Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-ad6b3884-24c3-4c0e-a699-753f3cf7729b.json
+++ b/project/issues/plx-ad6b3884-24c3-4c0e-a699-753f3cf7729b.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-ad6b3884-24c3-4c0e-a699-753f3cf7729b",
+  "title": "Compare arbitrary score versions",
+  "description": "Feature: Compare arbitrary score versions\n\nAs a lab worker, I want to compare any two score versions, so that I can understand code and guideline changes before promotion or client reporting.\n\nScenario: Compare two versions\nGiven two score versions exist for a score\nWhen I choose them in the compare UI or tool\nThen I see code and guideline diffs for the selected left and right versions.",
+  "type": "story",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-27T18:14:23.120820Z",
+  "updated_at": "2026-04-27T18:14:34.849136Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "title": "Implement ScoreVersion management schema and tools",
+  "description": "Implement the ScoreVersion management feature: schema field/index, frontend pin/diff/history UI, CLI and MCP tools, and champion promotion metadata updates. Keep the GraphQL schema delta limited to ScoreVersion.metadata plus one featured-version index.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "de67b267-477a-427a-9f1b-64aff5335bf5",
+      "author": "ryan",
+      "text": "Schema slice implemented: added nullable ScoreVersion.metadata JSON field and one ScoreVersion featured lookup index named byScoreIdAndIsFeaturedAndCreatedAt. No other schema indexes were changed.",
+      "created_at": "2026-04-27T18:15:17.524039Z"
+    }
+  ],
+  "created_at": "2026-04-27T18:14:23.120850Z",
+  "updated_at": "2026-04-27T18:15:17.524039Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-e2dbaa5b-91fc-4b3d-a8cb-e1d77c836bf4.json
+++ b/project/issues/plx-e2dbaa5b-91fc-4b3d-a8cb-e1d77c836bf4.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-e2dbaa5b-91fc-4b3d-a8cb-e1d77c836bf4",
+  "title": "Track champion production history",
+  "description": "Feature: Track champion production history\n\nAs a lab worker, I want to see which score versions were champion over time, so that production changes are auditable.\n\nScenario: Promotion records production transition\nGiven a score has a current champion\nWhen a new version is promoted\nThen the incoming and outgoing ScoreVersion metadata record the production transition with timestamps and linked predecessor/successor IDs.",
+  "type": "story",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-27T18:14:23.120825Z",
+  "updated_at": "2026-04-27T18:14:34.862896Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-fb52fc85-7e60-4999-a558-96e3b5bae143.json
+++ b/project/issues/plx-fb52fc85-7e60-4999-a558-96e3b5bae143.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-fb52fc85-7e60-4999-a558-96e3b5bae143",
+  "title": "Star important score versions",
+  "description": "Feature: Star important score versions\n\nAs a lab worker, I want to mark score versions as versions of interest, so that important human-reviewed versions stay visible above optimizer-generated noise.\n\nScenario: Starred versions are prioritized\nGiven a score has many generated versions\nWhen a version is starred\nThen it appears in the pinned section above recent unstarred versions and remains distinct from champion status.",
+  "type": "story",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-27T18:14:23.120933Z",
+  "updated_at": "2026-04-27T18:14:34.848792Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Add nullable ScoreVersion.metadata JSON field for champion production history.
- Add ScoreVersion.featuredKey materialized string field for featured-version indexing.
- Add one ScoreVersion featured lookup index: scoreId + featuredKey + createdAt.
- Add Kanbus records for the broader ScoreVersion management feature.

## Schema safety
- One new GSI on ScoreVersion only.
- No new associations.
- No Procedure or ChatSession index changes in this branch.
- Compatible with PR #206 because its GSI changes are on Procedure and ChatSession, not ScoreVersion.
- Amplify Gen2 does not allow boolean fields as index keys here, so isFeatured remains the product flag and featuredKey is the indexed storage key.

## Validation
- Dashboard typecheck in the main worktree caught the invalid boolean index shapes; the schema now uses a materialized string index key.