### PR TITLE
fix(scoreversions): use string featured state

### DIFF
--- a/MCP/tools/score/scores.py
+++ b/MCP/tools/score/scores.py
@@ -149,7 +149,6 @@ def register_score_tools(mcp: FastMCP):
             configuration
             guidelines
             isFeatured
-            featuredKey
             note
             branch
             parentVersionId
@@ -451,7 +450,6 @@ def register_score_tools(mcp: FastMCP):
                                     id
                                     createdAt
                                     isFeatured
-                                    featuredKey
                                     parentVersionId
                                     note
                                     metadata
@@ -477,7 +475,6 @@ def register_score_tools(mcp: FastMCP):
                                     "createdAt": v.get('createdAt'),
                                     "note": v.get('note'),
                                     "isFeatured": v.get('isFeatured'),
-                                    "featuredKey": v.get('featuredKey'),
                                     "parentVersionId": v.get('parentVersionId'),
                                     "isChampion": v.get('id') == score.get('championVersionId'),
                                     "metadata": v.get('metadata'),
@@ -505,7 +502,6 @@ def register_score_tools(mcp: FastMCP):
                                 updatedAt
                                 note
                                 isFeatured
-                                featuredKey
                                 parentVersionId
                                 metadata
                             }}
@@ -531,7 +527,6 @@ def register_score_tools(mcp: FastMCP):
                                 "updatedAt": version_data.get('updatedAt'),
                                 "note": version_data.get('note'),
                                 "isFeatured": version_data.get('isFeatured'),
-                                "featuredKey": version_data.get('featuredKey'),
                                 "parentVersionId": version_data.get('parentVersionId'),
                                 "metadata": version_data.get('metadata'),
                                 "isChampion": target_version_id == score.get('championVersionId')
@@ -2097,7 +2092,6 @@ def register_score_tools(mcp: FastMCP):
                 id
                 scoreId
                 isFeatured
-                featuredKey
                 updatedAt
               }
             }
@@ -2107,8 +2101,7 @@ def register_score_tools(mcp: FastMCP):
                 {
                     "input": {
                         "id": request.version_id,
-                        "isFeatured": request.pinned,
-                        "featuredKey": "featured" if request.pinned else "unfeatured",
+                        "isFeatured": "true" if request.pinned else None,
                         "createdAt": version.get("createdAt"),
                     }
                 },
@@ -2118,7 +2111,7 @@ def register_score_tools(mcp: FastMCP):
                 "score_id": context["score_id"],
                 "score_name": context["score_name"],
                 "version_id": updated.get("id") or request.version_id,
-                "pinned": updated.get("featuredKey") == "featured",
+                "pinned": updated.get("isFeatured") == "true",
             }
         except Exception as e:
             logger.error(f"Error pinning score version: {e}", exc_info=True)
@@ -2592,8 +2585,7 @@ async def _create_version_from_code_with_parent(
             'scoreId': score.id,
             'configuration': (code_content or '').strip(),
             'note': note or 'Updated via MCP score update tool',
-            'isFeatured': False,
-            'featuredKey': 'unfeatured'
+            'isFeatured': None
         }
         
         # Add guidelines if provided

--- a/dashboard/amplify/data/resource.ts
+++ b/dashboard/amplify/data/resource.ts
@@ -36,7 +36,7 @@ type TaskIndexFields = "accountId" | "type" | "status" | "target" |
     "currentStageId" | "updatedAt" | "scorecardId" | "scoreId";
 type TaskStageIndexFields = "taskId" | "name" | "order" | "status";
 type ShareLinkIndexFields = "token" | "resourceType" | "resourceId" | "accountId";
-type ScoreVersionIndexFields = "scoreId" | "versionNumber" | "isFeatured" | "featuredKey";
+type ScoreVersionIndexFields = "scoreId" | "versionNumber" | "isFeatured";
 type ReportConfigurationIndexFields = "accountId" | "name";
 type ReportIndexFields = "accountId" | "reportConfigurationId" | "createdAt" | "updatedAt" | "taskId";
 type ReportBlockIndexFields = "reportId" | "name" | "position" | "dataSetId";
@@ -194,8 +194,7 @@ const schema = a.schema({
             score: a.belongsTo('Score', 'scoreId'),
             configuration: a.string().required(),
             guidelines: a.string(),
-            isFeatured: a.boolean(),
-            featuredKey: a.string(),
+            isFeatured: a.string(),
             createdAt: a.datetime().required(),
             updatedAt: a.datetime().required(),
             note: a.string(),
@@ -216,7 +215,7 @@ const schema = a.schema({
         ])
         .secondaryIndexes((idx) => [
             idx("scoreId").sortKeys(["createdAt"]),
-            idx("scoreId").sortKeys(["featuredKey", "createdAt"]).name("byScoreIdAndFeaturedKeyAndCreatedAt")
+            idx("scoreId").sortKeys(["isFeatured", "createdAt"]).name("byScoreIdAndIsFeaturedAndCreatedAt")
         ]),
 
     Evaluation: a

--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -72,8 +72,7 @@ export interface ScoreVersion {
   scoreId: string
   configuration: string // YAML string
   guidelines?: string
-  isFeatured: boolean
-  featuredKey?: string
+  isFeatured?: string | null
   isChampion?: boolean
   note?: string
   branch?: string
@@ -125,6 +124,8 @@ const assertGraphQLSuccess = (response: any, action: string) => {
     throw new Error(`${action}: ${response.errors.map((error: any) => error?.message || String(error)).join('; ')}`)
   }
 }
+
+const isScoreVersionPinned = (version?: Pick<ScoreVersion, 'isFeatured'> | null) => version?.isFeatured === 'true'
 
 const buildChampionMetadata = ({
   metadata,
@@ -1660,7 +1661,7 @@ const DetailContent = React.memo(({
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem onClick={() => onToggleFeature?.(selectedVersion.id)}>
                             <Star className="mr-2 h-4 w-4" />
-                            {selectedVersion.featuredKey === 'featured' ? 'Unstar Version' : 'Star Version'}
+                            {isScoreVersionPinned(selectedVersion) ? 'Unstar Version' : 'Star Version'}
                           </DropdownMenuItem>
                           <DropdownMenuItem onClick={() => handleOpenVersionDiff()}>
                             <GitCompareArrows className="mr-2 h-4 w-4" />
@@ -2270,7 +2271,6 @@ export function ScoreComponent({
               configuration
               guidelines
               isFeatured
-              featuredKey
               note
               branch
               parentVersionId
@@ -2398,7 +2398,6 @@ export function ScoreComponent({
               configuration
               guidelines
               isFeatured
-              featuredKey
               note
               branch
               parentVersionId
@@ -2436,7 +2435,6 @@ export function ScoreComponent({
                 configuration
                 guidelines
                 isFeatured
-                featuredKey
                 note
                 branch
                 parentVersionId
@@ -2475,9 +2473,9 @@ export function ScoreComponent({
             $sortDirection: ModelSortDirection
             $limit: Int
           ) {
-            listScoreVersionByScoreIdAndFeaturedKeyAndCreatedAt(
+            listScoreVersionByScoreIdAndIsFeaturedAndCreatedAt(
               scoreId: $scoreId,
-              featuredKeyCreatedAt: { beginsWith: { featuredKey: "featured" } },
+              isFeaturedCreatedAt: { beginsWith: { isFeatured: "true" } },
               sortDirection: $sortDirection,
               limit: $limit
             ) {
@@ -2487,7 +2485,6 @@ export function ScoreComponent({
                 configuration
                 guidelines
                 isFeatured
-                featuredKey
                 note
                 branch
                 parentVersionId
@@ -2504,12 +2501,12 @@ export function ScoreComponent({
           limit: 100,
         }
       }) as GraphQLResult<{
-        listScoreVersionByScoreIdAndFeaturedKeyAndCreatedAt?: {
+        listScoreVersionByScoreIdAndIsFeaturedAndCreatedAt?: {
           items: ScoreVersion[]
         }
       }>;
 
-      return response.data?.listScoreVersionByScoreIdAndFeaturedKeyAndCreatedAt?.items ?? [];
+      return response.data?.listScoreVersionByScoreIdAndIsFeaturedAndCreatedAt?.items ?? [];
     };
 
     const selectPreferredVersion = async (
@@ -2844,7 +2841,7 @@ export function ScoreComponent({
     try {
       const version = versions.find(v => v.id === versionId);
       if (!version) return;
-      const isPinned = version.featuredKey === 'featured';
+      const isPinned = isScoreVersionPinned(version);
       const nextPinned = !isPinned;
 
       // Enable API call to persist the feature status
@@ -2854,15 +2851,13 @@ export function ScoreComponent({
             updateScoreVersion(input: $input) {
               id
               isFeatured
-              featuredKey
             }
           }
         `,
         variables: {
           input: {
             id: String(versionId),
-            isFeatured: nextPinned,
-            featuredKey: nextPinned ? 'featured' : 'unfeatured',
+            isFeatured: nextPinned ? 'true' : null,
             createdAt: version.createdAt,
           }
         }
@@ -2872,7 +2867,7 @@ export function ScoreComponent({
       // This ensures UI is updated even if we can't verify the response format
       setVersions(prev => prev.map(v => 
         v.id === versionId
-          ? { ...v, isFeatured: nextPinned, featuredKey: nextPinned ? 'featured' : 'unfeatured' }
+          ? { ...v, isFeatured: nextPinned ? 'true' : null }
           : v
       ));
 
@@ -3016,8 +3011,7 @@ export function ScoreComponent({
         scoreId: String(score.id),
         configuration: configurationYaml,
         guidelines: overrideGuidelines !== undefined ? overrideGuidelines : (editedScore.guidelines || ''),
-        isFeatured: false,
-        featuredKey: 'unfeatured',
+        isFeatured: null,
         note: versionNote || 'Updated score configuration',
         createdAt: now,
         updatedAt: now
@@ -3032,7 +3026,6 @@ export function ScoreComponent({
               configuration
               guidelines
               isFeatured
-              featuredKey
               note
               createdAt
               updatedAt

--- a/dashboard/components/ui/score-sidebar-version-history.tsx
+++ b/dashboard/components/ui/score-sidebar-version-history.tsx
@@ -88,7 +88,7 @@ export const ScoreSidebarVersionHistory: React.FC<ScoreSidebarVersionHistoryProp
   const sortedVersions = [...versions].sort((a, b) => 
     new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
-  const isPinned = (version: ScoreVersion) => version.featuredKey === 'featured'
+  const isPinned = (version: ScoreVersion) => version.isFeatured === 'true'
   const pinnedVersions = sortedVersions.filter(v => isPinned(v) && v.id !== championVersionId)
   const recentVersions = sortedVersions.filter(v => v.id !== championVersionId && !isPinned(v))
 

--- a/plexus/cli/score/scores.py
+++ b/plexus/cli/score/scores.py
@@ -475,7 +475,6 @@ def versions(id: str, pinned_only: bool):
                     createdAt
                     updatedAt
                     isFeatured
-                    featuredKey
                     parentVersionId
                     note
                 }}
@@ -508,7 +507,7 @@ def versions(id: str, pinned_only: bool):
             return
         
         def is_pinned_version(version):
-            return version.get('featuredKey') == 'featured'
+            return version.get('isFeatured') == 'true'
 
         if pinned_only:
             versions = [version for version in versions if is_pinned_version(version)]
@@ -1365,8 +1364,7 @@ def push(scorecard: str, score: str, note: str):
                 'configuration': cleaned_yaml_content,
                 'note': note,
                 # Never auto-promote to champion via CLI push
-                'isFeatured': False,
-                'featuredKey': 'unfeatured'
+                'isFeatured': None
             }
         }
 
@@ -1751,7 +1749,6 @@ def _fetch_score_version_for_management(client, version_id: str) -> dict:
         configuration
         guidelines
         isFeatured
-        featuredKey
         note
         branch
         parentVersionId
@@ -1798,7 +1795,6 @@ def version_pin(scorecard: str, score: str, version_id: str, pinned: bool, outpu
         id
         scoreId
         isFeatured
-        featuredKey
         updatedAt
       }
     }
@@ -1808,8 +1804,7 @@ def version_pin(scorecard: str, score: str, version_id: str, pinned: bool, outpu
         {
             "input": {
                 "id": version_id,
-                "isFeatured": pinned,
-                "featuredKey": "featured" if pinned else "unfeatured",
+                "isFeatured": "true" if pinned else None,
                 "createdAt": version.get("createdAt"),
             }
         },
@@ -1819,7 +1814,7 @@ def version_pin(scorecard: str, score: str, version_id: str, pinned: bool, outpu
         "score_id": context["score_id"],
         "score_name": context["score_name"],
         "version_id": updated.get("id") or version_id,
-        "pinned": updated.get("featuredKey") == "featured",
+        "pinned": updated.get("isFeatured") == "true",
     }
 
     if output == 'json':

--- a/plexus/cli/score_chat/repl.py
+++ b/plexus/cli/score_chat/repl.py
@@ -1133,8 +1133,7 @@ You can also just ask me questions or tell me what you'd like to do in plain Eng
                     'configuration': yaml_content,
                     'parentVersionId': score_data.get('championVersionId'),
                     'note': 'Updated via CLI push command',
-                    'isFeatured': False,
-                    'featuredKey': 'unfeatured'
+                    'isFeatured': None
                 }
             })
             

--- a/plexus/dashboard/api/models/score.py
+++ b/plexus/dashboard/api/models/score.py
@@ -1007,8 +1007,7 @@ class Score(BaseModel):
                 'configuration': (code_content or '').strip(),
                 'note': note or 'Updated via Score.create_version_from_code()',
                 # Do not mark as featured - these are test versions from procedures
-                'isFeatured': False,
-                'featuredKey': 'unfeatured'
+                'isFeatured': None
             }
             
             # Add guidelines if provided

--- a/project/events/2026-04-27T23:14:54.218Z__d96d4491-e45f-48b7-8d28-1bc97394f7bc.json
+++ b/project/events/2026-04-27T23:14:54.218Z__d96d4491-e45f-48b7-8d28-1bc97394f7bc.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "d96d4491-e45f-48b7-8d28-1bc97394f7bc",
+  "issue_id": "plx-1d97c730-85f5-494a-9025-8040804ace75",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T23:14:54.218Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Remove the extra ScoreVersion featuredKey mirror field. Make isFeatured the single string field used for pinned state and indexing, with value \"true\" when pinned and absent/null otherwise. Update dashboard, CLI, and MCP to use one field consistently.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Replace ScoreVersion featured mirror with string state"
+  }
+}

--- a/project/events/2026-04-27T23:16:14.461Z__5fee59b7-e9f5-4bfd-b4a9-0e9d70480004.json
+++ b/project/events/2026-04-27T23:16:14.461Z__5fee59b7-e9f5-4bfd-b4a9-0e9d70480004.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5fee59b7-e9f5-4bfd-b4a9-0e9d70480004",
+  "issue_id": "plx-1d97c730-85f5-494a-9025-8040804ace75",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T23:16:14.461Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "c4fdd6f8-4431-4812-a34b-b69d3bbb066c"
+  }
+}

--- a/project/events/2026-04-27T23:22:35.644Z__0ff7458d-368b-4950-b9d6-db39ad5c2fcf.json
+++ b/project/events/2026-04-27T23:22:35.644Z__0ff7458d-368b-4950-b9d6-db39ad5c2fcf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0ff7458d-368b-4950-b9d6-db39ad5c2fcf",
+  "issue_id": "plx-1d97c730-85f5-494a-9025-8040804ace75",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T23:22:35.644Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "787fa580-dfaf-4d56-bfd4-e34b50118d80"
+  }
+}

--- a/project/issues/plx-1d97c730-85f5-494a-9025-8040804ace75.json
+++ b/project/issues/plx-1d97c730-85f5-494a-9025-8040804ace75.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-1d97c730-85f5-494a-9025-8040804ace75",
+  "title": "Replace ScoreVersion featured mirror with string state",
+  "description": "Remove the extra ScoreVersion featuredKey mirror field. Make isFeatured the single string field used for pinned state and indexing, with value \"true\" when pinned and absent/null otherwise. Update dashboard, CLI, and MCP to use one field consistently.",
+  "type": "bug",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "c4fdd6f8-4431-4812-a34b-b69d3bbb066c",
+      "author": "ryan",
+      "text": "Implementing schema/code cleanup: remove featuredKey mirror, make ScoreVersion.isFeatured the single string state used for pinned versions and indexing.",
+      "created_at": "2026-04-27T23:16:14.460302Z"
+    },
+    {
+      "id": "787fa580-dfaf-4d56-bfd4-e34b50118d80",
+      "author": "ryan",
+      "text": "Implemented and typechecked the target-state fix: ScoreVersion.isFeatured is now optional string state, pinned query uses scoreId + isFeatured + createdAt, and featuredKey is removed from frontend/CLI/MCP writers and readers.",
+      "created_at": "2026-04-27T23:22:35.643635Z"
+    }
+  ],
+  "created_at": "2026-04-27T23:14:54.217780Z",
+  "updated_at": "2026-04-27T23:22:35.643635Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- remove the extra ScoreVersion featuredKey mirror field
- make ScoreVersion.isFeatured the single optional string state for pinned versions
- update the pinned-version GSI to scoreId + isFeatured + createdAt
- update dashboard, CLI, and MCP pinning/version creation to use isFeatured = "true" or null

## Validation
- npm run typecheck (dashboard)
- python -m py_compile MCP/tools/score/scores.py plexus/cli/score/scores.py plexus/cli/score_chat/repl.py plexus/dashboard/api/models/score.py
- rg confirms no live featuredKey references outside Kanbus artifacts

## Deployment note
This replaces the ScoreVersion pinned index from featuredKey to isFeatured. Treat it as the schema change that needs deployment validation before the frontend pinning flow can work against the new API.