### PR TITLE
feat(scoreversions): add version management tools and UI

### DIFF
--- a/MCP/tools/score/scores.py
+++ b/MCP/tools/score/scores.py
@@ -2109,6 +2109,7 @@ def register_score_tools(mcp: FastMCP):
                         "id": request.version_id,
                         "isFeatured": request.pinned,
                         "featuredKey": "featured" if request.pinned else "unfeatured",
+                        "createdAt": version.get("createdAt"),
                     }
                 },
             ).get("updateScoreVersion") or {})

--- a/MCP/tools/score/scores.py
+++ b/MCP/tools/score/scores.py
@@ -6,6 +6,9 @@ import os
 import sys
 import json
 import logging
+import difflib
+import uuid
+from datetime import datetime, timezone
 from typing import Dict, Any, List, Union, Optional, Annotated
 from io import StringIO
 from fastmcp import FastMCP
@@ -136,6 +139,85 @@ def register_score_tools(mcp: FastMCP):
             "champion_version_id": score.get("championVersionId"),
             "service": OptimizerResultsService(client),
         }
+
+    def _fetch_score_version_for_management(client, version_id: str) -> Dict[str, Any]:
+        query = """
+        query GetScoreVersionForManagement($id: ID!) {
+          getScoreVersion(id: $id) {
+            id
+            scoreId
+            configuration
+            guidelines
+            isFeatured
+            featuredKey
+            note
+            branch
+            parentVersionId
+            metadata
+            createdAt
+            updatedAt
+          }
+        }
+        """
+        version = (client.execute(query, {"id": version_id}).get("getScoreVersion") or {})
+        if not version:
+            raise ValueError(f"Score version not found: {version_id}")
+        return version
+
+    def _build_unified_diff(left_text: str, right_text: str, left_label: str, right_label: str) -> str:
+        return "".join(difflib.unified_diff(
+            (left_text or "").splitlines(keepends=True),
+            (right_text or "").splitlines(keepends=True),
+            fromfile=left_label,
+            tofile=right_label,
+        ))
+
+    def _build_champion_metadata(
+        metadata: Optional[Dict[str, Any]],
+        *,
+        score_id: str,
+        version_id: str,
+        transition_id: str,
+        incoming: bool,
+        entered_at: Optional[str] = None,
+        exited_at: Optional[str] = None,
+        previous_champion_version_id: Optional[str] = None,
+        next_champion_version_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        next_metadata: Dict[str, Any] = dict(metadata or {})
+        history = list(next_metadata.get("championHistory") or [])
+        if incoming:
+            history.append({
+                "scoreId": score_id,
+                "versionId": version_id,
+                "enteredAt": entered_at,
+                "exitedAt": None,
+                "previousChampionVersionId": previous_champion_version_id,
+                "nextChampionVersionId": None,
+                "transitionId": transition_id,
+            })
+        else:
+            open_index = next((idx for idx in range(len(history) - 1, -1, -1) if not history[idx].get("exitedAt")), None)
+            if open_index is None:
+                history.append({
+                    "scoreId": score_id,
+                    "versionId": version_id,
+                    "enteredAt": None,
+                    "exitedAt": exited_at,
+                    "previousChampionVersionId": None,
+                    "nextChampionVersionId": next_champion_version_id,
+                    "transitionId": transition_id,
+                    "inferred": True,
+                })
+            else:
+                history[open_index] = {
+                    **history[open_index],
+                    "exitedAt": exited_at,
+                    "nextChampionVersionId": next_champion_version_id,
+                    "transitionId": transition_id,
+                }
+        next_metadata["championHistory"] = history
+        return next_metadata
     
     @mcp.tool()
     async def plexus_score_info(
@@ -368,7 +450,10 @@ def register_score_tools(mcp: FastMCP):
                                 items {{
                                     id
                                     createdAt
+                                    isFeatured
+                                    parentVersionId
                                     note
+                                    metadata
                                 }}
                             }}
                         }}
@@ -389,7 +474,11 @@ def register_score_tools(mcp: FastMCP):
                                 {
                                     "id": v.get('id'),
                                     "createdAt": v.get('createdAt'),
-                                    "note": v.get('note')
+                                    "note": v.get('note'),
+                                    "isFeatured": v.get('isFeatured'),
+                                    "parentVersionId": v.get('parentVersionId'),
+                                    "isChampion": v.get('id') == score.get('championVersionId'),
+                                    "metadata": v.get('metadata'),
                                 }
                                 for v in all_versions
                             ]
@@ -415,6 +504,7 @@ def register_score_tools(mcp: FastMCP):
                                 note
                                 isFeatured
                                 parentVersionId
+                                metadata
                             }}
                         }}
                         """
@@ -439,6 +529,7 @@ def register_score_tools(mcp: FastMCP):
                                 "note": version_data.get('note'),
                                 "isFeatured": version_data.get('isFeatured'),
                                 "parentVersionId": version_data.get('parentVersionId'),
+                                "metadata": version_data.get('metadata'),
                                 "isChampion": target_version_id == score.get('championVersionId')
                             }
                             
@@ -1858,14 +1949,21 @@ def register_score_tools(mcp: FastMCP):
                 return "Error: Could not create dashboard client."
 
             version_query = """
-            query GetScoreVersionForChampionGuard($id: ID!) {
-                getScoreVersion(id: $id) {
+            query GetScoreVersionForChampionGuard($scoreId: ID!, $versionId: ID!) {
+                getScore(id: $scoreId) {
                     id
+                    championVersionId
+                }
+                getScoreVersion(id: $versionId) {
+                    id
+                    scoreId
                     configuration
+                    metadata
                 }
             }
             """
-            version_result = client.execute(version_query, {"id": version_id})
+            version_result = client.execute(version_query, {"scoreId": score_id, "versionId": version_id})
+            score_data = version_result.get("getScore") or {}
             version_data = version_result.get("getScoreVersion") or {}
             shadow_invalid_feedback_item_ids = extract_shadow_invalid_feedback_item_ids_from_yaml_text(
                 version_data.get("configuration") or ""
@@ -1883,6 +1981,14 @@ def register_score_tools(mcp: FastMCP):
                     "versionId": version_id,
                     "optimizer_shadow_invalid_feedback_item_ids": shadow_invalid_feedback_item_ids,
                 }
+            if version_data.get("scoreId") != score_id:
+                return {
+                    "success": False,
+                    "error": "VERSION_SCORE_MISMATCH",
+                    "message": f"Version {version_id} does not belong to score {score_id}.",
+                    "scoreId": score_id,
+                    "versionId": version_id,
+                }
 
             mutation = """
             mutation UpdateScore($input: UpdateScoreInput!) {
@@ -1893,16 +1999,55 @@ def register_score_tools(mcp: FastMCP):
             }
             """
             try:
+                previous_champion_version_id = score_data.get("championVersionId")
+                previous_version_data: Dict[str, Any] = {}
+                if previous_champion_version_id and previous_champion_version_id != version_id:
+                    previous_version_data = _fetch_score_version_for_management(client, previous_champion_version_id)
+
                 result = client.execute(mutation, {'input': {
                     'id': score_id,
                     'championVersionId': version_id
                 }})
                 if result and 'updateScore' in result:
                     updated = result['updateScore']
+                    promoted_at = datetime.now(timezone.utc).isoformat()
+                    transition_id = str(uuid.uuid4())
+                    incoming_metadata = _build_champion_metadata(
+                        version_data.get("metadata"),
+                        score_id=score_id,
+                        version_id=version_id,
+                        entered_at=promoted_at,
+                        previous_champion_version_id=previous_champion_version_id if previous_champion_version_id != version_id else None,
+                        transition_id=transition_id,
+                        incoming=True,
+                    )
+                    update_version_mutation = """
+                    mutation UpdateScoreVersionMetadata($input: UpdateScoreVersionInput!) {
+                        updateScoreVersion(input: $input) {
+                            id
+                            metadata
+                        }
+                    }
+                    """
+                    client.execute(update_version_mutation, {"input": {"id": version_id, "metadata": incoming_metadata}})
+                    if previous_champion_version_id and previous_champion_version_id != version_id:
+                        outgoing_metadata = _build_champion_metadata(
+                            previous_version_data.get("metadata"),
+                            score_id=score_id,
+                            version_id=previous_champion_version_id,
+                            exited_at=promoted_at,
+                            next_champion_version_id=version_id,
+                            transition_id=transition_id,
+                            incoming=False,
+                        )
+                        client.execute(update_version_mutation, {"input": {"id": previous_champion_version_id, "metadata": outgoing_metadata}})
                     return {
                         "success": True,
                         "scoreId": updated['id'],
-                        "championVersionId": updated['championVersionId']
+                        "championVersionId": updated['championVersionId'],
+                        "previousChampionVersionId": previous_champion_version_id,
+                        "transitionId": transition_id,
+                        "promotedAt": promoted_at,
                     }
                 else:
                     return f"Error: Failed to set champion: {result}"
@@ -1917,6 +2062,114 @@ def register_score_tools(mcp: FastMCP):
             if captured:
                 logger.warning(f"Captured unexpected stdout during plexus_score_set_champion: {captured}")
             sys.stdout = old_stdout
+
+    class ScoreVersionPinRequest(BaseModel):
+        scorecard_identifier: Annotated[str, Field(description="Scorecard identifier (ID, key, name, or external ID)")]
+        score_identifier: Annotated[str, Field(description="Score identifier (ID, key, name, or external ID)")]
+        version_id: Annotated[str, Field(description="ScoreVersion ID to pin or unpin")]
+        pinned: Annotated[bool, Field(description="Whether the version should be pinned/starred")] = True
+
+    @mcp.tool()
+    async def plexus_score_version_pin(request: ScoreVersionPinRequest) -> Dict[str, Any]:
+        """Pin or unpin a ScoreVersion using isFeatured."""
+        try:
+            from plexus.cli.shared.client_utils import create_client as create_dashboard_client
+
+            client = create_dashboard_client()
+            if not client:
+                return _structured_error("Could not create API client")
+
+            context = _build_optimizer_score_context(client, request.scorecard_identifier, request.score_identifier)
+            version = _fetch_score_version_for_management(client, request.version_id)
+            if version.get("scoreId") != context["score_id"]:
+                return _structured_error(
+                    f"Version {request.version_id} belongs to score {version.get('scoreId')}, not {context['score_id']}",
+                    error="wrong_score",
+                )
+
+            mutation = """
+            mutation UpdateScoreVersionPin($input: UpdateScoreVersionInput!) {
+              updateScoreVersion(input: $input) {
+                id
+                scoreId
+                isFeatured
+                featuredKey
+                updatedAt
+              }
+            }
+            """
+            updated = (client.execute(
+                mutation,
+                {
+                    "input": {
+                        "id": request.version_id,
+                        "isFeatured": request.pinned,
+                        "featuredKey": "featured" if request.pinned else "unfeatured",
+                    }
+                },
+            ).get("updateScoreVersion") or {})
+            return {
+                "success": True,
+                "score_id": context["score_id"],
+                "score_name": context["score_name"],
+                "version_id": updated.get("id") or request.version_id,
+                "pinned": bool(updated.get("isFeatured")),
+            }
+        except Exception as e:
+            logger.error(f"Error pinning score version: {e}", exc_info=True)
+            return _structured_error("Failed to pin score version", error=str(e))
+
+    class ScoreVersionDiffRequest(BaseModel):
+        scorecard_identifier: Annotated[str, Field(description="Scorecard identifier (ID, key, name, or external ID)")]
+        score_identifier: Annotated[str, Field(description="Score identifier (ID, key, name, or external ID)")]
+        left_version_id: Annotated[str, Field(description="Left/original ScoreVersion ID")]
+        right_version_id: Annotated[str, Field(description="Right/modified ScoreVersion ID")]
+        include: Annotated[str, Field(description='"code", "guidelines", or "both"')] = "both"
+
+    @mcp.tool()
+    async def plexus_score_version_diff(request: ScoreVersionDiffRequest) -> Dict[str, Any]:
+        """Return code and/or guideline diffs between two ScoreVersions."""
+        try:
+            from plexus.cli.shared.client_utils import create_client as create_dashboard_client
+
+            client = create_dashboard_client()
+            if not client:
+                return _structured_error("Could not create API client")
+
+            context = _build_optimizer_score_context(client, request.scorecard_identifier, request.score_identifier)
+            left = _fetch_score_version_for_management(client, request.left_version_id)
+            right = _fetch_score_version_for_management(client, request.right_version_id)
+            for label, version in (("left", left), ("right", right)):
+                if version.get("scoreId") != context["score_id"]:
+                    return _structured_error(
+                        f"{label} version {version.get('id')} belongs to score {version.get('scoreId')}, not {context['score_id']}",
+                        error="wrong_score",
+                    )
+
+            include_code = request.include in ("code", "both")
+            include_guidelines = request.include in ("guidelines", "both")
+            return {
+                "success": True,
+                "score_id": context["score_id"],
+                "score_name": context["score_name"],
+                "left_version_id": request.left_version_id,
+                "right_version_id": request.right_version_id,
+                "code_diff": _build_unified_diff(
+                    left.get("configuration") or "",
+                    right.get("configuration") or "",
+                    f"{request.left_version_id}/code.yaml",
+                    f"{request.right_version_id}/code.yaml",
+                ) if include_code else None,
+                "guidelines_diff": _build_unified_diff(
+                    left.get("guidelines") or "",
+                    right.get("guidelines") or "",
+                    f"{request.left_version_id}/guidelines.md",
+                    f"{request.right_version_id}/guidelines.md",
+                ) if include_guidelines else None,
+            }
+        except Exception as e:
+            logger.error(f"Error diffing score versions: {e}", exc_info=True)
+            return _structured_error("Failed to diff score versions", error=str(e))
 
     class ScoreOptimizerRunsRequest(BaseModel):
         scorecard_identifier: Annotated[str, Field(description="Scorecard identifier (ID, key, name, or external ID)")]
@@ -2334,7 +2587,8 @@ async def _create_version_from_code_with_parent(
             'scoreId': score.id,
             'configuration': (code_content or '').strip(),
             'note': note or 'Updated via MCP score update tool',
-            'isFeatured': True  # Mark as featured by default
+            'isFeatured': False,
+            'featuredKey': 'unfeatured'
         }
         
         # Add guidelines if provided

--- a/MCP/tools/score/scores.py
+++ b/MCP/tools/score/scores.py
@@ -451,6 +451,7 @@ def register_score_tools(mcp: FastMCP):
                                     id
                                     createdAt
                                     isFeatured
+                                    featuredKey
                                     parentVersionId
                                     note
                                     metadata
@@ -476,6 +477,7 @@ def register_score_tools(mcp: FastMCP):
                                     "createdAt": v.get('createdAt'),
                                     "note": v.get('note'),
                                     "isFeatured": v.get('isFeatured'),
+                                    "featuredKey": v.get('featuredKey'),
                                     "parentVersionId": v.get('parentVersionId'),
                                     "isChampion": v.get('id') == score.get('championVersionId'),
                                     "metadata": v.get('metadata'),
@@ -503,6 +505,7 @@ def register_score_tools(mcp: FastMCP):
                                 updatedAt
                                 note
                                 isFeatured
+                                featuredKey
                                 parentVersionId
                                 metadata
                             }}
@@ -528,6 +531,7 @@ def register_score_tools(mcp: FastMCP):
                                 "updatedAt": version_data.get('updatedAt'),
                                 "note": version_data.get('note'),
                                 "isFeatured": version_data.get('isFeatured'),
+                                "featuredKey": version_data.get('featuredKey'),
                                 "parentVersionId": version_data.get('parentVersionId'),
                                 "metadata": version_data.get('metadata'),
                                 "isChampion": target_version_id == score.get('championVersionId')
@@ -2113,7 +2117,7 @@ def register_score_tools(mcp: FastMCP):
                 "score_id": context["score_id"],
                 "score_name": context["score_name"],
                 "version_id": updated.get("id") or request.version_id,
-                "pinned": bool(updated.get("isFeatured")),
+                "pinned": updated.get("featuredKey") == "featured",
             }
         except Exception as e:
             logger.error(f"Error pinning score version: {e}", exc_info=True)

--- a/dashboard/components/scorecards-dashboard.tsx
+++ b/dashboard/components/scorecards-dashboard.tsx
@@ -28,7 +28,8 @@ import {
   Square,
   X,
   MessageCircleMore,
-  Coins
+  Coins,
+  History
 } from "lucide-react"
 import { ScoreCount } from "./scorecards/score-count"
 import { CardButton } from "./CardButton"
@@ -50,6 +51,7 @@ import { AdHocFeedbackAlignment } from "@/components/ui/ad-hoc-feedback-alignmen
 import { AdHocCostAnalysis } from "@/components/ui/ad-hoc-cost-analysis"
 import { ScoreProcedureList } from "@/components/ui/score-procedure-list"
 import { ScoreEvaluationList } from "@/components/ui/score-evaluation-list"
+import { ScoreChampionHistory } from "@/components/ui/score-champion-history"
 import { motion, AnimatePresence } from 'framer-motion'
 import { FilterInput } from '@/components/FilterInput'
 import { useAccount } from "@/app/contexts/AccountContext"
@@ -130,7 +132,7 @@ export default function ScorecardsComponent({
     isOpen: boolean;
     scoreId: string;
     scoreName?: string;
-    type: 'procedures' | 'evaluations';
+    type: 'procedures' | 'evaluations' | 'champion-history';
   } | null>(null)
   const [scorecardsFilter, setScorecardsFilter] = useState('')
   const router = useRouter()
@@ -406,6 +408,19 @@ export default function ScorecardsComponent({
       scoreId,
       scoreName,
       type: 'evaluations',
+    });
+    setIsTaskViewActive(false);
+  };
+
+  const handleScoreViewChampionHistory = (scoreId: string, scoreName?: string) => {
+    console.log('Opening champion history for score:', scoreId);
+    setFeedbackAlignmentPanel(null);
+    setCostAnalysisPanel(null);
+    setScoreExplorerPanel({
+      isOpen: true,
+      scoreId,
+      scoreName,
+      type: 'champion-history',
     });
     setIsTaskViewActive(false);
   };
@@ -1502,6 +1517,7 @@ export default function ScorecardsComponent({
           onDelete={() => handleDeleteScore(selectedScore.id)}
           onViewProcedures={() => handleScoreViewProcedures(selectedScore.id, selectedScore.name)}
           onViewEvaluations={() => handleScoreViewEvaluations(selectedScore.id, selectedScore.name)}
+          onViewChampionHistory={() => handleScoreViewChampionHistory(selectedScore.id, selectedScore.name)}
           initialSelectedVersionId={selectedVersionId}
           onVersionSelect={handleVersionSelect}
           onSave={async () => {
@@ -1594,13 +1610,15 @@ export default function ScorecardsComponent({
           showHeader={false}
           surface="slot"
         />
-      ) : (
+      ) : scoreExplorerPanel.type === 'evaluations' ? (
         <ScoreEvaluationList
           scoreId={selectedScore.id}
           scope="score"
           showHeader={false}
           surface="slot"
         />
+      ) : (
+        <ScoreChampionHistory scoreId={selectedScore.id} />
       )
     )
   }
@@ -1853,6 +1871,8 @@ export default function ScorecardsComponent({
                           {scoreExplorerPanel?.isOpen ? (
                             scoreExplorerPanel.type === 'procedures' ? (
                               <Activity className="h-5 w-5 text-foreground" />
+                            ) : scoreExplorerPanel.type === 'champion-history' ? (
+                              <History className="h-5 w-5 text-foreground" />
                             ) : (
                               <Database className="h-5 w-5 text-foreground" />
                             )
@@ -1863,7 +1883,11 @@ export default function ScorecardsComponent({
                           )}
                           <h2 className="text-lg font-semibold">
                             {scoreExplorerPanel?.isOpen
-                              ? (scoreExplorerPanel.type === 'procedures' ? 'Procedures' : 'Evaluations')
+                              ? (scoreExplorerPanel.type === 'procedures'
+                                  ? 'Procedures'
+                                  : scoreExplorerPanel.type === 'champion-history'
+                                    ? 'Champion History'
+                                    : 'Evaluations')
                               : feedbackAnalysisPanel?.isOpen
                                 ? 'Feedback Alignment'
                                 : 'Cost Analysis'}

--- a/dashboard/components/ui/score-champion-history.tsx
+++ b/dashboard/components/ui/score-champion-history.tsx
@@ -1,0 +1,239 @@
+"use client"
+
+import * as React from "react"
+import { Crown, History } from "lucide-react"
+import { generateClient } from "aws-amplify/api"
+
+import type { GraphQLResult } from "@aws-amplify/api"
+import { Timestamp } from "@/components/ui/timestamp"
+import { cn } from "@/lib/utils"
+
+const getClient = (() => {
+  let client: any
+  return () => (client ??= generateClient())
+})()
+
+interface ScoreChampionHistoryProps {
+  scoreId: string
+  className?: string
+}
+
+interface VersionRecord {
+  id: string
+  scoreId: string
+  note?: string | null
+  isFeatured: boolean
+  parentVersionId?: string | null
+  createdAt: string
+  updatedAt: string
+  metadata?: Record<string, any> | null
+}
+
+interface ScoreResponse {
+  getScore?: {
+    id: string
+    name?: string | null
+    championVersionId?: string | null
+  } | null
+}
+
+interface VersionPageResponse {
+  listScoreVersionByScoreIdAndCreatedAt?: {
+    items: VersionRecord[]
+    nextToken?: string | null
+  } | null
+}
+
+interface ChampionHistoryEntry {
+  versionId: string
+  versionNote?: string | null
+  enteredAt?: string | null
+  exitedAt?: string | null
+  previousChampionVersionId?: string | null
+  nextChampionVersionId?: string | null
+  transitionId?: string | null
+  inferred?: boolean
+}
+
+function getChampionEntries(version: VersionRecord): ChampionHistoryEntry[] {
+  const entries = version.metadata?.championHistory
+  if (!Array.isArray(entries)) return []
+  return entries.map((entry) => ({
+    versionId: version.id,
+    versionNote: version.note,
+    enteredAt: typeof entry?.enteredAt === "string" ? entry.enteredAt : null,
+    exitedAt: typeof entry?.exitedAt === "string" ? entry.exitedAt : null,
+    previousChampionVersionId: typeof entry?.previousChampionVersionId === "string" ? entry.previousChampionVersionId : null,
+    nextChampionVersionId: typeof entry?.nextChampionVersionId === "string" ? entry.nextChampionVersionId : null,
+    transitionId: typeof entry?.transitionId === "string" ? entry.transitionId : null,
+    inferred: Boolean(entry?.inferred),
+  }))
+}
+
+export function ScoreChampionHistory({ scoreId, className }: ScoreChampionHistoryProps) {
+  const [scoreName, setScoreName] = React.useState<string>("Score")
+  const [championVersionId, setChampionVersionId] = React.useState<string | null>(null)
+  const [entries, setEntries] = React.useState<ChampionHistoryEntry[]>([])
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    const loadHistory = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const scoreResponse = await getClient().graphql({
+          query: `
+            query GetScoreForChampionHistory($id: ID!) {
+              getScore(id: $id) {
+                id
+                name
+                championVersionId
+              }
+            }
+          `,
+          variables: { id: scoreId },
+        }) as GraphQLResult<ScoreResponse>
+
+        const score = scoreResponse.data?.getScore
+        if (!score) {
+          throw new Error("Score not found")
+        }
+
+        const allVersions: VersionRecord[] = []
+        let nextToken: string | null | undefined = null
+        do {
+          const versionResponse = await getClient().graphql({
+            query: `
+              query ListScoreVersionsForChampionHistory($scoreId: String!, $nextToken: String) {
+                listScoreVersionByScoreIdAndCreatedAt(scoreId: $scoreId, sortDirection: DESC, limit: 100, nextToken: $nextToken) {
+                  items {
+                    id
+                    scoreId
+                    note
+                    isFeatured
+                    parentVersionId
+                    createdAt
+                    updatedAt
+                    metadata
+                  }
+                  nextToken
+                }
+              }
+            `,
+            variables: { scoreId, nextToken },
+          }) as GraphQLResult<VersionPageResponse>
+
+          const page = versionResponse.data?.listScoreVersionByScoreIdAndCreatedAt
+          allVersions.push(...(page?.items ?? []))
+          nextToken = page?.nextToken
+        } while (nextToken)
+
+        const historyEntries = allVersions
+          .flatMap(getChampionEntries)
+          .sort((a, b) => {
+            const aTime = a.enteredAt ? new Date(a.enteredAt).getTime() : 0
+            const bTime = b.enteredAt ? new Date(b.enteredAt).getTime() : 0
+            return bTime - aTime
+          })
+
+        if (!cancelled) {
+          setScoreName(score.name || "Score")
+          setChampionVersionId(score.championVersionId || null)
+          setEntries(historyEntries)
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          console.error("Failed to load champion history:", loadError)
+          setError("Failed to load champion history.")
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    loadHistory()
+    return () => {
+      cancelled = true
+    }
+  }, [scoreId])
+
+  return (
+    <div className={cn("h-full min-h-0 flex flex-col bg-background p-3", className)}>
+      <div className="flex items-center justify-between gap-3 pb-3">
+        <div className="flex items-center gap-2">
+          <History className="h-4 w-4 text-foreground" />
+          <div>
+            <div className="text-sm font-semibold">Champion History</div>
+            <div className="text-xs text-muted-foreground">{scoreName}</div>
+          </div>
+        </div>
+        {championVersionId && (
+          <div className="text-xs text-muted-foreground">
+            Current champion: <span className="font-mono">{championVersionId}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto space-y-2">
+        {isLoading && Array.from({ length: 5 }).map((_, index) => (
+          <div key={`history-skeleton-${index}`} className="bg-card p-3 rounded-md">
+            <div className="h-4 w-48 rounded bg-muted animate-pulse mb-2" />
+            <div className="h-3 w-72 rounded bg-muted animate-pulse" />
+          </div>
+        ))}
+
+        {!isLoading && error && (
+          <div className="bg-card p-3 rounded-md text-sm text-destructive">{error}</div>
+        )}
+
+        {!isLoading && !error && entries.length === 0 && (
+          <div className="bg-card p-3 rounded-md text-sm text-muted-foreground">
+            No champion history metadata has been recorded yet. Future promotions will populate this log.
+          </div>
+        )}
+
+        {!isLoading && !error && entries.map((entry) => (
+          <div key={`${entry.versionId}-${entry.transitionId || entry.enteredAt || "legacy"}`} className="bg-card p-3 rounded-md">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  {entry.versionId === championVersionId && <Crown className="h-4 w-4 text-muted-foreground" />}
+                  <span className="font-mono truncate">{entry.versionId}</span>
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground truncate">
+                  {entry.versionNote || "No note"}
+                </div>
+              </div>
+              <div className="shrink-0 text-right text-xs text-muted-foreground">
+                {entry.inferred ? "Legacy inferred range" : "Recorded range"}
+              </div>
+            </div>
+            <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-2 text-xs">
+              <div className="bg-background p-2 rounded">
+                <div className="text-muted-foreground">Entered production</div>
+                {entry.enteredAt ? <Timestamp time={entry.enteredAt} variant="relative" className="text-xs" /> : <div>Unknown</div>}
+              </div>
+              <div className="bg-background p-2 rounded">
+                <div className="text-muted-foreground">Exited production</div>
+                {entry.exitedAt ? <Timestamp time={entry.exitedAt} variant="relative" className="text-xs" /> : <div>Current / open</div>}
+              </div>
+              <div className="bg-background p-2 rounded">
+                <div className="text-muted-foreground">Replaced</div>
+                <div className="font-mono truncate">{entry.previousChampionVersionId || "None recorded"}</div>
+              </div>
+              <div className="bg-background p-2 rounded">
+                <div className="text-muted-foreground">Replaced by</div>
+                <div className="font-mono truncate">{entry.nextChampionVersionId || "None recorded"}</div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { ScoreSidebarVersionHistory } from '@/components/ui/score-sidebar-version-history'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { generateClient } from 'aws-amplify/api'
@@ -174,6 +175,42 @@ const buildChampionMetadata = ({
   return nextMetadata
 }
 
+interface ChampionHistoryEntry {
+  enteredAt?: string | null
+  exitedAt?: string | null
+  previousChampionVersionId?: string | null
+  nextChampionVersionId?: string | null
+}
+
+const getLatestChampionHistoryEntry = (version?: ScoreVersion): ChampionHistoryEntry | null => {
+  const entries = Array.isArray(version?.metadata?.championHistory)
+    ? version?.metadata?.championHistory
+    : []
+
+  if (!entries.length) return null
+
+  return entries.reduce<{ entry: ChampionHistoryEntry | null; index: number }>((latest, rawEntry, index) => {
+    const entry = rawEntry && typeof rawEntry === 'object' ? rawEntry as ChampionHistoryEntry : null
+    if (!entry) return latest
+
+    if (!latest.entry) return { entry, index }
+
+    const latestEntered = Date.parse(latest.entry.enteredAt || '') || 0
+    const currentEntered = Date.parse(entry.enteredAt || '') || 0
+    if (currentEntered !== latestEntered) {
+      return currentEntered > latestEntered ? { entry, index } : latest
+    }
+
+    const latestExited = Date.parse(latest.entry.exitedAt || '') || 0
+    const currentExited = Date.parse(entry.exitedAt || '') || 0
+    if (currentExited !== latestExited) {
+      return currentExited > latestExited ? { entry, index } : latest
+    }
+
+    return index > latest.index ? { entry, index } : latest
+  }, { entry: null, index: -1 }).entry
+}
+
 // Add a new interface for the secondary index query response
 interface GetScoreVersionsByScoreIdResponse {
   listScoreVersionByScoreIdAndCreatedAt: {
@@ -260,6 +297,7 @@ interface DetailContentProps {
   championVersionId?: string
   selectedVersionId?: string
   onVersionSelect?: (version: ScoreVersion) => void
+  onHydrateVersionById?: (versionId: string) => Promise<ScoreVersion | null>
   onToggleFeature?: (versionId: string) => void
   onPromoteToChampion?: (versionId: string) => void
   isVersionsLoading?: boolean
@@ -304,6 +342,96 @@ function ScoreVersionContentSkeleton({ label = 'Loading version...' }: { label?:
         <div className="h-4 w-2/3 max-w-lg rounded bg-muted animate-pulse" />
       </div>
     </div>
+  )
+}
+
+interface RelatedScoreVersionCardProps {
+  label: string
+  currentVersion: ScoreVersion
+  relatedVersion?: ScoreVersion
+  relatedVersionId: string
+  failedToLoad?: boolean
+  onSelect?: (version: ScoreVersion) => void
+  onCompare?: (leftVersionId: string, rightVersionId: string) => void
+}
+
+function RelatedScoreVersionCard({
+  label,
+  currentVersion,
+  relatedVersion,
+  relatedVersionId,
+  failedToLoad = false,
+  onSelect,
+  onCompare,
+}: RelatedScoreVersionCardProps) {
+  const [isOpen, setIsOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    setIsOpen(false)
+  }, [currentVersion.id, relatedVersionId])
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="bg-background rounded-md">
+        <CollapsibleTrigger asChild>
+          <button type="button" className="w-full p-2 text-left">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0 flex items-center gap-2">
+                {isOpen ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
+                <div className="min-w-0">
+                  <div className="text-xs font-medium truncate">{label}</div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    {relatedVersion
+                      ? <Timestamp time={relatedVersion.createdAt} variant="relative" showIcon={false} className="text-xs" />
+                      : failedToLoad
+                        ? `Unavailable: ${relatedVersionId}`
+                        : `Loading: ${relatedVersionId}`}
+                  </div>
+                </div>
+              </div>
+              {relatedVersion && (
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="shrink-0 text-xs text-primary hover:text-primary/80"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onSelect?.(relatedVersion)
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      onSelect?.(relatedVersion)
+                    }
+                  }}
+                >
+                  Open version
+                </span>
+              )}
+            </div>
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="px-2 pb-2 space-y-2">
+            <div className="text-xs text-muted-foreground">
+              {relatedVersion?.note || (failedToLoad ? 'This related version could not be loaded.' : 'Loading related version details...')}
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              className="h-8"
+              disabled={!relatedVersion}
+              onClick={() => relatedVersion && onCompare?.(relatedVersion.id, currentVersion.id)}
+            >
+              <GitCompareArrows className="mr-2 h-4 w-4" />
+              Compare with this version
+            </Button>
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
   )
 }
 
@@ -693,6 +821,7 @@ const DetailContent = React.memo(({
   championVersionId,
   selectedVersionId,
   onVersionSelect,
+  onHydrateVersionById,
   onToggleFeature,
   onPromoteToChampion,
   isVersionsLoading = false,
@@ -936,6 +1065,7 @@ const DetailContent = React.memo(({
   const [isFeedbackDialogOpen, setIsFeedbackDialogOpen] = React.useState(false)
   const [feedbackAction, setFeedbackAction] = React.useState<{name: string, versionId?: string} | null>(null)
   const [isVersionDiffOpen, setIsVersionDiffOpen] = React.useState(false)
+  const [versionDiffInitialPair, setVersionDiffInitialPair] = React.useState<{ leftVersionId?: string; rightVersionId?: string }>({})
 
   
 
@@ -1112,6 +1242,73 @@ const DetailContent = React.memo(({
     }
     return championVersion
   }, [selectedVersionId, championVersion, versions])
+
+  const [failedRelatedVersionIds, setFailedRelatedVersionIds] = React.useState<Set<string>>(() => new Set())
+
+  React.useEffect(() => {
+    setFailedRelatedVersionIds(new Set())
+  }, [selectedVersion?.id])
+
+  const relatedVersionTargets = React.useMemo(() => {
+    if (!selectedVersion) return []
+
+    const latestChampionEntry = getLatestChampionHistoryEntry(selectedVersion)
+    const targets = [
+      { label: 'Parent Version', id: selectedVersion.parentVersionId },
+      { label: 'Previous Champion', id: latestChampionEntry?.previousChampionVersionId },
+      { label: 'Next Champion', id: latestChampionEntry?.nextChampionVersionId },
+    ]
+    const byId = new Map<string, { id: string; labels: string[] }>()
+
+    for (const target of targets) {
+      if (!target.id || target.id === selectedVersion.id) continue
+      const existing = byId.get(target.id)
+      if (existing) {
+        existing.labels.push(target.label)
+      } else {
+        byId.set(target.id, { id: target.id, labels: [target.label] })
+      }
+    }
+
+    return Array.from(byId.values())
+  }, [selectedVersion])
+
+  React.useEffect(() => {
+    if (!onHydrateVersionById || relatedVersionTargets.length === 0) return
+
+    let cancelled = false
+    const loadedVersionIds = new Set((versions ?? []).map(version => version.id))
+    const missingVersionIds = relatedVersionTargets
+      .map(target => target.id)
+      .filter(versionId => !loadedVersionIds.has(versionId) && !failedRelatedVersionIds.has(versionId))
+
+    if (missingVersionIds.length === 0) return
+
+    const hydrateMissingVersions = async () => {
+      const failedIds: string[] = []
+      for (const versionId of missingVersionIds) {
+        try {
+          const version = await onHydrateVersionById(versionId)
+          if (!version) failedIds.push(versionId)
+        } catch {
+          failedIds.push(versionId)
+        }
+      }
+      if (!cancelled && failedIds.length > 0) {
+        setFailedRelatedVersionIds(prev => new Set([...prev, ...failedIds]))
+      }
+    }
+
+    hydrateMissingVersions()
+    return () => {
+      cancelled = true
+    }
+  }, [failedRelatedVersionIds, onHydrateVersionById, relatedVersionTargets, versions])
+
+  const handleOpenVersionDiff = React.useCallback((leftVersionId?: string, rightVersionId?: string) => {
+    setVersionDiffInitialPair({ leftVersionId, rightVersionId })
+    setIsVersionDiffOpen(true)
+  }, [])
 
 
 
@@ -1409,6 +1606,25 @@ const DetailContent = React.memo(({
                     <div className="text-xs text-muted-foreground">
                       {selectedVersion.note || 'No note'}
                     </div>
+                    {relatedVersionTargets.length > 0 && (
+                      <div className="mt-3 space-y-2">
+                        {relatedVersionTargets.map((target) => {
+                          const relatedVersion = versions?.find(version => version.id === target.id)
+                          return (
+                            <RelatedScoreVersionCard
+                              key={target.id}
+                              label={target.labels.join(' / ')}
+                              currentVersion={selectedVersion}
+                              relatedVersion={relatedVersion}
+                              relatedVersionId={target.id}
+                              failedToLoad={failedRelatedVersionIds.has(target.id)}
+                              onSelect={onVersionSelect}
+                              onCompare={(leftVersionId, rightVersionId) => handleOpenVersionDiff(leftVersionId, rightVersionId)}
+                            />
+                          )
+                        })}
+                      </div>
+                    )}
                   </div>
                   <div className="flex items-center gap-2 ml-3">
                     {selectedVersion && (
@@ -1428,7 +1644,7 @@ const DetailContent = React.memo(({
                             <Star className="mr-2 h-4 w-4" />
                             {selectedVersion.featuredKey === 'featured' ? 'Unstar Version' : 'Star Version'}
                           </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => setIsVersionDiffOpen(true)}>
+                          <DropdownMenuItem onClick={() => handleOpenVersionDiff()}>
                             <GitCompareArrows className="mr-2 h-4 w-4" />
                             Compare Versions
                           </DropdownMenuItem>
@@ -1960,6 +2176,8 @@ const DetailContent = React.memo(({
         versions={versions ?? []}
         selectedVersionId={selectedVersionId}
         championVersionId={championVersionId}
+        initialLeftVersionId={versionDiffInitialPair.leftVersionId}
+        initialRightVersionId={versionDiffInitialPair.rightVersionId}
       />
     </div>
   )
@@ -2009,6 +2227,55 @@ export function ScoreComponent({
   const [guidelinesEditValue, setGuidelinesEditValue] = React.useState('')
   const [hasGuidelinesChanges, setHasGuidelinesChanges] = React.useState(false)
   const [isSavingGuidelines, setIsSavingGuidelines] = React.useState(false)
+
+  const sortScoreVersions = React.useCallback((items: ScoreVersion[]) =>
+    [...items].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()), [])
+
+  const mergeScoreVersions = React.useCallback((existing: ScoreVersion[], incoming: ScoreVersion[]) => {
+    const byId = new Map<string, ScoreVersion>();
+    for (const item of existing) byId.set(item.id, item);
+    for (const item of incoming) byId.set(item.id, item);
+    return sortScoreVersions([...byId.values()]);
+  }, [sortScoreVersions])
+
+  const hydrateVersionById = React.useCallback(async (versionId: string): Promise<ScoreVersion | null> => {
+    const existingVersion = versions.find(version => version.id === versionId)
+    if (existingVersion) return existingVersion
+
+    try {
+      const response = await getAmplifyClient().graphql({
+        query: `
+          query GetScoreVersion($id: ID!) {
+            getScoreVersion(id: $id) {
+              id
+              scoreId
+              configuration
+              guidelines
+              isFeatured
+              featuredKey
+              note
+              branch
+              parentVersionId
+              createdAt
+              updatedAt
+              metadata
+            }
+          }
+        `,
+        variables: { id: String(versionId) },
+      }) as GraphQLResult<GetScoreVersionResponse>;
+
+      const version = response.data?.getScoreVersion ?? null;
+      if (!version || version.scoreId !== score.id) return null
+
+      setVersions(prev => mergeScoreVersions(prev, [version]))
+      setLoadedVersionCount(prev => Math.max(prev, mergeScoreVersions(versions, [version]).length))
+      return version
+    } catch (error) {
+      console.error('Failed to hydrate related score version:', formatAmplifyError(error))
+      return null
+    }
+  }, [mergeScoreVersions, score.id, versions])
 
   // Version selection handler
   const handleVersionSelect = (version: ScoreVersion) => {
@@ -2993,6 +3260,7 @@ export function ScoreComponent({
               championVersionId={championVersionId}
               selectedVersionId={selectedVersionId}
               onVersionSelect={handleVersionSelect}
+              onHydrateVersionById={hydrateVersionById}
               onToggleFeature={handleToggleFeature}
               onPromoteToChampion={handlePromoteToChampion}
               isVersionsLoading={isVersionsLoading}

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -431,8 +431,8 @@ function RelatedScoreVersionCard({
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="flex items-start justify-between gap-3 pl-2 pb-2">
-            <div className="min-w-0 flex-1 text-xs text-muted-foreground">
+          <div className="flex items-start justify-between gap-3 pb-2">
+            <div className="min-w-0 flex-1 text-sm text-muted-foreground">
               {relatedVersion?.note || (failedToLoad ? 'This related version could not be loaded.' : 'Loading related version details...')}
             </div>
             <Button
@@ -1621,7 +1621,7 @@ const DetailContent = React.memo(({
                     <div className="text-xs text-muted-foreground mb-2">
                       <Timestamp time={selectedVersion.createdAt} variant="relative" className="text-xs" />
                     </div>
-                    <div className="text-xs text-muted-foreground">
+                    <div className="text-sm text-muted-foreground">
                       {selectedVersion.note || 'No note'}
                     </div>
                     {relatedVersionTargets.length > 0 && (

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -1425,7 +1425,7 @@ const DetailContent = React.memo(({
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem onClick={() => onToggleFeature?.(selectedVersion.id)}>
                             <Star className="mr-2 h-4 w-4" />
-                            {selectedVersion.isFeatured ? 'Unstar Version' : 'Star Version'}
+                            {selectedVersion.featuredKey === 'featured' ? 'Unstar Version' : 'Star Version'}
                           </DropdownMenuItem>
                           <DropdownMenuItem onClick={() => setIsVersionDiffOpen(true)}>
                             <GitCompareArrows className="mr-2 h-4 w-4" />
@@ -2558,6 +2558,8 @@ export function ScoreComponent({
     try {
       const version = versions.find(v => v.id === versionId);
       if (!version) return;
+      const isPinned = version.featuredKey === 'featured';
+      const nextPinned = !isPinned;
 
       // Enable API call to persist the feature status
       await getAmplifyClient().graphql({
@@ -2573,8 +2575,8 @@ export function ScoreComponent({
         variables: {
           input: {
             id: String(versionId),
-            isFeatured: !version.isFeatured,
-            featuredKey: !version.isFeatured ? 'featured' : 'unfeatured',
+            isFeatured: nextPinned,
+            featuredKey: nextPinned ? 'featured' : 'unfeatured',
           }
         }
       });
@@ -2583,7 +2585,7 @@ export function ScoreComponent({
       // This ensures UI is updated even if we can't verify the response format
       setVersions(prev => prev.map(v => 
         v.id === versionId
-          ? { ...v, isFeatured: !v.isFeatured, featuredKey: !v.isFeatured ? 'featured' : 'unfeatured' }
+          ? { ...v, isFeatured: nextPinned, featuredKey: nextPinned ? 'featured' : 'unfeatured' }
           : v
       ));
 

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -431,7 +431,7 @@ function RelatedScoreVersionCard({
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="flex items-start justify-between gap-3 px-2 pb-2">
+          <div className="flex items-start justify-between gap-3 pl-2 pb-2">
             <div className="min-w-0 flex-1 text-xs text-muted-foreground">
               {relatedVersion?.note || (failedToLoad ? 'This related version could not be loaded.' : 'Loading related version details...')}
             </div>

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -1608,8 +1608,8 @@ const DetailContent = React.memo(({
               </div>
             ) : selectedVersion && (
               <div className="p-3">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
+                <div className="relative">
+                  <div className="min-w-0">
                     <div className="flex items-center gap-2 mb-2">
                       <h3 className="font-medium text-sm">
                         {selectedVersion.id === championVersionId ? 'Champion Version' : 'Version'}
@@ -1644,7 +1644,7 @@ const DetailContent = React.memo(({
                       </div>
                     )}
                   </div>
-                  <div className="flex items-center gap-2 ml-3">
+                  <div className="absolute right-0 top-0 flex items-center gap-2">
                     {selectedVersion && (
                       <ShadcnDropdownMenu>
                         <DropdownMenuTrigger asChild>

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -431,20 +431,20 @@ function RelatedScoreVersionCard({
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="px-2 pb-2 space-y-2">
-            <div className="text-xs text-muted-foreground">
+          <div className="flex items-start justify-between gap-3 px-2 pb-2">
+            <div className="min-w-0 flex-1 text-xs text-muted-foreground">
               {relatedVersion?.note || (failedToLoad ? 'This related version could not be loaded.' : 'Loading related version details...')}
             </div>
             <Button
               type="button"
               size="sm"
               variant="secondary"
-              className="h-8"
+              className="h-6 shrink-0 px-2 text-xs"
               disabled={!relatedVersion}
               onClick={() => relatedVersion && onCompare?.(relatedVersion.id, currentVersion.id)}
             >
-              <GitCompareArrows className="mr-2 h-4 w-4" />
-              Compare with this version
+              <GitCompareArrows className="mr-1.5 h-3.5 w-3.5" />
+              Compare
             </Button>
           </div>
         </CollapsibleContent>

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
-import { MoreHorizontal, X, Square, Columns2, FileStack, ChevronDown, ChevronUp, ChevronRight, Award, FileCode, Minimize, Maximize, ArrowDownWideNarrow, Expand, Shrink, TestTube, FlaskConical, FlaskRound, TestTubes, ListCheck, MessageCircleMore, IdCard, Coins, Trash2, Crown, Clock, PanelLeftOpen, PanelLeftClose, Edit, Star, GitCompareArrows, History } from 'lucide-react'
+import { MoreHorizontal, X, Square, Columns2, FileStack, ChevronDown, ChevronUp, ChevronRight, Award, FileCode, Minimize, Maximize, ArrowDownWideNarrow, Expand, Shrink, TestTube, FlaskConical, FlaskRound, TestTubes, ListCheck, MessageCircleMore, IdCard, Coins, Trash2, Crown, Clock, PanelLeftOpen, PanelLeftClose, Edit, Star, GitCompareArrows, History, Link as LinkIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
@@ -378,22 +378,25 @@ function RelatedScoreVersionCard({
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0 flex items-center gap-2">
                 {isOpen ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
-                <div className="min-w-0">
-                  <div className="text-xs font-medium truncate">{label}</div>
-                  <div className="text-xs text-muted-foreground truncate">
+                <div className="min-w-0 flex items-center gap-1.5 text-xs truncate">
+                  <span className="font-medium truncate">{label}</span>
+                  <span className="text-muted-foreground">·</span>
+                  <span className="text-muted-foreground truncate">
                     {relatedVersion
                       ? <Timestamp time={relatedVersion.createdAt} variant="relative" showIcon={false} className="text-xs" />
                       : failedToLoad
                         ? `Unavailable: ${relatedVersionId}`
                         : `Loading: ${relatedVersionId}`}
-                  </div>
+                  </span>
                 </div>
               </div>
               {relatedVersion && (
                 <span
                   role="button"
                   tabIndex={0}
-                  className="shrink-0 text-xs text-primary hover:text-primary/80"
+                  aria-label="Open related version"
+                  title="Open related version"
+                  className="shrink-0 rounded-sm p-1 text-foreground hover:bg-card"
                   onClick={(event) => {
                     event.stopPropagation()
                     onSelect?.(relatedVersion)
@@ -406,7 +409,7 @@ function RelatedScoreVersionCard({
                     }
                   }}
                 >
-                  Open version
+                  <LinkIcon className="h-4 w-4" />
                 </span>
               )}
             </div>

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -389,7 +389,7 @@ function RelatedScoreVersionCard({
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <div className="bg-background rounded-md">
         <CollapsibleTrigger asChild>
-          <button type="button" className="w-full p-2 text-left">
+          <button type="button" className="w-full py-2 pr-2 text-left">
             <div className="flex items-center gap-3">
               <div className="min-w-0 flex items-center gap-2">
                 {isOpen ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
-import { MoreHorizontal, X, Square, Columns2, FileStack, ChevronDown, ChevronUp, ChevronRight, Award, FileCode, Minimize, Maximize, ArrowDownWideNarrow, Expand, Shrink, TestTube, FlaskConical, FlaskRound, TestTubes, ListCheck, MessageCircleMore, IdCard, Coins, Trash2, Crown, Clock, PanelLeftOpen, PanelLeftClose, Edit } from 'lucide-react'
+import { MoreHorizontal, X, Square, Columns2, FileStack, ChevronDown, ChevronUp, ChevronRight, Award, FileCode, Minimize, Maximize, ArrowDownWideNarrow, Expand, Shrink, TestTube, FlaskConical, FlaskRound, TestTubes, ListCheck, MessageCircleMore, IdCard, Coins, Trash2, Crown, Clock, PanelLeftOpen, PanelLeftClose, Edit, Star, GitCompareArrows, History } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
@@ -41,6 +41,7 @@ import { useAccount } from '@/app/contexts/AccountContext'
 import { GuidelinesEditor, FullscreenGuidelinesEditor } from '@/components/ui/guidelines-editor'
 import { ScoreProcedureList } from '@/components/ui/score-procedure-list'
 import { ScoreEvaluationList } from '@/components/ui/score-evaluation-list'
+import { ScoreVersionDiffDialog } from '@/components/ui/score-version-diff-dialog'
 import { Timestamp } from "@/components/ui/timestamp"
 import { ScoreHeaderInfo, type ScoreHeaderData } from '@/components/ui/score-header-info'
 import { IdentifierDisplay } from '@/components/ui/identifier-display'
@@ -70,10 +71,12 @@ export interface ScoreVersion {
   configuration: string // YAML string
   guidelines?: string
   isFeatured: boolean
+  featuredKey?: string
   isChampion?: boolean
   note?: string
   branch?: string
   parentVersionId?: string
+  metadata?: Record<string, any> | null
   createdAt: string
   updatedAt: string
   user?: {
@@ -102,6 +105,72 @@ interface GetScoreVersionsResponse {
 
 interface CreateScoreVersionResponse {
   createScoreVersion: ScoreVersion
+}
+
+const buildChampionMetadata = ({
+  metadata,
+  scoreId,
+  versionId,
+  enteredAt,
+  exitedAt,
+  previousChampionVersionId,
+  nextChampionVersionId,
+  transitionId,
+  incoming,
+}: {
+  metadata?: Record<string, any> | null
+  scoreId: string
+  versionId: string
+  enteredAt?: string | null
+  exitedAt?: string | null
+  previousChampionVersionId?: string | null
+  nextChampionVersionId?: string | null
+  transitionId: string
+  incoming: boolean
+}) => {
+  const nextMetadata = {
+    ...(metadata && typeof metadata === 'object' ? metadata : {}),
+  }
+  const history = Array.isArray(nextMetadata.championHistory)
+    ? [...nextMetadata.championHistory]
+    : []
+
+  if (incoming) {
+    history.push({
+      scoreId,
+      versionId,
+      enteredAt,
+      exitedAt: null,
+      previousChampionVersionId: previousChampionVersionId || null,
+      nextChampionVersionId: null,
+      transitionId,
+    })
+  } else {
+    const openIndex = [...history].reverse().findIndex((entry) => entry && !entry.exitedAt)
+    if (openIndex >= 0) {
+      const actualIndex = history.length - 1 - openIndex
+      history[actualIndex] = {
+        ...history[actualIndex],
+        exitedAt,
+        nextChampionVersionId: nextChampionVersionId || null,
+        transitionId,
+      }
+    } else {
+      history.push({
+        scoreId,
+        versionId,
+        enteredAt: null,
+        exitedAt,
+        previousChampionVersionId: null,
+        nextChampionVersionId: nextChampionVersionId || null,
+        transitionId,
+        inferred: true,
+      })
+    }
+  }
+
+  nextMetadata.championHistory = history
+  return nextMetadata
 }
 
 // Add a new interface for the secondary index query response
@@ -147,6 +216,7 @@ interface ScoreComponentProps extends React.HTMLAttributes<HTMLDivElement> {
   onCostAnalysis?: () => void
   onViewProcedures?: () => void
   onViewEvaluations?: () => void
+  onViewChampionHistory?: () => void
   onDelete?: () => void
   exampleItems?: Array<{
     id: string
@@ -182,6 +252,7 @@ interface DetailContentProps {
   onCostAnalysis?: () => void
   onViewProcedures?: () => void
   onViewEvaluations?: () => void
+  onViewChampionHistory?: () => void
   onDelete?: () => void
   hasChanges?: boolean
   versions?: ScoreVersion[]
@@ -614,6 +685,7 @@ const DetailContent = React.memo(({
   onCostAnalysis,
   onViewProcedures,
   onViewEvaluations,
+  onViewChampionHistory,
   onDelete,
   hasChanges,
   versions,
@@ -862,6 +934,7 @@ const DetailContent = React.memo(({
   const [evaluationAction, setEvaluationAction] = React.useState<{name: string, type: string, versionId?: string} | null>(null)
   const [isFeedbackDialogOpen, setIsFeedbackDialogOpen] = React.useState(false)
   const [feedbackAction, setFeedbackAction] = React.useState<{name: string, versionId?: string} | null>(null)
+  const [isVersionDiffOpen, setIsVersionDiffOpen] = React.useState(false)
 
   
 
@@ -1146,6 +1219,12 @@ const DetailContent = React.memo(({
                         View Evaluations
                       </DropdownMenuItem>
                     )}
+                    {onViewChampionHistory && (
+                      <DropdownMenuItem onClick={onViewChampionHistory}>
+                        <History className="mr-2 h-4 w-4" />
+                        View Champion History
+                      </DropdownMenuItem>
+                    )}
                     {onDelete && (
                       <>
                         <DropdownMenuSeparator />
@@ -1293,6 +1372,7 @@ const DetailContent = React.memo(({
             championVersionId={championVersionId}
             selectedVersionId={selectedVersionId}
             onVersionSelect={onVersionSelect}
+            onToggleFeature={onToggleFeature}
             isSidebarCollapsed={isSidebarCollapsed}
             onToggleSidebar={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
             isLoading={isVersionsLoading && !hasLoadedFirstVersionPage}
@@ -1343,6 +1423,15 @@ const DetailContent = React.memo(({
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => onToggleFeature?.(selectedVersion.id)}>
+                            <Star className="mr-2 h-4 w-4" />
+                            {selectedVersion.isFeatured ? 'Unstar Version' : 'Star Version'}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => setIsVersionDiffOpen(true)}>
+                            <GitCompareArrows className="mr-2 h-4 w-4" />
+                            Compare Versions
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
                           {selectedVersion.id !== championVersionId && onPromoteToChampion && (
                             <>
                               <DropdownMenuItem onClick={() => onPromoteToChampion(selectedVersion.id)}>
@@ -1863,6 +1952,14 @@ const DetailContent = React.memo(({
         scoreName={score.name}
         exampleItems={exampleItems}
       />
+
+      <ScoreVersionDiffDialog
+        isOpen={isVersionDiffOpen}
+        onClose={() => setIsVersionDiffOpen(false)}
+        versions={versions ?? []}
+        selectedVersionId={selectedVersionId}
+        championVersionId={championVersionId}
+      />
     </div>
   )
 })
@@ -1880,6 +1977,7 @@ export function ScoreComponent({
   onCostAnalysis,
   onViewProcedures,
   onViewEvaluations,
+  onViewChampionHistory,
   onDelete,
   exampleItems = [],
   scorecardName,
@@ -2014,11 +2112,13 @@ export function ScoreComponent({
               configuration
               guidelines
               isFeatured
+              featuredKey
               note
               branch
               parentVersionId
               createdAt
               updatedAt
+              metadata
             }
           }
         `,
@@ -2050,21 +2150,23 @@ export function ScoreComponent({
                 configuration
                 guidelines
                 isFeatured
+                featuredKey
                 note
                 branch
                 parentVersionId
                 createdAt
                 updatedAt
+                metadata
               }
               nextToken
             }
           }
         `,
         variables: {
-          scoreId: String(score.id),
-          sortDirection: "DESC",
-          limit: 100,
-          nextToken,
+            scoreId: String(score.id),
+            sortDirection: "DESC",
+            limit: 100,
+            nextToken,
         }
       }) as GraphQLResult<GetScoreVersionsByScoreIdResponse>;
 
@@ -2077,6 +2179,51 @@ export function ScoreComponent({
         items: resultData?.items ?? [],
         nextToken: resultData?.nextToken ?? null,
       };
+    };
+
+    const fetchPinnedVersions = async () => {
+      const response = await getAmplifyClient().graphql({
+        query: `
+          query GetPinnedScoreVersionsByScoreId(
+            $scoreId: String!
+            $sortDirection: ModelSortDirection
+            $limit: Int
+          ) {
+            listScoreVersionByScoreIdAndFeaturedKeyAndCreatedAt(
+              scoreId: $scoreId,
+              featuredKeyCreatedAt: { beginsWith: { featuredKey: "featured" } },
+              sortDirection: $sortDirection,
+              limit: $limit
+            ) {
+              items {
+                id
+                scoreId
+                configuration
+                guidelines
+                isFeatured
+                featuredKey
+                note
+                branch
+                parentVersionId
+                createdAt
+                updatedAt
+                metadata
+              }
+            }
+          }
+        `,
+        variables: {
+          scoreId: String(score.id),
+          sortDirection: "DESC",
+          limit: 100,
+        }
+      }) as GraphQLResult<{
+        listScoreVersionByScoreIdAndFeaturedKeyAndCreatedAt?: {
+          items: ScoreVersion[]
+        }
+      }>;
+
+      return response.data?.listScoreVersionByScoreIdAndFeaturedKeyAndCreatedAt?.items ?? [];
     };
 
     const selectPreferredVersion = async (
@@ -2157,10 +2304,13 @@ export function ScoreComponent({
           }
         }
 
-        const firstPage = await fetchVersionPage(null);
+        const [firstPage, pinnedVersions] = await Promise.all([
+          fetchVersionPage(null),
+          fetchPinnedVersions(),
+        ]);
         if (cancelled) return;
 
-        const firstPageVersions = sortVersions(firstPage.items);
+        const firstPageVersions = mergeVersions(firstPage.items, pinnedVersions);
         setVersions(firstPageVersions);
         setLoadedVersionCount(firstPageVersions.length);
         setHasLoadedFirstVersionPage(true);
@@ -2416,13 +2566,15 @@ export function ScoreComponent({
             updateScoreVersion(input: $input) {
               id
               isFeatured
+              featuredKey
             }
           }
         `,
         variables: {
           input: {
             id: String(versionId),
-            isFeatured: !version.isFeatured
+            isFeatured: !version.isFeatured,
+            featuredKey: !version.isFeatured ? 'featured' : 'unfeatured',
           }
         }
       });
@@ -2430,7 +2582,9 @@ export function ScoreComponent({
       // Update local state regardless of response
       // This ensures UI is updated even if we can't verify the response format
       setVersions(prev => prev.map(v => 
-        v.id === versionId ? { ...v, isFeatured: !v.isFeatured } : v
+        v.id === versionId
+          ? { ...v, isFeatured: !v.isFeatured, featuredKey: !v.isFeatured ? 'featured' : 'unfeatured' }
+          : v
       ));
 
       toast.success('Version feature status updated');
@@ -2574,6 +2728,7 @@ export function ScoreComponent({
         configuration: configurationYaml,
         guidelines: overrideGuidelines !== undefined ? overrideGuidelines : (editedScore.guidelines || ''),
         isFeatured: false,
+        featuredKey: 'unfeatured',
         note: versionNote || 'Updated score configuration',
         createdAt: now,
         updatedAt: now
@@ -2588,6 +2743,7 @@ export function ScoreComponent({
               configuration
               guidelines
               isFeatured
+              featuredKey
               note
               createdAt
               updatedAt
@@ -2669,6 +2825,14 @@ export function ScoreComponent({
     try {
       const version = versions.find(v => v.id === versionId);
       if (!version) return;
+      const previousChampionVersionId = championVersionId && championVersionId !== versionId ? championVersionId : undefined;
+      const previousChampionVersion = previousChampionVersionId
+        ? versions.find(v => v.id === previousChampionVersionId)
+        : undefined;
+      const promotedAt = new Date().toISOString();
+      const transitionId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `${versionId}-${promotedAt}`;
 
       // Update the Score record to set this as the champion version
       await getAmplifyClient().graphql({
@@ -2688,8 +2852,71 @@ export function ScoreComponent({
         }
       });
 
+      const updateVersionMetadata = async (targetVersionId: string, metadata: Record<string, any>) => {
+        await getAmplifyClient().graphql({
+          query: `
+            mutation UpdateScoreVersionMetadata($input: UpdateScoreVersionInput!) {
+              updateScoreVersion(input: $input) {
+                id
+                metadata
+              }
+            }
+          `,
+          variables: {
+            input: {
+              id: String(targetVersionId),
+              metadata,
+            }
+          }
+        });
+      };
+
+      const incomingMetadata = buildChampionMetadata({
+        metadata: version.metadata,
+        scoreId: score.id,
+        versionId,
+        enteredAt: promotedAt,
+        previousChampionVersionId: previousChampionVersionId || null,
+        transitionId,
+        incoming: true,
+      });
+      await updateVersionMetadata(versionId, incomingMetadata);
+
+      if (previousChampionVersionId) {
+        const outgoingMetadata = buildChampionMetadata({
+          metadata: previousChampionVersion?.metadata,
+          scoreId: score.id,
+          versionId: previousChampionVersionId,
+          exitedAt: promotedAt,
+          nextChampionVersionId: versionId,
+          transitionId,
+          incoming: false,
+        });
+        await updateVersionMetadata(previousChampionVersionId, outgoingMetadata);
+      }
+
       // Update local state
       setChampionVersionId(versionId);
+      setVersions(prev => prev.map(item => {
+        if (item.id === versionId) {
+          return { ...item, metadata: incomingMetadata };
+        }
+        if (item.id === previousChampionVersionId) {
+          return {
+            ...item,
+            metadata: buildChampionMetadata({
+              metadata: item.metadata,
+              scoreId: score.id,
+              versionId: item.id,
+              exitedAt: promotedAt,
+              nextChampionVersionId: versionId,
+              transitionId,
+              incoming: false,
+            })
+          };
+        }
+        return item;
+      }));
       
       // If this version is not already selected, select it
       if (selectedVersionId !== versionId) {
@@ -2755,6 +2982,7 @@ export function ScoreComponent({
               onCostAnalysis={onCostAnalysis}
               onViewProcedures={onViewProcedures}
               onViewEvaluations={onViewEvaluations}
+              onViewChampionHistory={onViewChampionHistory}
               onDelete={onDelete}
               hasChanges={hasChanges}
               versions={versions}

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -109,6 +109,23 @@ interface CreateScoreVersionResponse {
   createScoreVersion: ScoreVersion
 }
 
+const parseScoreVersionMetadata = (metadata: unknown): Record<string, any> => {
+  if (!metadata) return {}
+  if (typeof metadata === 'string') {
+    const trimmed = metadata.trim()
+    if (!trimmed) return {}
+    const parsed = JSON.parse(trimmed)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  }
+  return typeof metadata === 'object' && !Array.isArray(metadata) ? metadata as Record<string, any> : {}
+}
+
+const assertGraphQLSuccess = (response: any, action: string) => {
+  if (response?.errors?.length) {
+    throw new Error(`${action}: ${response.errors.map((error: any) => error?.message || String(error)).join('; ')}`)
+  }
+}
+
 const buildChampionMetadata = ({
   metadata,
   scoreId,
@@ -120,7 +137,7 @@ const buildChampionMetadata = ({
   transitionId,
   incoming,
 }: {
-  metadata?: Record<string, any> | null
+  metadata?: unknown
   scoreId: string
   versionId: string
   enteredAt?: string | null
@@ -130,9 +147,7 @@ const buildChampionMetadata = ({
   transitionId: string
   incoming: boolean
 }) => {
-  const nextMetadata = {
-    ...(metadata && typeof metadata === 'object' ? metadata : {}),
-  }
+  const nextMetadata = parseScoreVersionMetadata(metadata)
   const history = Array.isArray(nextMetadata.championHistory)
     ? [...nextMetadata.championHistory]
     : []
@@ -3109,7 +3124,7 @@ export function ScoreComponent({
         : `${versionId}-${promotedAt}`;
 
       // Update the Score record to set this as the champion version
-      await getAmplifyClient().graphql({
+      const updateScoreResponse = await getAmplifyClient().graphql({
         query: `
           mutation UpdateScoreChampion($input: UpdateScoreInput!) {
             updateScore(input: $input) {
@@ -3125,9 +3140,10 @@ export function ScoreComponent({
           }
         }
       });
+      assertGraphQLSuccess(updateScoreResponse, 'Update score champion');
 
       const updateVersionMetadata = async (targetVersionId: string, metadata: Record<string, any>) => {
-        await getAmplifyClient().graphql({
+        const updateMetadataResponse = await getAmplifyClient().graphql({
           query: `
             mutation UpdateScoreVersionMetadata($input: UpdateScoreVersionInput!) {
               updateScoreVersion(input: $input) {
@@ -3139,10 +3155,11 @@ export function ScoreComponent({
           variables: {
             input: {
               id: String(targetVersionId),
-              metadata,
+              metadata: JSON.stringify(metadata),
             }
           }
         });
+        assertGraphQLSuccess(updateMetadataResponse, 'Update score version champion metadata');
       };
 
       const incomingMetadata = buildChampionMetadata({
@@ -3199,8 +3216,9 @@ export function ScoreComponent({
 
       toast.success('Version promoted to champion');
     } catch (error) {
-      console.error('Error promoting version to champion:', error);
-      toast.error('Failed to promote version to champion');
+      const message = formatAmplifyError(error);
+      console.error('Error promoting version to champion:', message);
+      toast.error(`Failed to promote version to champion: ${message}`);
     }
   };
 

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -375,43 +375,43 @@ function RelatedScoreVersionCard({
       <div className="bg-background rounded-md">
         <CollapsibleTrigger asChild>
           <button type="button" className="w-full p-2 text-left">
-            <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
               <div className="min-w-0 flex items-center gap-2">
                 {isOpen ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
                 <div className="min-w-0 flex items-center gap-1.5 text-xs truncate">
                   <span className="font-medium truncate">{label}</span>
                   <span className="text-muted-foreground">·</span>
-                  <span className="text-muted-foreground truncate">
-                    {relatedVersion
-                      ? <Timestamp time={relatedVersion.createdAt} variant="relative" showIcon={false} className="text-xs" />
-                      : failedToLoad
-                        ? `Unavailable: ${relatedVersionId}`
-                        : `Loading: ${relatedVersionId}`}
-                  </span>
+                  {relatedVersion ? (
+                    <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground truncate">
+                      <Timestamp time={relatedVersion.createdAt} variant="relative" className="text-xs" />
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        aria-label="Open related version"
+                        title="Open related version"
+                        className="shrink-0 rounded-sm p-1 text-foreground hover:bg-card"
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          onSelect?.(relatedVersion)
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault()
+                            event.stopPropagation()
+                            onSelect?.(relatedVersion)
+                          }
+                        }}
+                      >
+                        <LinkIcon className="h-4 w-4" />
+                      </span>
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground truncate">
+                      {failedToLoad ? `Unavailable: ${relatedVersionId}` : `Loading: ${relatedVersionId}`}
+                    </span>
+                  )}
                 </div>
               </div>
-              {relatedVersion && (
-                <span
-                  role="button"
-                  tabIndex={0}
-                  aria-label="Open related version"
-                  title="Open related version"
-                  className="shrink-0 rounded-sm p-1 text-foreground hover:bg-card"
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onSelect?.(relatedVersion)
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault()
-                      event.stopPropagation()
-                      onSelect?.(relatedVersion)
-                    }
-                  }}
-                >
-                  <LinkIcon className="h-4 w-4" />
-                </span>
-              )}
             </div>
           </button>
         </CollapsibleTrigger>

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -37,6 +37,7 @@ import YamlLinterPanel from '@/components/ui/yaml-linter-panel'
 import { TestScoreDialog } from '@/components/scorecards/test-score-dialog'
 import { EvaluationDialog, FeedbackEvaluationDialog } from '@/components/task-dispatch'
 import { createTask } from '@/utils/data-operations'
+import { formatAmplifyError } from '@/utils/amplify-client'
 import { useAccount } from '@/app/contexts/AccountContext'
 import { GuidelinesEditor, FullscreenGuidelinesEditor } from '@/components/ui/guidelines-editor'
 import { ScoreProcedureList } from '@/components/ui/score-procedure-list'
@@ -2577,6 +2578,7 @@ export function ScoreComponent({
             id: String(versionId),
             isFeatured: nextPinned,
             featuredKey: nextPinned ? 'featured' : 'unfeatured',
+            createdAt: version.createdAt,
           }
         }
       });
@@ -2591,7 +2593,7 @@ export function ScoreComponent({
 
       toast.success('Version feature status updated');
     } catch (error) {
-      console.error('Error toggling feature:', error);
+      console.error('Error toggling version favorite:', formatAmplifyError(error));
       toast.error('Failed to update version feature status');
     }
   };

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -438,8 +438,8 @@ function RelatedScoreVersionCard({
             <Button
               type="button"
               size="sm"
-              variant="secondary"
-              className="h-6 shrink-0 px-2 text-xs"
+              variant="ghost"
+              className="h-6 shrink-0 bg-muted px-2 text-xs text-muted-foreground hover:bg-muted/80 hover:text-foreground"
               disabled={!relatedVersion}
               onClick={() => relatedVersion && onCompare?.(relatedVersion.id, currentVersion.id)}
             >

--- a/dashboard/components/ui/score-sidebar-version-history.tsx
+++ b/dashboard/components/ui/score-sidebar-version-history.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import { Button } from "@/components/ui/button"
 import { Crown, Clock, PanelLeftOpen, PanelLeftClose, Star } from 'lucide-react'
+import { LayoutGroup, motion, useReducedMotion } from 'framer-motion'
 import { Timestamp } from "@/components/ui/timestamp"
 import { ScoreVersion } from "./score-component"
 
@@ -31,6 +32,14 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
 }) => {
   // State for sidebar width (in pixels)
   const [sidebarWidth, setSidebarWidth] = React.useState(320) // Default 320px (w-80)
+  const prefersReducedMotion = useReducedMotion()
+  const shouldAnimateLayout = !prefersReducedMotion
+  const versionLayoutTransition = {
+    type: 'spring' as const,
+    stiffness: 420,
+    damping: 38,
+    mass: 0.7,
+  }
 
   // Drag resize handler
   const handleDragStart = React.useCallback((e: React.MouseEvent) => {
@@ -84,51 +93,57 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
   const recentVersions = sortedVersions.filter(v => v.id !== championVersionId && !isPinned(v))
 
   const renderVersionButton = (version: ScoreVersion, icon: React.ReactNode, title?: string) => (
-    <Button
+    <motion.div
       key={version.id}
-      variant={selectedVersionId === version.id ? "secondary" : "ghost"}
-      size="sm"
-      onClick={() => onVersionSelect?.(version)}
-      className="w-full justify-start text-left p-2 h-auto"
+      layout={shouldAnimateLayout ? "position" : false}
+      layoutId={shouldAnimateLayout ? `score-version-${version.id}` : undefined}
+      transition={versionLayoutTransition}
     >
-      <div className="flex items-center gap-2 min-w-0 flex-1">
-        {icon}
-        <div className="min-w-0 flex-1">
-          <div className="text-xs font-medium truncate">
-            {title || version.note || `Version ${version.id.slice(0, 8)}`}
-          </div>
-          {title && (
-            <div className="text-xs text-muted-foreground truncate">
-              {version.note || `Version ${version.id.slice(0, 8)}`}
+      <Button
+        variant={selectedVersionId === version.id ? "secondary" : "ghost"}
+        size="sm"
+        onClick={() => onVersionSelect?.(version)}
+        className="w-full justify-start text-left p-2 h-auto"
+      >
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          {icon}
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium truncate">
+              {title || version.note || `Version ${version.id.slice(0, 8)}`}
             </div>
-          )}
-          <div className="text-xs text-muted-foreground">
-            <Timestamp time={version.createdAt} variant="relative" showIcon={false} className="text-xs" />
+            {title && (
+              <div className="text-xs text-muted-foreground truncate">
+                {version.note || `Version ${version.id.slice(0, 8)}`}
+              </div>
+            )}
+            <div className="text-xs text-muted-foreground">
+              <Timestamp time={version.createdAt} variant="relative" showIcon={false} className="text-xs" />
+            </div>
           </div>
-        </div>
-        {onToggleFeature && version.id !== championVersionId && (
-          <span
-            role="button"
-            tabIndex={0}
-            aria-label={isPinned(version) ? "Unstar version" : "Star version"}
-            className="shrink-0 rounded-sm p-1 text-muted-foreground hover:bg-background hover:text-foreground"
-            onClick={(event) => {
-              event.stopPropagation()
-              onToggleFeature(version.id)
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault()
+          {onToggleFeature && version.id !== championVersionId && (
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label={isPinned(version) ? "Unstar version" : "Star version"}
+              className="shrink-0 rounded-sm p-1 text-muted-foreground hover:bg-background hover:text-foreground"
+              onClick={(event) => {
                 event.stopPropagation()
                 onToggleFeature(version.id)
-              }
-            }}
-          >
-            <Star className={`h-3.5 w-3.5 ${isPinned(version) ? 'fill-current' : ''}`} />
-          </span>
-        )}
-      </div>
-    </Button>
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  event.stopPropagation()
+                  onToggleFeature(version.id)
+                }
+              }}
+            >
+              <Star className={`h-3.5 w-3.5 ${isPinned(version) ? 'fill-current' : ''}`} />
+            </span>
+          )}
+        </div>
+      </Button>
+    </motion.div>
   )
 
   return (
@@ -161,7 +176,8 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
       
       {/* Version List */}
       {!isSidebarCollapsed && (
-        <div className="flex-1 overflow-y-auto p-2 space-y-1">
+        <LayoutGroup id="score-version-history">
+          <div className="flex-1 overflow-y-auto p-2 space-y-1">
           {isLoading && versions.length === 0 && (
             Array.from({ length: 6 }).map((_, index) => (
               <div key={`version-skeleton-${index}`} className="w-full p-2">
@@ -203,7 +219,8 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
           {isLoadingMore && versions.length > 0 && (
             <div className="px-2 py-1 text-xs text-muted-foreground">Loading more versions...</div>
           )}
-        </div>
+          </div>
+        </LayoutGroup>
       )}
       
       {/* Collapsed Sidebar Content */}

--- a/dashboard/components/ui/score-sidebar-version-history.tsx
+++ b/dashboard/components/ui/score-sidebar-version-history.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import { Button } from "@/components/ui/button"
-import { Crown, Clock, PanelLeftOpen, PanelLeftClose } from 'lucide-react'
+import { Crown, Clock, PanelLeftOpen, PanelLeftClose, Star } from 'lucide-react'
 import { Timestamp } from "@/components/ui/timestamp"
 import { ScoreVersion } from "./score-component"
 
@@ -11,6 +11,7 @@ interface ScoreSidebarVersionHistoryProps {
   championVersionId?: string
   selectedVersionId?: string
   onVersionSelect?: (version: ScoreVersion) => void
+  onToggleFeature?: (versionId: string) => void
   isSidebarCollapsed?: boolean
   onToggleSidebar?: () => void
   isLoading?: boolean
@@ -22,6 +23,7 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
   championVersionId,
   selectedVersionId,
   onVersionSelect,
+  onToggleFeature,
   isSidebarCollapsed = false,
   onToggleSidebar,
   isLoading = false,
@@ -77,6 +79,56 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
   const sortedVersions = [...versions].sort((a, b) => 
     new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
+  const pinnedVersions = sortedVersions.filter(v => v.isFeatured && v.id !== championVersionId)
+  const recentVersions = sortedVersions.filter(v => v.id !== championVersionId && !v.isFeatured)
+
+  const renderVersionButton = (version: ScoreVersion, icon: React.ReactNode, title?: string) => (
+    <Button
+      key={version.id}
+      variant={selectedVersionId === version.id ? "secondary" : "ghost"}
+      size="sm"
+      onClick={() => onVersionSelect?.(version)}
+      className="w-full justify-start text-left p-2 h-auto"
+    >
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        {icon}
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium truncate">
+            {title || version.note || `Version ${version.id.slice(0, 8)}`}
+          </div>
+          {title && (
+            <div className="text-xs text-muted-foreground truncate">
+              {version.note || `Version ${version.id.slice(0, 8)}`}
+            </div>
+          )}
+          <div className="text-xs text-muted-foreground">
+            <Timestamp time={version.createdAt} variant="relative" showIcon={false} className="text-xs" />
+          </div>
+        </div>
+        {onToggleFeature && version.id !== championVersionId && (
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label={version.isFeatured ? "Unstar version" : "Star version"}
+            className="shrink-0 rounded-sm p-1 text-muted-foreground hover:bg-background hover:text-foreground"
+            onClick={(event) => {
+              event.stopPropagation()
+              onToggleFeature(version.id)
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                event.stopPropagation()
+                onToggleFeature(version.id)
+              }
+            }}
+          >
+            <Star className={`h-3.5 w-3.5 ${version.isFeatured ? 'fill-current' : ''}`} />
+          </span>
+        )}
+      </div>
+    </Button>
+  )
 
   return (
     <div 
@@ -125,51 +177,27 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
 
           {/* Champion Version - Always at top */}
           {!isLoading && championVersion && (
-            <Button
-              key={championVersion.id}
-              variant={selectedVersionId === championVersion.id ? "secondary" : "ghost"}
-              size="sm"
-              onClick={() => onVersionSelect?.(championVersion)}
-              className="w-full justify-start text-left p-2 h-auto"
-            >
-              <div className="flex items-center gap-2 min-w-0 flex-1">
-                <Crown className="h-4 w-4 flex-shrink-0" />
-                <div className="min-w-0 flex-1">
-                  <div className="text-xs font-medium truncate">
-                    Champion Version
-                  </div>
-                  <div className="text-xs text-muted-foreground truncate">
-                    {championVersion.note || `Version ${championVersion.id.slice(0, 8)}`}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    <Timestamp time={championVersion.createdAt} variant="relative" showIcon={false} className="text-xs" />
-                  </div>
-                </div>
-              </div>
-            </Button>
+            renderVersionButton(championVersion, <Crown className="h-4 w-4 flex-shrink-0" />, "Champion Version")
           )}
-          
-          {/* Other Versions */}
-          {sortedVersions.filter(v => v.id !== championVersionId).map((version) => (
-            <Button
-              key={version.id}
-              variant={selectedVersionId === version.id ? "secondary" : "ghost"}
-              size="sm"
-              onClick={() => onVersionSelect?.(version)}
-              className="w-full justify-start text-left p-2 h-auto"
-            >
-              <div className="flex items-center gap-2 min-w-0 flex-1">
-                <Clock className="h-4 w-4 flex-shrink-0" />
-                <div className="min-w-0 flex-1">
-                  <div className="text-xs font-medium truncate">
-                    {version.note || `Version ${version.id.slice(0, 8)}`}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    <Timestamp time={version.createdAt} variant="relative" showIcon={false} className="text-xs" />
-                  </div>
-                </div>
-              </div>
-            </Button>
+
+          {pinnedVersions.length > 0 && (
+            <div className="px-2 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Starred
+            </div>
+          )}
+          {pinnedVersions.map((version) => renderVersionButton(
+            version,
+            <Star className="h-4 w-4 flex-shrink-0 fill-current" />
+          ))}
+
+          {recentVersions.length > 0 && (
+            <div className="px-2 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Recent
+            </div>
+          )}
+          {recentVersions.map((version) => renderVersionButton(
+            version,
+            <Clock className="h-4 w-4 flex-shrink-0" />
           ))}
           {isLoadingMore && versions.length > 0 && (
             <div className="px-2 py-1 text-xs text-muted-foreground">Loading more versions...</div>
@@ -195,7 +223,7 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
           )}
           
           {/* Other Versions */}
-          {sortedVersions.filter(v => v.id !== championVersionId).slice(0, 4).map((version) => (
+          {[...pinnedVersions, ...recentVersions].slice(0, 4).map((version) => (
             <Button
               key={version.id}
               variant={selectedVersionId === version.id ? "secondary" : "ghost"}
@@ -204,7 +232,7 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
               className="w-full h-8 p-0"
               title={version.note || `Version ${version.id.slice(0, 8)}`}
             >
-              <Clock className="h-4 w-4" />
+              {version.isFeatured ? <Star className="h-4 w-4 fill-current" /> : <Clock className="h-4 w-4" />}
             </Button>
           ))}
         </div>

--- a/dashboard/components/ui/score-sidebar-version-history.tsx
+++ b/dashboard/components/ui/score-sidebar-version-history.tsx
@@ -79,8 +79,9 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
   const sortedVersions = [...versions].sort((a, b) => 
     new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
-  const pinnedVersions = sortedVersions.filter(v => v.isFeatured && v.id !== championVersionId)
-  const recentVersions = sortedVersions.filter(v => v.id !== championVersionId && !v.isFeatured)
+  const isPinned = (version: ScoreVersion) => version.featuredKey === 'featured'
+  const pinnedVersions = sortedVersions.filter(v => isPinned(v) && v.id !== championVersionId)
+  const recentVersions = sortedVersions.filter(v => v.id !== championVersionId && !isPinned(v))
 
   const renderVersionButton = (version: ScoreVersion, icon: React.ReactNode, title?: string) => (
     <Button
@@ -109,7 +110,7 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
           <span
             role="button"
             tabIndex={0}
-            aria-label={version.isFeatured ? "Unstar version" : "Star version"}
+            aria-label={isPinned(version) ? "Unstar version" : "Star version"}
             className="shrink-0 rounded-sm p-1 text-muted-foreground hover:bg-background hover:text-foreground"
             onClick={(event) => {
               event.stopPropagation()
@@ -123,7 +124,7 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
               }
             }}
           >
-            <Star className={`h-3.5 w-3.5 ${version.isFeatured ? 'fill-current' : ''}`} />
+            <Star className={`h-3.5 w-3.5 ${isPinned(version) ? 'fill-current' : ''}`} />
           </span>
         )}
       </div>
@@ -187,7 +188,7 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
           )}
           {pinnedVersions.map((version) => renderVersionButton(
             version,
-            <Star className="h-4 w-4 flex-shrink-0 fill-current" />
+            <Clock className="h-4 w-4 flex-shrink-0" />
           ))}
 
           {recentVersions.length > 0 && (
@@ -232,7 +233,7 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
               className="w-full h-8 p-0"
               title={version.note || `Version ${version.id.slice(0, 8)}`}
             >
-              {version.isFeatured ? <Star className="h-4 w-4 fill-current" /> : <Clock className="h-4 w-4" />}
+              {isPinned(version) ? <Star className="h-4 w-4 fill-current" /> : <Clock className="h-4 w-4" />}
             </Button>
           ))}
         </div>

--- a/dashboard/components/ui/score-version-diff-dialog.tsx
+++ b/dashboard/components/ui/score-version-diff-dialog.tsx
@@ -104,6 +104,7 @@ export function ScoreVersionDiffDialog({
               }}
               disabled={!leftVersionId || !rightVersionId}
             >
+              <GitCompareArrows className="mr-2 h-4 w-4" />
               Swap
             </Button>
             <VersionSelect

--- a/dashboard/components/ui/score-version-diff-dialog.tsx
+++ b/dashboard/components/ui/score-version-diff-dialog.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import * as React from "react"
+import { DiffEditor, type Monaco } from "@monaco-editor/react"
+import { GitCompareArrows } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Timestamp } from "@/components/ui/timestamp"
+import {
+  applyMonacoTheme,
+  configureYamlLanguage,
+  defineCustomMonacoThemes,
+  getCommonMonacoOptions,
+  setupMonacoThemeWatcher,
+} from "@/lib/monaco-theme"
+import type { ScoreVersion } from "./score-component"
+
+interface ScoreVersionDiffDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  versions: ScoreVersion[]
+  selectedVersionId?: string
+  championVersionId?: string
+}
+
+const versionLabel = (version?: ScoreVersion) => {
+  if (!version) return "Select version"
+  return version.note || `Version ${version.id.slice(0, 8)}`
+}
+
+const findDefaultLeftVersionId = (
+  versions: ScoreVersion[],
+  selectedVersionId?: string,
+  championVersionId?: string
+) => {
+  if (!selectedVersionId) return championVersionId || versions[0]?.id
+  if (selectedVersionId !== championVersionId) return championVersionId || versions[0]?.id
+  const selected = versions.find(version => version.id === selectedVersionId)
+  return selected?.parentVersionId || versions.find(version => version.id !== selectedVersionId)?.id || selectedVersionId
+}
+
+export function ScoreVersionDiffDialog({
+  isOpen,
+  onClose,
+  versions,
+  selectedVersionId,
+  championVersionId,
+}: ScoreVersionDiffDialogProps) {
+  const sortedVersions = React.useMemo(
+    () => [...versions].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    [versions]
+  )
+  const [leftVersionId, setLeftVersionId] = React.useState<string | undefined>()
+  const [rightVersionId, setRightVersionId] = React.useState<string | undefined>()
+
+  React.useEffect(() => {
+    if (!isOpen) return
+    setLeftVersionId(findDefaultLeftVersionId(sortedVersions, selectedVersionId, championVersionId))
+    setRightVersionId(selectedVersionId || championVersionId || sortedVersions[0]?.id)
+  }, [championVersionId, isOpen, selectedVersionId, sortedVersions])
+
+  const leftVersion = sortedVersions.find(version => version.id === leftVersionId)
+  const rightVersion = sortedVersions.find(version => version.id === rightVersionId)
+
+  const handleEditorMount = (_editor: unknown, monaco: Monaco) => {
+    defineCustomMonacoThemes(monaco)
+    applyMonacoTheme(monaco)
+    setupMonacoThemeWatcher(monaco)
+    configureYamlLanguage(monaco)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-[min(96vw,1400px)] h-[86vh] bg-card border-0 p-0 overflow-hidden flex flex-col">
+        <DialogHeader className="px-4 py-3 bg-card">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <GitCompareArrows className="h-4 w-4" />
+            Compare Score Versions
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col min-h-0 flex-1 bg-background p-3 gap-3">
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] gap-3 items-end">
+            <VersionSelect
+              label="Left version"
+              value={leftVersionId}
+              onValueChange={setLeftVersionId}
+              versions={sortedVersions}
+              championVersionId={championVersionId}
+            />
+            <Button
+              variant="secondary"
+              className="h-9"
+              onClick={() => {
+                setLeftVersionId(rightVersionId)
+                setRightVersionId(leftVersionId)
+              }}
+              disabled={!leftVersionId || !rightVersionId}
+            >
+              Swap
+            </Button>
+            <VersionSelect
+              label="Right version"
+              value={rightVersionId}
+              onValueChange={setRightVersionId}
+              versions={sortedVersions}
+              championVersionId={championVersionId}
+            />
+          </div>
+
+          <Tabs defaultValue="code" className="flex-1 min-h-0 flex flex-col">
+            <TabsList className="h-auto p-0 bg-card justify-start">
+              <TabsTrigger value="code" className="bg-transparent data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-4 border-transparent data-[state=active]:border-primary rounded-none px-3 py-2">Code</TabsTrigger>
+              <TabsTrigger value="guidelines" className="bg-transparent data-[state=active]:bg-transparent data-[state=active]:shadow-none border-b-4 border-transparent data-[state=active]:border-primary rounded-none px-3 py-2">Guidelines</TabsTrigger>
+            </TabsList>
+            <TabsContent value="code" className="flex-1 min-h-0 mt-0">
+              <DiffEditor
+                height="100%"
+                language="yaml"
+                original={leftVersion?.configuration || ""}
+                modified={rightVersion?.configuration || ""}
+                onMount={handleEditorMount}
+                options={{
+                  ...getCommonMonacoOptions(),
+                  readOnly: true,
+                  renderSideBySide: true,
+                  automaticLayout: true,
+                  minimap: { enabled: false },
+                  scrollBeyondLastLine: false,
+                }}
+              />
+            </TabsContent>
+            <TabsContent value="guidelines" className="flex-1 min-h-0 mt-0">
+              <DiffEditor
+                height="100%"
+                language="markdown"
+                original={leftVersion?.guidelines || ""}
+                modified={rightVersion?.guidelines || ""}
+                onMount={handleEditorMount}
+                options={{
+                  ...getCommonMonacoOptions(),
+                  readOnly: true,
+                  renderSideBySide: true,
+                  automaticLayout: true,
+                  minimap: { enabled: false },
+                  scrollBeyondLastLine: false,
+                }}
+              />
+            </TabsContent>
+          </Tabs>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function VersionSelect({
+  label,
+  value,
+  onValueChange,
+  versions,
+  championVersionId,
+}: {
+  label: string
+  value?: string
+  onValueChange: (value: string) => void
+  versions: ScoreVersion[]
+  championVersionId?: string
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger className="bg-card border-0">
+          <SelectValue placeholder="Select version" />
+        </SelectTrigger>
+        <SelectContent className="bg-card border-0">
+          {versions.map((version) => (
+            <SelectItem key={version.id} value={version.id}>
+              <div className="flex flex-col">
+                <span>{versionLabel(version)}{version.id === championVersionId ? " (champion)" : ""}</span>
+                <span className="text-xs text-muted-foreground">
+                  <Timestamp time={version.createdAt} variant="relative" showIcon={false} className="text-xs" />
+                </span>
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/dashboard/components/ui/score-version-diff-dialog.tsx
+++ b/dashboard/components/ui/score-version-diff-dialog.tsx
@@ -24,6 +24,8 @@ interface ScoreVersionDiffDialogProps {
   versions: ScoreVersion[]
   selectedVersionId?: string
   championVersionId?: string
+  initialLeftVersionId?: string
+  initialRightVersionId?: string
 }
 
 const versionLabel = (version?: ScoreVersion) => {
@@ -48,6 +50,8 @@ export function ScoreVersionDiffDialog({
   versions,
   selectedVersionId,
   championVersionId,
+  initialLeftVersionId,
+  initialRightVersionId,
 }: ScoreVersionDiffDialogProps) {
   const sortedVersions = React.useMemo(
     () => [...versions].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
@@ -58,9 +62,9 @@ export function ScoreVersionDiffDialog({
 
   React.useEffect(() => {
     if (!isOpen) return
-    setLeftVersionId(findDefaultLeftVersionId(sortedVersions, selectedVersionId, championVersionId))
-    setRightVersionId(selectedVersionId || championVersionId || sortedVersions[0]?.id)
-  }, [championVersionId, isOpen, selectedVersionId, sortedVersions])
+    setLeftVersionId(initialLeftVersionId || findDefaultLeftVersionId(sortedVersions, selectedVersionId, championVersionId))
+    setRightVersionId(initialRightVersionId || selectedVersionId || championVersionId || sortedVersions[0]?.id)
+  }, [championVersionId, initialLeftVersionId, initialRightVersionId, isOpen, selectedVersionId, sortedVersions])
 
   const leftVersion = sortedVersions.find(version => version.id === leftVersionId)
   const rightVersion = sortedVersions.find(version => version.id === rightVersionId)

--- a/dashboard/lib/monaco-theme.ts
+++ b/dashboard/lib/monaco-theme.ts
@@ -59,7 +59,6 @@ export const configureYamlLanguage = (monaco: Monaco): void => {
       aliases: ['YAML', 'yaml', 'YML', 'yml'],
       mimetypes: ['application/x-yaml', 'text/x-yaml', 'text/yaml']
     });
-    console.log('YAML language registered successfully');
   }
 
   // Register YAML language configuration
@@ -91,7 +90,6 @@ export const configureYamlLanguage = (monaco: Monaco): void => {
       decreaseIndentPattern: /^\s*[\}\]\)].*$/,
     },
   })
-  console.log('YAML language configuration set');
 
   // Enhanced YAML tokenization rules for better syntax highlighting
   monaco.languages.setMonarchTokensProvider('yaml', {
@@ -197,7 +195,6 @@ export const configureYamlLanguage = (monaco: Monaco): void => {
       ],
     },
   })
-  console.log('YAML tokenizer provider registered');
 
   // Set up YAML validation for indentation errors
   monaco.languages.registerDocumentFormattingEditProvider('yaml', {
@@ -241,8 +238,7 @@ export const configureYamlLanguage = (monaco: Monaco): void => {
 
   // Register YAML validation - we'll call this from the editor onChange
   monaco.languages.onLanguage('yaml', () => {
-    // This ensures the language is properly registered
-    console.log('YAML language registered successfully')
+    // This ensures the language is properly registered.
   })
 }
 

--- a/plexus/cli/score/scores.py
+++ b/plexus/cli/score/scores.py
@@ -1805,7 +1805,14 @@ def version_pin(scorecard: str, score: str, version_id: str, pinned: bool, outpu
     """
     updated = (client.execute(
         mutation,
-        {"input": {"id": version_id, "isFeatured": pinned, "featuredKey": "featured" if pinned else "unfeatured"}},
+        {
+            "input": {
+                "id": version_id,
+                "isFeatured": pinned,
+                "featuredKey": "featured" if pinned else "unfeatured",
+                "createdAt": version.get("createdAt"),
+            }
+        },
     ).get("updateScoreVersion") or {})
     payload = {
         "success": True,

--- a/plexus/cli/score/scores.py
+++ b/plexus/cli/score/scores.py
@@ -507,8 +507,11 @@ def versions(id: str, pinned_only: bool):
             console.print("[yellow]No versions found for this score.[/yellow]")
             return
         
+        def is_pinned_version(version):
+            return version.get('featuredKey') == 'featured'
+
         if pinned_only:
-            versions = [version for version in versions if version.get('isFeatured')]
+            versions = [version for version in versions if is_pinned_version(version)]
 
         def version_sort_key(version):
             created_at = (version.get('createdAt') or '1970-01-01T00:00:00+00:00').replace('Z', '+00:00')
@@ -518,7 +521,7 @@ def versions(id: str, pinned_only: bool):
                 created_ts = 0
             return (
                 0 if version.get('id') == champion_version_id else 1,
-                0 if version.get('isFeatured') else 1,
+                0 if is_pinned_version(version) else 1,
                 -created_ts,
             )
 
@@ -540,7 +543,7 @@ def versions(id: str, pinned_only: bool):
             updated_at = version.get('updatedAt')
             parent_id = version.get('parentVersionId', 'None')
             is_champion = "✓" if version_id == champion_version_id else ""
-            is_pinned = "★" if version.get('isFeatured') else ""
+            is_pinned = "★" if is_pinned_version(version) else ""
             note = version.get('note', '')
             
             # Truncate note if it's too long
@@ -1809,7 +1812,7 @@ def version_pin(scorecard: str, score: str, version_id: str, pinned: bool, outpu
         "score_id": context["score_id"],
         "score_name": context["score_name"],
         "version_id": updated.get("id") or version_id,
-        "pinned": bool(updated.get("isFeatured")),
+        "pinned": updated.get("featuredKey") == "featured",
     }
 
     if output == 'json':

--- a/plexus/cli/score/scores.py
+++ b/plexus/cli/score/scores.py
@@ -24,6 +24,7 @@ import urllib3.exceptions
 import re
 import datetime
 import requests
+import difflib
 from gql import gql
 from plexus.cli.shared.file_editor import FileEditor
 from plexus.cli.shared import sanitize_path_name, get_score_yaml_path, get_score_guidelines_path
@@ -450,7 +451,8 @@ def dataset_curate_vetted(
 
 @score.command()
 @click.option('--id', required=True, help='Score ID to list versions for')
-def versions(id: str):
+@click.option('--pinned-only', is_flag=True, help='Show only pinned/starred versions')
+def versions(id: str, pinned_only: bool):
     """List all versions for a specific score."""
     client = create_client()
     
@@ -473,6 +475,7 @@ def versions(id: str):
                     createdAt
                     updatedAt
                     isFeatured
+                    featuredKey
                     parentVersionId
                     note
                 }}
@@ -504,8 +507,22 @@ def versions(id: str):
             console.print("[yellow]No versions found for this score.[/yellow]")
             return
         
-        # Sort versions by creation date (newest first)
-        versions.sort(key=lambda v: v.get('createdAt', ''), reverse=True)
+        if pinned_only:
+            versions = [version for version in versions if version.get('isFeatured')]
+
+        def version_sort_key(version):
+            created_at = (version.get('createdAt') or '1970-01-01T00:00:00+00:00').replace('Z', '+00:00')
+            try:
+                created_ts = datetime.datetime.fromisoformat(created_at).timestamp()
+            except ValueError:
+                created_ts = 0
+            return (
+                0 if version.get('id') == champion_version_id else 1,
+                0 if version.get('isFeatured') else 1,
+                -created_ts,
+            )
+
+        versions.sort(key=version_sort_key)
         
         # Create a table to display the versions
         table = Table(title=f"Score Versions ({len(versions)} total)")
@@ -514,6 +531,7 @@ def versions(id: str):
         table.add_column("Updated", style="green")
         table.add_column("Parent ID", style="blue")
         table.add_column("Champion", style="magenta")
+        table.add_column("Pinned", style="magenta")
         table.add_column("Note", style="yellow")
         
         for version in versions:
@@ -522,6 +540,7 @@ def versions(id: str):
             updated_at = version.get('updatedAt')
             parent_id = version.get('parentVersionId', 'None')
             is_champion = "✓" if version_id == champion_version_id else ""
+            is_pinned = "★" if version.get('isFeatured') else ""
             note = version.get('note', '')
             
             # Truncate note if it's too long
@@ -534,6 +553,7 @@ def versions(id: str):
                 updated_at,
                 parent_id,
                 is_champion,
+                is_pinned,
                 note
             )
         
@@ -1316,7 +1336,7 @@ def push(scorecard: str, score: str, note: str):
             console.print(f"[blue]Changes detected: {' and '.join(changes)}. Creating new version.[/blue]")
     else:
         console.print("[blue]Creating initial version.[/blue]")
-    
+
     # Create a new version with the cleaned configuration
     mutation = """
     mutation CreateScoreVersion($input: CreateScoreVersionInput!) {
@@ -1342,7 +1362,8 @@ def push(scorecard: str, score: str, note: str):
                 'configuration': cleaned_yaml_content,
                 'note': note,
                 # Never auto-promote to champion via CLI push
-                'isFeatured': False
+                'isFeatured': False,
+                'featuredKey': 'unfeatured'
             }
         }
 
@@ -1717,6 +1738,141 @@ def _resolve_optimizer_score_context(client, scorecard_identifier: str, score_id
         "champion_version_id": score.get("championVersionId"),
         "service": OptimizerResultsService(client),
     }
+
+def _fetch_score_version_for_management(client, version_id: str) -> dict:
+    query = """
+    query GetScoreVersionForManagement($id: ID!) {
+      getScoreVersion(id: $id) {
+        id
+        scoreId
+        configuration
+        guidelines
+        isFeatured
+        featuredKey
+        note
+        branch
+        parentVersionId
+        metadata
+        createdAt
+        updatedAt
+      }
+    }
+    """
+    version = (client.execute(query, {"id": version_id}).get("getScoreVersion") or {})
+    if not version:
+        raise click.ClickException(f"Score version not found: {version_id}")
+    return version
+
+
+def _build_unified_diff(left_text: str, right_text: str, left_label: str, right_label: str) -> str:
+    return "".join(difflib.unified_diff(
+        (left_text or "").splitlines(keepends=True),
+        (right_text or "").splitlines(keepends=True),
+        fromfile=left_label,
+        tofile=right_label,
+    ))
+
+
+@score.command(name="version-pin")
+@click.option('--scorecard', '-s', required=True, help='Scorecard identifier (name, key, or ID)')
+@click.option('--score', '-c', required=True, help='Score identifier (name, key, or ID)')
+@click.option('--version', 'version_id', required=True, help='ScoreVersion ID to pin or unpin')
+@click.option('--pinned/--unpinned', default=True, show_default=True, help='Whether the version should be pinned/starred')
+@click.option('--output', '-o', type=click.Choice(['json', 'table']), default='table', show_default=True)
+def version_pin(scorecard: str, score: str, version_id: str, pinned: bool, output: str):
+    """Pin or unpin a ScoreVersion using isFeatured."""
+    client = create_client()
+    context = _resolve_optimizer_score_context(client, scorecard, score)
+    version = _fetch_score_version_for_management(client, version_id)
+    if version.get("scoreId") != context["score_id"]:
+        raise click.ClickException(
+            f"Version {version_id} belongs to score {version.get('scoreId')}, not {context['score_id']}"
+        )
+
+    mutation = """
+    mutation UpdateScoreVersionPin($input: UpdateScoreVersionInput!) {
+      updateScoreVersion(input: $input) {
+        id
+        scoreId
+        isFeatured
+        featuredKey
+        updatedAt
+      }
+    }
+    """
+    updated = (client.execute(
+        mutation,
+        {"input": {"id": version_id, "isFeatured": pinned, "featuredKey": "featured" if pinned else "unfeatured"}},
+    ).get("updateScoreVersion") or {})
+    payload = {
+        "success": True,
+        "score_id": context["score_id"],
+        "score_name": context["score_name"],
+        "version_id": updated.get("id") or version_id,
+        "pinned": bool(updated.get("isFeatured")),
+    }
+
+    if output == 'json':
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    table = Table(title="Score Version Pin")
+    table.add_column("Field", style="cyan")
+    table.add_column("Value", style="white")
+    table.add_row("Score", context["score_name"])
+    table.add_row("Version", payload["version_id"])
+    table.add_row("Pinned", "yes" if payload["pinned"] else "no")
+    console.print(table)
+
+
+scores.add_command(version_pin)
+
+
+@score.command(name="version-diff")
+@click.option('--scorecard', '-s', required=True, help='Scorecard identifier (name, key, or ID)')
+@click.option('--score', '-c', required=True, help='Score identifier (name, key, or ID)')
+@click.option('--left', 'left_version_id', required=True, help='Left/original ScoreVersion ID')
+@click.option('--right', 'right_version_id', required=True, help='Right/modified ScoreVersion ID')
+@click.option('--include', 'include_part', type=click.Choice(['code', 'guidelines', 'both']), default='both', show_default=True)
+@click.option('--output', '-o', type=click.Choice(['json', 'text']), default='text', show_default=True)
+def version_diff(scorecard: str, score: str, left_version_id: str, right_version_id: str, include_part: str, output: str):
+    """Show code and/or guideline diffs between two ScoreVersions."""
+    client = create_client()
+    context = _resolve_optimizer_score_context(client, scorecard, score)
+    left = _fetch_score_version_for_management(client, left_version_id)
+    right = _fetch_score_version_for_management(client, right_version_id)
+    for label, version in (("left", left), ("right", right)):
+        if version.get("scoreId") != context["score_id"]:
+            raise click.ClickException(
+                f"{label} version {version.get('id')} belongs to score {version.get('scoreId')}, not {context['score_id']}"
+            )
+
+    include_code = include_part in ('code', 'both')
+    include_guidelines = include_part in ('guidelines', 'both')
+    payload = {
+        "success": True,
+        "score_id": context["score_id"],
+        "score_name": context["score_name"],
+        "left_version_id": left_version_id,
+        "right_version_id": right_version_id,
+        "code_diff": _build_unified_diff(left.get("configuration") or "", right.get("configuration") or "", f"{left_version_id}/code.yaml", f"{right_version_id}/code.yaml") if include_code else None,
+        "guidelines_diff": _build_unified_diff(left.get("guidelines") or "", right.get("guidelines") or "", f"{left_version_id}/guidelines.md", f"{right_version_id}/guidelines.md") if include_guidelines else None,
+    }
+
+    if output == 'json':
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    console.print(f"[bold]Score version diff for {context['score_name']}[/bold]")
+    if include_code:
+        console.print("\n[bold cyan]Code[/bold cyan]")
+        console.print(payload["code_diff"] or "[dim]No code differences.[/dim]")
+    if include_guidelines:
+        console.print("\n[bold cyan]Guidelines[/bold cyan]")
+        console.print(payload["guidelines_diff"] or "[dim]No guideline differences.[/dim]")
+
+
+scores.add_command(version_diff)
 
 
 @score.command(name="optimizer-runs")

--- a/plexus/cli/score_chat/repl.py
+++ b/plexus/cli/score_chat/repl.py
@@ -1133,7 +1133,8 @@ You can also just ask me questions or tell me what you'd like to do in plain Eng
                     'configuration': yaml_content,
                     'parentVersionId': score_data.get('championVersionId'),
                     'note': 'Updated via CLI push command',
-                    'isFeatured': True
+                    'isFeatured': False,
+                    'featuredKey': 'unfeatured'
                 }
             })
             

--- a/plexus/dashboard/api/models/score.py
+++ b/plexus/dashboard/api/models/score.py
@@ -1007,7 +1007,8 @@ class Score(BaseModel):
                 'configuration': (code_content or '').strip(),
                 'note': note or 'Updated via Score.create_version_from_code()',
                 # Do not mark as featured - these are test versions from procedures
-                'isFeatured': False
+                'isFeatured': False,
+                'featuredKey': 'unfeatured'
             }
             
             # Add guidelines if provided

--- a/project/events/2026-04-27T20:00:56.807Z__6331ced2-4484-4bde-9886-6c0e6926db3e.json
+++ b/project/events/2026-04-27T20:00:56.807Z__6331ced2-4484-4bde-9886-6c0e6926db3e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6331ced2-4484-4bde-9886-6c0e6926db3e",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T20:00:56.807Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "80fe66e3-7684-4269-8a09-884467dce45f"
+  }
+}

--- a/project/events/2026-04-27T20:31:33.355Z__fc710ded-3f33-4104-9b19-b07ca9c5e36c.json
+++ b/project/events/2026-04-27T20:31:33.355Z__fc710ded-3f33-4104-9b19-b07ca9c5e36c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "fc710ded-3f33-4104-9b19-b07ca9c5e36c",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T20:31:33.355Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "dfea3802-e70a-4699-a9a2-6f30d3a36f56"
+  }
+}

--- a/project/events/2026-04-27T20:45:36.230Z__867d6a2f-665a-4c13-ba8b-ae53e89eca98.json
+++ b/project/events/2026-04-27T20:45:36.230Z__867d6a2f-665a-4c13-ba8b-ae53e89eca98.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "867d6a2f-665a-4c13-ba8b-ae53e89eca98",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T20:45:36.230Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "9d557cd9-ef0d-482e-b89c-0c683d2cbc50"
+  }
+}

--- a/project/events/2026-04-27T21:09:17.897Z__d0ce1f47-bd3c-42d4-a430-1c745c29b8df.json
+++ b/project/events/2026-04-27T21:09:17.897Z__d0ce1f47-bd3c-42d4-a430-1c745c29b8df.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d0ce1f47-bd3c-42d4-a430-1c745c29b8df",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:09:17.897Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a547744c-2855-400f-928e-e163aad398cd"
+  }
+}

--- a/project/events/2026-04-27T21:12:40.679Z__eb7ea018-9b13-4753-b29b-89590122d7ef.json
+++ b/project/events/2026-04-27T21:12:40.679Z__eb7ea018-9b13-4753-b29b-89590122d7ef.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "eb7ea018-9b13-4753-b29b-89590122d7ef",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:12:40.679Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "d1d16e09-ad17-47b7-8d56-92342444680d"
+  }
+}

--- a/project/events/2026-04-27T21:28:50.483Z__4e3e9e3d-f15a-4578-806e-92d9d4205a1d.json
+++ b/project/events/2026-04-27T21:28:50.483Z__4e3e9e3d-f15a-4578-806e-92d9d4205a1d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4e3e9e3d-f15a-4578-806e-92d9d4205a1d",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:28:50.483Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "cd6e8de3-b2c2-4fe9-ba1d-8ad13b19a27f"
+  }
+}

--- a/project/events/2026-04-27T21:33:02.662Z__7228016f-9e59-49a2-9c6f-525fd687ab21.json
+++ b/project/events/2026-04-27T21:33:02.662Z__7228016f-9e59-49a2-9c6f-525fd687ab21.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7228016f-9e59-49a2-9c6f-525fd687ab21",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:33:02.662Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "b64f70a4-04d7-4d58-a8de-e8282d199681"
+  }
+}

--- a/project/events/2026-04-27T21:38:35.220Z__0bcf3403-828b-42b5-9ee3-d6c32fd7511d.json
+++ b/project/events/2026-04-27T21:38:35.220Z__0bcf3403-828b-42b5-9ee3-d6c32fd7511d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0bcf3403-828b-42b5-9ee3-d6c32fd7511d",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:38:35.220Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "8ab777f3-d123-4bcf-b459-6293f4378d23"
+  }
+}

--- a/project/events/2026-04-27T21:43:11.893Z__b3ffc4e1-da86-491e-91e9-a243edfef120.json
+++ b/project/events/2026-04-27T21:43:11.893Z__b3ffc4e1-da86-491e-91e9-a243edfef120.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b3ffc4e1-da86-491e-91e9-a243edfef120",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:43:11.893Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "9887c561-f6b2-4e5e-bcca-6168d080fca9"
+  }
+}

--- a/project/events/2026-04-27T21:53:41.703Z__8337bb0e-3cc9-4ae3-bef5-f56b34a89c57.json
+++ b/project/events/2026-04-27T21:53:41.703Z__8337bb0e-3cc9-4ae3-bef5-f56b34a89c57.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8337bb0e-3cc9-4ae3-bef5-f56b34a89c57",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:53:41.703Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "4b7f1faa-5d1d-4718-806d-0be91918aabf"
+  }
+}

--- a/project/events/2026-04-27T21:54:11.331Z__875f896d-a532-495c-a03a-e225b5aac817.json
+++ b/project/events/2026-04-27T21:54:11.331Z__875f896d-a532-495c-a03a-e225b5aac817.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "875f896d-a532-495c-a03a-e225b5aac817",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:54:11.331Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "8013feac-08f9-4eec-b432-28fc8b32e9b5"
+  }
+}

--- a/project/events/2026-04-27T21:55:42.801Z__9deb784c-af4d-4271-8f31-8cca4594ce49.json
+++ b/project/events/2026-04-27T21:55:42.801Z__9deb784c-af4d-4271-8f31-8cca4594ce49.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9deb784c-af4d-4271-8f31-8cca4594ce49",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:55:42.801Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e5c839a7-c1a1-46e7-819f-327539f50e37"
+  }
+}

--- a/project/events/2026-04-27T21:56:51.033Z__ed6823b7-6eb3-4510-940f-7645536cec34.json
+++ b/project/events/2026-04-27T21:56:51.033Z__ed6823b7-6eb3-4510-940f-7645536cec34.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ed6823b7-6eb3-4510-940f-7645536cec34",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:56:51.033Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "7e04c76e-6206-41a8-b559-45e1b79a1ee3"
+  }
+}

--- a/project/events/2026-04-27T21:58:05.146Z__20c1fbea-ddd3-449b-a772-191281ebe1fb.json
+++ b/project/events/2026-04-27T21:58:05.146Z__20c1fbea-ddd3-449b-a772-191281ebe1fb.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "20c1fbea-ddd3-449b-a772-191281ebe1fb",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:58:05.146Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "4262b8d7-1396-450f-9fef-d38bb9311f31"
+  }
+}

--- a/project/events/2026-04-27T22:01:13.585Z__2954527d-2432-4cc2-bd86-6520ec309ba2.json
+++ b/project/events/2026-04-27T22:01:13.585Z__2954527d-2432-4cc2-bd86-6520ec309ba2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2954527d-2432-4cc2-bd86-6520ec309ba2",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:01:13.585Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "34f4ff51-e33b-4a49-a00a-6927444eb65b"
+  }
+}

--- a/project/events/2026-04-27T22:02:00.724Z__ae02cf10-5aff-49a5-a6f8-e34b5018dd50.json
+++ b/project/events/2026-04-27T22:02:00.724Z__ae02cf10-5aff-49a5-a6f8-e34b5018dd50.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ae02cf10-5aff-49a5-a6f8-e34b5018dd50",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:02:00.724Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a76f7200-8d02-4a33-ac33-6e08de6eb067"
+  }
+}

--- a/project/events/2026-04-27T22:05:28.486Z__122b520c-af00-40f7-a41a-830bc003a257.json
+++ b/project/events/2026-04-27T22:05:28.486Z__122b520c-af00-40f7-a41a-830bc003a257.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "122b520c-af00-40f7-a41a-830bc003a257",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:05:28.486Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "7d799e74-7e0c-401e-a5ad-b0a6c263a6c1"
+  }
+}

--- a/project/events/2026-04-27T22:06:15.632Z__9e015f95-4cbf-4876-85dc-9bfbe31754ea.json
+++ b/project/events/2026-04-27T22:06:15.632Z__9e015f95-4cbf-4876-85dc-9bfbe31754ea.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9e015f95-4cbf-4876-85dc-9bfbe31754ea",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:06:15.632Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "28e68bd1-be3d-44f8-8328-945d697cef36"
+  }
+}

--- a/project/events/2026-04-27T22:09:58.678Z__f90efe0e-d95b-4045-b8f0-3f4522e5ddf5.json
+++ b/project/events/2026-04-27T22:09:58.678Z__f90efe0e-d95b-4045-b8f0-3f4522e5ddf5.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f90efe0e-d95b-4045-b8f0-3f4522e5ddf5",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:09:58.678Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "da71d998-6724-4c07-a437-55d20ec148b1"
+  }
+}

--- a/project/events/2026-04-27T22:11:07.438Z__678e4e4e-ccb6-4197-82a4-88bee4d631f2.json
+++ b/project/events/2026-04-27T22:11:07.438Z__678e4e4e-ccb6-4197-82a4-88bee4d631f2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "678e4e4e-ccb6-4197-82a4-88bee4d631f2",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:11:07.438Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "23f03b81-8257-4efb-98dc-bf00ee6226e3"
+  }
+}

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -130,10 +130,16 @@
       "author": "ryan",
       "text": "Changing the compact related-version Compare action to use the muted button surface rather than the stronger secondary button color.",
       "created_at": "2026-04-27T22:06:15.632148Z"
+    },
+    {
+      "id": "da71d998-6724-4c07-a437-55d20ec148b1",
+      "author": "ryan",
+      "text": "Fixing score-version header layout so the top-right actions/ellipsis slot overlays the header instead of reducing the content column width. Related cards should flow underneath and use full width.",
+      "created_at": "2026-04-27T22:09:58.678126Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T22:06:15.632148Z",
+  "updated_at": "2026-04-27T22:09:58.678126Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -106,10 +106,16 @@
       "author": "ryan",
       "text": "Investigating champion promotion failure from the score-version UI. Goal: fix the real promotion mutation/path and improve error reporting enough that future failures are diagnosable.",
       "created_at": "2026-04-27T21:58:05.146494Z"
+    },
+    {
+      "id": "34f4ff51-e33b-4a49-a00a-6927444eb65b",
+      "author": "ryan",
+      "text": "Refining expanded related ScoreVersion cards so the compare action is compact and aligned to the right of the note instead of appearing as a larger primary row.",
+      "created_at": "2026-04-27T22:01:13.580875Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T21:58:05.146494Z",
+  "updated_at": "2026-04-27T22:01:13.580875Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -124,10 +124,16 @@
       "author": "ryan",
       "text": "Adjusting expanded related ScoreVersion cards so the compact Compare action aligns flush to the right edge with no extra right padding.",
       "created_at": "2026-04-27T22:05:28.484830Z"
+    },
+    {
+      "id": "28e68bd1-be3d-44f8-8328-945d697cef36",
+      "author": "ryan",
+      "text": "Changing the compact related-version Compare action to use the muted button surface rather than the stronger secondary button color.",
+      "created_at": "2026-04-27T22:06:15.632148Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T22:05:28.484830Z",
+  "updated_at": "2026-04-27T22:06:15.632148Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -22,10 +22,22 @@
       "author": "ryan",
       "text": "Hotfix: CI showed Amplify Gen2 does not allow boolean isFeatured as an index sort key. Switched the new featured-version GSI to use a materialized string featuredKey while preserving isFeatured as the product flag. Local dashboard typecheck passes in the hotfix worktree.",
       "created_at": "2026-04-27T19:06:56.148764Z"
+    },
+    {
+      "id": "80fe66e3-7684-4269-8a09-884467dce45f",
+      "author": "ryan",
+      "text": "Replayed ScoreVersion management UI/CLI/MCP implementation onto clean branch from deployed schema commit. Code patch excludes obsolete pre-hotfix schema diff; local validation will run on this clean branch.",
+      "created_at": "2026-04-27T20:00:56.806497Z"
+    },
+    {
+      "id": "dfea3802-e70a-4699-a9a2-6f30d3a36f56",
+      "author": "ryan",
+      "text": "Acceptance checks on clean ScoreVersion branch: Python compile passed; focused MCP promotion guard test passed; CLI version-diff works against live Prescriber versions; clean dashboard dev server on localhost:3011 returns 200 for a score-version route after using the deployed schema artifacts.",
+      "created_at": "2026-04-27T20:31:33.353193Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T19:06:56.148764Z",
+  "updated_at": "2026-04-27T20:31:33.353193Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -118,10 +118,16 @@
       "author": "ryan",
       "text": "Tightening related ScoreVersion card header spacing by removing extra left padding before the expand caret while preserving the card body padding.",
       "created_at": "2026-04-27T22:02:00.724149Z"
+    },
+    {
+      "id": "7d799e74-7e0c-401e-a5ad-b0a6c263a6c1",
+      "author": "ryan",
+      "text": "Adjusting expanded related ScoreVersion cards so the compact Compare action aligns flush to the right edge with no extra right padding.",
+      "created_at": "2026-04-27T22:05:28.484830Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T22:02:00.724149Z",
+  "updated_at": "2026-04-27T22:05:28.484830Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -40,10 +40,22 @@
       "author": "ryan",
       "text": "UI correction: favorite rendering now treats featuredKey=featured as the source of truth instead of legacy isFeatured booleans. Version rows use a single Lucide star control that fills only for true favorites; pinned rows no longer show a duplicate solid star on the left.",
       "created_at": "2026-04-27T20:45:36.225649Z"
+    },
+    {
+      "id": "a547744c-2855-400f-928e-e163aad398cd",
+      "author": "ryan",
+      "text": "Investigating favorite toggle failure reported from frontend. Goal: identify whether the updateScoreVersion mutation is failing due to schema/auth/backend behavior or whether the UI is losing the real GraphQL error and showing an empty object.",
+      "created_at": "2026-04-27T21:09:17.896415Z"
+    },
+    {
+      "id": "d1d16e09-ad17-47b7-8d56-92342444680d",
+      "author": "ryan",
+      "text": "Fixed favorite toggle persistence. Root cause: AppSync requires createdAt when updating featuredKey because it is part of the composite byScoreIdAndFeaturedKeyAndCreatedAt sort key. Frontend, CLI, and MCP now include createdAt in the update input. Verified live CLI pin and unpin both succeed, restoring the tested Prescriber version to unpinned. Also removed noisy Monaco YAML setup console logs and changed the frontend catch path to log formatAmplifyError instead of an empty object.",
+      "created_at": "2026-04-27T21:12:40.678261Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T20:45:36.225649Z",
+  "updated_at": "2026-04-27T21:12:40.678261Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -88,10 +88,16 @@
       "author": "ryan",
       "text": "Adjusted related version card header: relationship label and related timestamp now render on one line, and the open-version action is a normal text-color Lucide Link icon.",
       "created_at": "2026-04-27T21:54:11.331286Z"
+    },
+    {
+      "id": "e5c839a7-c1a1-46e7-819f-327539f50e37",
+      "author": "ryan",
+      "text": "Refining score-version comparison UI icons so every comparison/diff action consistently uses the GitCompareArrows icon.",
+      "created_at": "2026-04-27T21:55:42.801037Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T21:54:11.331286Z",
+  "updated_at": "2026-04-27T21:55:42.801037Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -94,10 +94,16 @@
       "author": "ryan",
       "text": "Refining score-version comparison UI icons so every comparison/diff action consistently uses the GitCompareArrows icon.",
       "created_at": "2026-04-27T21:55:42.801037Z"
+    },
+    {
+      "id": "7e04c76e-6206-41a8-b559-45e1b79a1ee3",
+      "author": "ryan",
+      "text": "Adjusting related ScoreVersion cards so the standard timestamp component keeps its icon, and the related-version link icon sits immediately after the timestamp.",
+      "created_at": "2026-04-27T21:56:51.025802Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T21:55:42.801037Z",
+  "updated_at": "2026-04-27T21:56:51.025802Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -100,10 +100,16 @@
       "author": "ryan",
       "text": "Adjusting related ScoreVersion cards so the standard timestamp component keeps its icon, and the related-version link icon sits immediately after the timestamp.",
       "created_at": "2026-04-27T21:56:51.025802Z"
+    },
+    {
+      "id": "4262b8d7-1396-450f-9fef-d38bb9311f31",
+      "author": "ryan",
+      "text": "Investigating champion promotion failure from the score-version UI. Goal: fix the real promotion mutation/path and improve error reporting enough that future failures are diagnosable.",
+      "created_at": "2026-04-27T21:58:05.146494Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T21:56:51.025802Z",
+  "updated_at": "2026-04-27T21:58:05.146494Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -34,10 +34,16 @@
       "author": "ryan",
       "text": "Acceptance checks on clean ScoreVersion branch: Python compile passed; focused MCP promotion guard test passed; CLI version-diff works against live Prescriber versions; clean dashboard dev server on localhost:3011 returns 200 for a score-version route after using the deployed schema artifacts.",
       "created_at": "2026-04-27T20:31:33.353193Z"
+    },
+    {
+      "id": "9d557cd9-ef0d-482e-b89c-0c683d2cbc50",
+      "author": "ryan",
+      "text": "UI correction: favorite rendering now treats featuredKey=featured as the source of truth instead of legacy isFeatured booleans. Version rows use a single Lucide star control that fills only for true favorites; pinned rows no longer show a duplicate solid star on the left.",
+      "created_at": "2026-04-27T20:45:36.225649Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T20:31:33.353193Z",
+  "updated_at": "2026-04-27T20:45:36.225649Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -64,10 +64,22 @@
       "author": "ryan",
       "text": "Favorite reorder animation implemented with framer-motion LayoutGroup and motion row wrappers. Active dashboard dev server recompiled the score-version route successfully after the change. Full dashboard typecheck was started but stopped after several minutes without output to avoid leaving a long-running process; this change is isolated to the sidebar component.",
       "created_at": "2026-04-27T21:33:02.658574Z"
+    },
+    {
+      "id": "8ab777f3-d123-4bcf-b459-6293f4378d23",
+      "author": "ryan",
+      "text": "Implementing related ScoreVersion header cards: parent, previous champion, and next champion. Scope is frontend only, reusing existing parentVersionId and metadata.championHistory plus targeted getScoreVersion hydration.",
+      "created_at": "2026-04-27T21:38:35.219638Z"
+    },
+    {
+      "id": "9887c561-f6b2-4e5e-bcca-6168d080fca9",
+      "author": "ryan",
+      "text": "Related version header cards implemented. The score-version route in the active dev server compiled and served successfully after mirroring the component changes. Full dashboard typecheck was started but stopped after ~90 seconds of no output to avoid leaving a long-running process; git diff --check passed.",
+      "created_at": "2026-04-27T21:43:11.892280Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T21:33:02.658574Z",
+  "updated_at": "2026-04-27T21:43:11.892280Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -136,10 +136,16 @@
       "author": "ryan",
       "text": "Fixing score-version header layout so the top-right actions/ellipsis slot overlays the header instead of reducing the content column width. Related cards should flow underneath and use full width.",
       "created_at": "2026-04-27T22:09:58.678126Z"
+    },
+    {
+      "id": "23f03b81-8257-4efb-98dc-bf00ee6226e3",
+      "author": "ryan",
+      "text": "Refining ScoreVersion note typography: remove residual left padding from expanded related-version notes and increase both selected-version and related-version note text size.",
+      "created_at": "2026-04-27T22:11:07.437949Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T22:09:58.678126Z",
+  "updated_at": "2026-04-27T22:11:07.437949Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -76,10 +76,22 @@
       "author": "ryan",
       "text": "Related version header cards implemented. The score-version route in the active dev server compiled and served successfully after mirroring the component changes. Full dashboard typecheck was started but stopped after ~90 seconds of no output to avoid leaving a long-running process; git diff --check passed.",
       "created_at": "2026-04-27T21:43:11.892280Z"
+    },
+    {
+      "id": "4b7f1faa-5d1d-4718-806d-0be91918aabf",
+      "author": "ryan",
+      "text": "Tweaking related ScoreVersion card presentation: put relationship label and timestamp on one line, and use the Lucide Link icon in normal text color for the open-version action.",
+      "created_at": "2026-04-27T21:53:41.697973Z"
+    },
+    {
+      "id": "8013feac-08f9-4eec-b432-28fc8b32e9b5",
+      "author": "ryan",
+      "text": "Adjusted related version card header: relationship label and related timestamp now render on one line, and the open-version action is a normal text-color Lucide Link icon.",
+      "created_at": "2026-04-27T21:54:11.331286Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T21:43:11.892280Z",
+  "updated_at": "2026-04-27T21:54:11.331286Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -112,10 +112,16 @@
       "author": "ryan",
       "text": "Refining expanded related ScoreVersion cards so the compare action is compact and aligned to the right of the note instead of appearing as a larger primary row.",
       "created_at": "2026-04-27T22:01:13.580875Z"
+    },
+    {
+      "id": "a76f7200-8d02-4a33-ac33-6e08de6eb067",
+      "author": "ryan",
+      "text": "Tightening related ScoreVersion card header spacing by removing extra left padding before the expand caret while preserving the card body padding.",
+      "created_at": "2026-04-27T22:02:00.724149Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T22:01:13.580875Z",
+  "updated_at": "2026-04-27T22:02:00.724149Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -52,10 +52,22 @@
       "author": "ryan",
       "text": "Fixed favorite toggle persistence. Root cause: AppSync requires createdAt when updating featuredKey because it is part of the composite byScoreIdAndFeaturedKeyAndCreatedAt sort key. Frontend, CLI, and MCP now include createdAt in the update input. Verified live CLI pin and unpin both succeed, restoring the tested Prescriber version to unpinned. Also removed noisy Monaco YAML setup console logs and changed the frontend catch path to log formatAmplifyError instead of an empty object.",
       "created_at": "2026-04-27T21:12:40.678261Z"
+    },
+    {
+      "id": "cd6e8de3-b2c2-4fe9-ba1d-8ad13b19a27f",
+      "author": "ryan",
+      "text": "Implementing low-risk favorite reorder animation in ScoreSidebarVersionHistory using existing framer-motion LayoutGroup/motion.div wrappers. Scope is UI-only: no schema/API/data-flow changes.",
+      "created_at": "2026-04-27T21:28:50.482608Z"
+    },
+    {
+      "id": "b64f70a4-04d7-4d58-a8de-e8282d199681",
+      "author": "ryan",
+      "text": "Favorite reorder animation implemented with framer-motion LayoutGroup and motion row wrappers. Active dashboard dev server recompiled the score-version route successfully after the change. Full dashboard typecheck was started but stopped after several minutes without output to avoid leaving a long-running process; this change is isolated to the sidebar component.",
+      "created_at": "2026-04-27T21:33:02.658574Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T21:12:40.678261Z",
+  "updated_at": "2026-04-27T21:33:02.658574Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
## Summary

Adds a ScoreVersion management workflow for finding, curating, comparing, and auditing score versions as optimizer-generated versions grow.

## What changed

- Adds star/pin controls for ScoreVersions using the existing featured state so important versions appear above generated noise.
- Adds animated ScoreVersion reordering between Champion, Starred, and Recent sections.
- Adds arbitrary ScoreVersion comparison with Monaco diff views for score YAML and guidelines.
- Adds champion history UI using ScoreVersion metadata, including previous/next champion relationship cards.
- Adds related-version header cards for parent, previous champion, and next champion with direct navigation and compact compare actions.
- Updates promotion flows to write champion transition metadata for incoming and outgoing versions.
- Adds CLI and MCP support for version pinning and version diffs.
- Improves error handling around favorite toggles and champion promotion so AppSync errors are visible.

## Notes

- The required GraphQL schema support was deployed separately before this PR; this PR builds on that deployed schema.
- Promotion remains explicit/manual; this adds audit metadata around that manual promotion action.

## Testing

- Verified UI behavior through the running local dashboard/dev server during implementation.
- Ran focused `git diff --check` validation after each UI patch.
- Exercised favorite toggle behavior against the live API and restored the test version to unpinned.
