### PR TITLE
Fix console chat runtime update mutation for response-status index key

### DIFF
--- a/plexus/console/chat_runtime.py
+++ b/plexus/console/chat_runtime.py
@@ -140,6 +140,7 @@ def claim_message(
         {
             "input": {
                 "id": message.id,
+                "createdAt": message.created_at,
                 "responseStatus": RUNNING,
                 "responseOwner": owner,
                 "responseStartedAt": utc_now(),
@@ -159,7 +160,12 @@ def claim_message(
     return isinstance(claimed, dict) and claimed.get("id") == message.id
 
 
-def mark_message_completed(client: PlexusDashboardClient, message_id: str) -> None:
+def mark_message_completed(
+    client: PlexusDashboardClient,
+    message_id: str,
+    *,
+    created_at: Optional[str],
+) -> None:
     mutation = """
     mutation CompleteConsoleChatMessage($input: UpdateChatMessageInput!) {
       updateChatMessage(input: $input) {
@@ -173,6 +179,7 @@ def mark_message_completed(client: PlexusDashboardClient, message_id: str) -> No
         {
             "input": {
                 "id": message_id,
+                "createdAt": created_at,
                 "responseStatus": COMPLETED,
                 "responseCompletedAt": utc_now(),
                 "responseError": None,
@@ -181,7 +188,13 @@ def mark_message_completed(client: PlexusDashboardClient, message_id: str) -> No
     )
 
 
-def mark_message_failed(client: PlexusDashboardClient, message_id: str, error: Exception) -> None:
+def mark_message_failed(
+    client: PlexusDashboardClient,
+    message_id: str,
+    error: Exception,
+    *,
+    created_at: Optional[str],
+) -> None:
     mutation = """
     mutation FailConsoleChatMessage($input: UpdateChatMessageInput!) {
       updateChatMessage(input: $input) {
@@ -195,6 +208,7 @@ def mark_message_failed(client: PlexusDashboardClient, message_id: str, error: E
         {
             "input": {
                 "id": message_id,
+                "createdAt": created_at,
                 "responseStatus": FAILED,
                 "responseCompletedAt": utc_now(),
                 "responseError": str(error),
@@ -335,14 +349,15 @@ def process_console_message(
     if not claim_message(client, message, expected_target=expected_target, owner=owner):
         return False
 
+    latest_message = message
     try:
         latest_message = fetch_message(client, message.id) or message
         run_console_chat_response(client, latest_message, owner=owner)
-        mark_message_completed(client, message.id)
+        mark_message_completed(client, message.id, created_at=latest_message.created_at)
         return True
     except Exception as exc:
         logger.exception("Console chat response failed for message %s", message.id)
-        mark_message_failed(client, message.id, exc)
+        mark_message_failed(client, message.id, exc, created_at=latest_message.created_at)
         raise
 
 

--- a/plexus/console/test_chat_runtime.py
+++ b/plexus/console/test_chat_runtime.py
@@ -128,6 +128,7 @@ def test_claim_message_uses_conditional_pending_to_running_update():
 
     query, variables = client.executed[0]
     assert "ClaimConsoleChatMessage" in query
+    assert variables["input"]["createdAt"] == "2026-04-27T00:00:00.000Z"
     assert variables["input"]["responseStatus"] == "RUNNING"
     assert variables["input"]["responseOwner"] == "cloud:test"
     assert variables["condition"] == {
@@ -170,7 +171,13 @@ def test_process_console_message_runs_harness_and_marks_completed(monkeypatch):
         owner="cloud:test",
     ) is True
     assert calls == ["ran"]
-    assert any("CompleteConsoleChatMessage" in query for query, _ in client.executed)
+    complete_call = next(
+        variables
+        for query, variables in client.executed
+        if "CompleteConsoleChatMessage" in query
+    )
+    assert complete_call["input"]["createdAt"] == "2026-04-27T00:00:00.000Z"
+    assert complete_call["input"]["responseStatus"] == "COMPLETED"
 
 
 def test_process_console_message_marks_failed_when_harness_raises(monkeypatch):
@@ -198,6 +205,7 @@ def test_process_console_message_marks_failed_when_harness_raises(monkeypatch):
         for query, variables in client.executed
         if "FailConsoleChatMessage" in query
     )
+    assert fail_call["input"]["createdAt"] == "2026-04-27T00:00:00.000Z"
     assert fail_call["input"]["responseStatus"] == "FAILED"
     assert fail_call["input"]["responseError"] == "boom"
 


### PR DESCRIPTION
## Summary
- include createdAt in console chat message update mutations when claiming/running/completing/failing
- propagate created_at through process flow so updates satisfy composite key requirements
- extend chat runtime tests to assert createdAt is present on claim, complete, and fail updates

## Why
AppSync updateChatMessage mutations fail on the response-target/status/createdAt index if key fields are omitted. This prevented the chat responder from transitioning message status and completing responses.

## Testing
- PYTHONPATH=. pytest plexus/console/test_chat_runtime.py dashboard/amplify/functions/consoleRunWorker/app_test.py -q