### PR TITLE
Harden console chat local worker and message update edge cases

### DIFF
--- a/dashboard/amplify/functions/consoleRunWorker/app_test.py
+++ b/dashboard/amplify/functions/consoleRunWorker/app_test.py
@@ -129,3 +129,21 @@ def test_handler_skips_insert_without_new_image(monkeypatch):
 
     assert result["processed"] == 0
     assert result["skipped"] == 1
+
+
+def test_handler_duplicate_stream_delivery_counts_only_one_processed(monkeypatch):
+    app = _load_app_module()
+    outcomes = iter([True, False])
+
+    monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "cloud")
+    monkeypatch.setattr(app, "_resolve_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(app, "process_console_message", lambda *_args, **_kwargs: next(outcomes))
+
+    result = app.handler(
+        {"Records": [_stream_record(), _stream_record()]},
+        SimpleNamespace(aws_request_id="req-1"),
+    )
+
+    assert result["processed"] == 1
+    assert result["skipped"] == 1
+    assert result["batchItemFailures"] == []

--- a/dashboard/amplify/functions/consoleRunWorker/local_worker_test.py
+++ b/dashboard/amplify/functions/consoleRunWorker/local_worker_test.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_local_worker_module():
+    worker_path = Path(__file__).with_name("local_worker.py")
+    spec = importlib.util.spec_from_file_location("console_chat_local_worker", worker_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_client_accepts_next_public_env(monkeypatch):
+    worker = _load_local_worker_module()
+    created = []
+
+    class FakeClient:
+        def __init__(self, *, api_url, api_key):
+            created.append((api_url, api_key))
+
+    monkeypatch.delenv("PLEXUS_API_URL", raising=False)
+    monkeypatch.delenv("PLEXUS_API_KEY", raising=False)
+    monkeypatch.setenv("NEXT_PUBLIC_PLEXUS_API_URL", "https://example.appsync-api.us-east-1.amazonaws.com/graphql")
+    monkeypatch.setenv("NEXT_PUBLIC_PLEXUS_API_KEY", "da2-test")
+    monkeypatch.setattr(worker, "PlexusDashboardClient", FakeClient)
+
+    worker._resolve_client()
+
+    assert created == [("https://example.appsync-api.us-east-1.amazonaws.com/graphql", "da2-test")]
+
+
+def test_main_rejects_cloud_response_target(monkeypatch):
+    worker = _load_local_worker_module()
+    monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "cloud")
+
+    try:
+        worker.main()
+    except RuntimeError as exc:
+        assert "local:<developer>" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_main_processes_pending_messages_with_local_owner(monkeypatch):
+    worker = _load_local_worker_module()
+    calls = []
+
+    monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "local:ryan")
+    monkeypatch.setenv("CONSOLE_LOCAL_WORKER_POLL_SECONDS", "0")
+    monkeypatch.setattr(worker, "_resolve_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        worker,
+        "process_pending_local_messages",
+        lambda _client, **kwargs: calls.append(kwargs) or 1,
+    )
+    monkeypatch.setattr(worker.time, "sleep", lambda _secs: (_ for _ in ()).throw(SystemExit(0)))
+
+    try:
+        worker.main()
+    except SystemExit:
+        pass
+    else:
+        raise AssertionError("expected SystemExit from patched sleep")
+
+    assert len(calls) == 1
+    assert calls[0]["response_target"] == "local:ryan"
+    assert calls[0]["limit"] == 5
+    assert calls[0]["owner"].startswith("local:ryan:")

--- a/plexus/console/chat_runtime.py
+++ b/plexus/console/chat_runtime.py
@@ -352,12 +352,14 @@ def process_console_message(
     latest_message = message
     try:
         latest_message = fetch_message(client, message.id) or message
+        created_at = latest_message.created_at or message.created_at or None
         run_console_chat_response(client, latest_message, owner=owner)
-        mark_message_completed(client, message.id, created_at=latest_message.created_at)
+        mark_message_completed(client, message.id, created_at=created_at)
         return True
     except Exception as exc:
         logger.exception("Console chat response failed for message %s", message.id)
-        mark_message_failed(client, message.id, exc, created_at=latest_message.created_at)
+        created_at = latest_message.created_at or message.created_at or None
+        mark_message_failed(client, message.id, exc, created_at=created_at)
         raise
 
 

--- a/plexus/console/test_chat_runtime.py
+++ b/plexus/console/test_chat_runtime.py
@@ -83,6 +83,19 @@ class FakePendingClient(FakeClient):
         return super().execute(query, variables, **_kwargs)
 
 
+class FakeHistoryClient(FakeClient):
+    def __init__(self, pages):
+        super().__init__()
+        self.pages = list(pages)
+
+    def execute(self, query, variables=None, **_kwargs):
+        if "ListConsoleSessionHistory" in query:
+            self.executed.append((query, variables or {}))
+            page = self.pages.pop(0) if self.pages else {"items": [], "nextToken": None}
+            return {"data": {"listChatMessageBySessionIdAndCreatedAt": page}}
+        return super().execute(query, variables, **_kwargs)
+
+
 def test_should_handle_only_matching_pending_user_chat_message():
     message = chat_runtime.parse_chat_message(_raw_message())
 
@@ -210,6 +223,34 @@ def test_process_console_message_marks_failed_when_harness_raises(monkeypatch):
     assert fail_call["input"]["responseError"] == "boom"
 
 
+def test_process_console_message_falls_back_to_trigger_created_at(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(
+        chat_runtime,
+        "run_console_chat_response",
+        lambda *_args, **_kwargs: {"success": True},
+    )
+    monkeypatch.setattr(
+        chat_runtime,
+        "fetch_message",
+        lambda *_args, **_kwargs: chat_runtime.parse_chat_message(_raw_message(createdAt="")),
+    )
+
+    assert chat_runtime.process_console_message(
+        client,
+        _raw_message(createdAt="2026-04-27T00:00:00.000Z"),
+        expected_target="cloud",
+        owner="cloud:test",
+    ) is True
+
+    complete_call = next(
+        variables
+        for query, variables in client.executed
+        if "CompleteConsoleChatMessage" in query
+    )
+    assert complete_call["input"]["createdAt"] == "2026-04-27T00:00:00.000Z"
+
+
 def test_process_console_message_ignores_local_target_for_cloud_worker(monkeypatch):
     client = FakeClient()
     calls = []
@@ -332,3 +373,57 @@ def test_run_console_chat_response_passes_console_context_to_builtin(monkeypatch
         "console_trigger_message_id": "msg-1",
         "console_response_owner": "local:ryan:test",
     }
+
+
+def test_fetch_session_history_filters_and_sorts_messages():
+    client = FakeHistoryClient([
+        {
+            "items": [
+                {
+                    "id": "msg-3",
+                    "role": "ASSISTANT",
+                    "messageType": "MESSAGE",
+                    "humanInteraction": "CHAT_ASSISTANT",
+                    "content": "third",
+                    "createdAt": "2026-04-27T00:00:03.000Z",
+                },
+                {
+                    "id": "msg-tool",
+                    "role": "ASSISTANT",
+                    "messageType": "TOOL_CALL",
+                    "humanInteraction": "CHAT_ASSISTANT",
+                    "content": "ignore",
+                    "createdAt": "2026-04-27T00:00:02.000Z",
+                },
+            ],
+            "nextToken": "page-2",
+        },
+        {
+            "items": [
+                {
+                    "id": "msg-1",
+                    "role": "USER",
+                    "messageType": "MESSAGE",
+                    "humanInteraction": "CHAT",
+                    "content": "first",
+                    "createdAt": "2026-04-27T00:00:01.000Z",
+                },
+                {
+                    "id": "msg-sys",
+                    "role": "SYSTEM",
+                    "messageType": "MESSAGE",
+                    "humanInteraction": "CHAT",
+                    "content": "ignore",
+                    "createdAt": "2026-04-27T00:00:00.500Z",
+                },
+            ],
+            "nextToken": None,
+        },
+    ])
+
+    history = chat_runtime.fetch_session_history(client, "sess-1", limit=10)
+
+    assert history == [
+        {"role": "USER", "content": "first"},
+        {"role": "ASSISTANT", "content": "third"},
+    ]


### PR DESCRIPTION
## Summary
- harden console chat runtime to fall back to trigger message createdAt when completing/failing responses
- add stream handler duplicate-delivery test coverage
- add local worker tests for env resolution, cloud-target rejection, and poll loop wiring
- add session history filtering/sorting coverage in chat runtime tests

## Why
These changes tighten local programmatic validation and prevent composite-key update regressions in edge cases while we continue validating the new chat architecture.

## Testing
- PYTHONPATH=. pytest plexus/console/test_chat_runtime.py dashboard/amplify/functions/consoleRunWorker/app_test.py dashboard/amplify/functions/consoleRunWorker/local_worker_test.py -q