### PR TITLE
fix(dashboard): use string key for featured score versions

### DIFF
--- a/dashboard/amplify/data/resource.ts
+++ b/dashboard/amplify/data/resource.ts
@@ -36,7 +36,7 @@ type TaskIndexFields = "accountId" | "type" | "status" | "target" |
     "currentStageId" | "updatedAt" | "scorecardId" | "scoreId";
 type TaskStageIndexFields = "taskId" | "name" | "order" | "status";
 type ShareLinkIndexFields = "token" | "resourceType" | "resourceId" | "accountId";
-type ScoreVersionIndexFields = "scoreId" | "versionNumber" | "isFeatured";
+type ScoreVersionIndexFields = "scoreId" | "versionNumber" | "isFeatured" | "featuredKey";
 type ReportConfigurationIndexFields = "accountId" | "name";
 type ReportIndexFields = "accountId" | "reportConfigurationId" | "createdAt" | "updatedAt" | "taskId";
 type ReportBlockIndexFields = "reportId" | "name" | "position" | "dataSetId";
@@ -198,6 +198,7 @@ const schema = a.schema({
             configuration: a.string().required(),
             guidelines: a.string(),
             isFeatured: a.boolean().required(),
+            featuredKey: a.string(),
             createdAt: a.datetime().required(),
             updatedAt: a.datetime().required(),
             note: a.string(),
@@ -218,7 +219,7 @@ const schema = a.schema({
         ])
         .secondaryIndexes((idx) => [
             idx("scoreId").sortKeys(["createdAt"]),
-            idx("scoreId").sortKeys(["isFeatured", "createdAt"]).name("byScoreIdAndIsFeaturedAndCreatedAt")
+            idx("scoreId").sortKeys(["featuredKey", "createdAt"]).name("byScoreIdAndFeaturedKeyAndCreatedAt")
         ]),
 
     Evaluation: a

--- a/project/events/2026-04-27T19:06:56.149Z__e23f7705-bf39-4bfd-bac5-51cc5a003406.json
+++ b/project/events/2026-04-27T19:06:56.149Z__e23f7705-bf39-4bfd-bac5-51cc5a003406.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e23f7705-bf39-4bfd-bac5-51cc5a003406",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T19:06:56.149Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "43bc220d-2655-41dd-8fde-68eaf8a035c4"
+  }
+}

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -16,10 +16,16 @@
       "author": "ryan",
       "text": "Schema slice implemented: added nullable ScoreVersion.metadata JSON field and one ScoreVersion featured lookup index named byScoreIdAndIsFeaturedAndCreatedAt. No other schema indexes were changed.",
       "created_at": "2026-04-27T18:15:17.524039Z"
+    },
+    {
+      "id": "43bc220d-2655-41dd-8fde-68eaf8a035c4",
+      "author": "ryan",
+      "text": "Hotfix: CI showed Amplify Gen2 does not allow boolean isFeatured as an index sort key. Switched the new featured-version GSI to use a materialized string featuredKey while preserving isFeatured as the product flag. Local dashboard typecheck passes in the hotfix worktree.",
+      "created_at": "2026-04-27T19:06:56.148764Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T18:15:17.524039Z",
+  "updated_at": "2026-04-27T19:06:56.148764Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
**Summary**\n- Fixes the ScoreVersion featured-version index added in #211.\n- Adds nullable string `featuredKey` as the materialized index key while preserving `isFeatured` as the product flag.\n- Changes the new GSI to `scoreId + featuredKey + createdAt` because Amplify Gen2 does not allow boolean fields as sort keys.\n\n**Validation**\n- Local dashboard typecheck passed in the hotfix worktree: `tsc --noEmit --pretty --diagnostics`.\n\n**Schema safety**\n- Still only one ScoreVersion GSI change in this wave.\n- No associations added.\n- No Procedure or ChatSession index changes.