### PR TITLE
Add rubric memory storage bucket

### DIFF
--- a/dashboard/amplify/backend.ts
+++ b/dashboard/amplify/backend.ts
@@ -1,7 +1,7 @@
 import { defineBackend } from '@aws-amplify/backend';
 import { data } from './data/resource.js';
 import { auth } from './auth/resource.js';
-import { reportBlockDetails, dataSources, scoreResultAttachments, taskAttachments } from './storage/resource.js';
+import { reportBlockDetails, dataSources, scoreResultAttachments, taskAttachments, rubricMemory } from './storage/resource.js';
 import { TaskDispatcherStack } from './functions/taskDispatcher/resource.js';
 import { ConsoleChatResponderStack } from './functions/consoleRunWorker/resource.js';
 import { McpStack } from './mcp/mcp_stack.js';
@@ -19,7 +19,8 @@ const backend = defineBackend({
     reportBlockDetails,
     dataSources,
     scoreResultAttachments,
-    taskAttachments
+    taskAttachments,
+    rubricMemory
 });
 
 // Enable PITR on all Amplify Data DynamoDB tables (AWS default retention is 35 days).

--- a/dashboard/amplify/storage/resource.ts
+++ b/dashboard/amplify/storage/resource.ts
@@ -64,3 +64,13 @@ export const taskAttachments = defineStorage({
     ]
   })
 });
+
+// Define a storage bucket for rubric-memory knowledge-base source files
+export const rubricMemory = defineStorage({
+  name: 'rubricMemory',
+  access: (allow) => ({
+    '*': [
+      allow.authenticated.to(['read', 'write', 'delete'])
+    ]
+  })
+});


### PR DESCRIPTION
## Summary
- Adds a dedicated Amplify storage bucket named `rubricMemory` for scorecard knowledge-base source files.
- Registers the bucket in the Amplify backend so deployment creates it.
- Authenticated users get read/write/delete access; no guest access is granted.

## Validation
- `git diff --check -- dashboard/amplify/backend.ts dashboard/amplify/storage/resource.ts`
- `kbs validate`

Runtime S3 retrieval code is intentionally not included in this PR; this infrastructure PR is only to create the bucket so we can set `AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME` and test the runtime path next.