### PR TITLE
chore(kanbus): close scoreversion management work

### DIFF
--- a/project/events/2026-04-27T22:27:30.689Z__3723c340-8990-4c0a-aeed-3d1168fbc1f9.json
+++ b/project/events/2026-04-27T22:27:30.689Z__3723c340-8990-4c0a-aeed-3d1168fbc1f9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3723c340-8990-4c0a-aeed-3d1168fbc1f9",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:27:30.689Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a00d7186-5ee5-43b4-a160-d05c8594ac80"
+  }
+}

--- a/project/events/2026-04-27T22:27:32.182Z__ca3a2239-9d46-4659-8094-9ec5486f1f4c.json
+++ b/project/events/2026-04-27T22:27:32.182Z__ca3a2239-9d46-4659-8094-9ec5486f1f4c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ca3a2239-9d46-4659-8094-9ec5486f1f4c",
+  "issue_id": "plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-27T22:27:32.182Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-04-27T22:27:33.046Z__a3ce4b47-1ff1-4242-ae7f-15a9fdfc8c6b.json
+++ b/project/events/2026-04-27T22:27:33.046Z__a3ce4b47-1ff1-4242-ae7f-15a9fdfc8c6b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a3ce4b47-1ff1-4242-ae7f-15a9fdfc8c6b",
+  "issue_id": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:27:33.046Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "407edb58-df8e-497f-9cda-02b1dadc5991"
+  }
+}

--- a/project/events/2026-04-27T22:27:33.140Z__8fe1e7a8-57e7-4c58-9210-6e408f6cac57.json
+++ b/project/events/2026-04-27T22:27:33.140Z__8fe1e7a8-57e7-4c58-9210-6e408f6cac57.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8fe1e7a8-57e7-4c58-9210-6e408f6cac57",
+  "issue_id": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-27T22:27:33.140Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7.json
+++ b/project/issues/plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7.json
@@ -3,7 +3,7 @@
   "title": "ScoreVersion management: pinning, diffs, and champion history",
   "description": "",
   "type": "epic",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 1,
   "assignee": null,
   "creator": null,
@@ -16,10 +16,16 @@
       "author": "ryan",
       "text": "Starting implementation. First priority is the urgent GraphQL schema slice: add ScoreVersion.metadata as JSON and one featured-version lookup index, with no other table/index changes. Follow-up implementation will add frontend, CLI, MCP, and champion-history promotion wiring on the same feature branch.",
       "created_at": "2026-04-27T18:14:17.839783Z"
+    },
+    {
+      "id": "407edb58-df8e-497f-9cda-02b1dadc5991",
+      "author": "ryan",
+      "text": "ScoreVersion management feature landed in develop via PR #220. Includes pinning, diffs, champion history metadata, related-version cards, and CLI/MCP utilities. Develop CI passed.",
+      "created_at": "2026-04-27T22:27:33.042791Z"
     }
   ],
   "created_at": "2026-04-27T18:14:11.621385Z",
-  "updated_at": "2026-04-27T18:14:17.839783Z",
-  "closed_at": null,
+  "updated_at": "2026-04-27T22:27:33.139446Z",
+  "closed_at": "2026-04-27T22:27:33.139446Z",
   "custom": {}
 }

--- a/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
+++ b/project/issues/plx-e24fd0e5-3f12-44b8-aeff-9d32cb7ee67f.json
@@ -3,7 +3,7 @@
   "title": "Implement ScoreVersion management schema and tools",
   "description": "Implement the ScoreVersion management feature: schema field/index, frontend pin/diff/history UI, CLI and MCP tools, and champion promotion metadata updates. Keep the GraphQL schema delta limited to ScoreVersion.metadata plus one featured-version index.",
   "type": "task",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 1,
   "assignee": null,
   "creator": null,
@@ -142,10 +142,16 @@
       "author": "ryan",
       "text": "Refining ScoreVersion note typography: remove residual left padding from expanded related-version notes and increase both selected-version and related-version note text size.",
       "created_at": "2026-04-27T22:11:07.437949Z"
+    },
+    {
+      "id": "a00d7186-5ee5-43b4-a160-d05c8594ac80",
+      "author": "ryan",
+      "text": "Merged PR #220 into develop with squash commit 0bdcd5e0: feat(scoreversions): add version management tools and UI. Develop CI run 25022392159 passed.",
+      "created_at": "2026-04-27T22:27:30.687493Z"
     }
   ],
   "created_at": "2026-04-27T18:14:23.120850Z",
-  "updated_at": "2026-04-27T22:11:07.437949Z",
-  "closed_at": null,
+  "updated_at": "2026-04-27T22:27:32.180854Z",
+  "closed_at": "2026-04-27T22:27:32.180854Z",
   "custom": {}
 }


### PR DESCRIPTION
Closes the Kanbus epic/task artifacts after PR #220 landed in develop and CI passed.