### PR TITLE
Add Procedure score-version index

### DIFF
--- a/dashboard/amplify/data/resource.ts
+++ b/dashboard/amplify/data/resource.ts
@@ -894,6 +894,7 @@ const schema = a.schema({
             idx("accountId").sortKeys(["updatedAt"]),
             idx("scorecardId").sortKeys(["updatedAt"]),
             idx("scoreId").sortKeys(["updatedAt"]),
+            idx("scoreVersionId").sortKeys(["updatedAt"]),
             idx("parentProcedureId").sortKeys(["updatedAt"]),
             idx("category").sortKeys(["version"]).name("byCategory"),
             idx("status").sortKeys(["updatedAt"]).name("byStatus")

--- a/project/events/2026-04-28T02:32:21.485Z__2abe8bee-a88e-4961-9d2b-0a6dddf239cf.json
+++ b/project/events/2026-04-28T02:32:21.485Z__2abe8bee-a88e-4961-9d2b-0a6dddf239cf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2abe8bee-a88e-4961-9d2b-0a6dddf239cf",
+  "issue_id": "plx-0271cca8-a07a-4e4f-8774-69a015107ef2",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T02:32:21.485Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "1b37dd36-6724-4f81-93a2-98acc7da5509"
+  }
+}

--- a/project/events/2026-04-28T02:39:42.545Z__10535e5e-7e2d-4ba7-b5d7-d0711e1fe4a9.json
+++ b/project/events/2026-04-28T02:39:42.545Z__10535e5e-7e2d-4ba7-b5d7-d0711e1fe4a9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "10535e5e-7e2d-4ba7-b5d7-d0711e1fe4a9",
+  "issue_id": "plx-0271cca8-a07a-4e4f-8774-69a015107ef2",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T02:39:42.545Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "08dc65bb-c250-4dfb-bb9e-4f63c2129948"
+  }
+}

--- a/project/issues/plx-0271cca8-a07a-4e4f-8774-69a015107ef2.json
+++ b/project/issues/plx-0271cca8-a07a-4e4f-8774-69a015107ef2.json
@@ -16,10 +16,22 @@
       "author": "ryan",
       "text": "Root cause: the dashboard's initial procedure load stopped after a single sparse page from listProcedureByAccountIdAndUpdatedAt. The AppSync GSI/query was fine; newer procedures were on later pages. Fix: keep using the normal Amplify Gen2 list query, but page through nextToken during initial load until we accumulate enough visible rows for the existing client-side start/created-time sort to surface recent procedures.",
       "created_at": "2026-04-20T19:39:57.057885Z"
+    },
+    {
+      "id": "1b37dd36-6724-4f81-93a2-98acc7da5509",
+      "author": "ryan",
+      "text": "Fixed version-scoped procedure discovery in scorecards dashboard. Root cause for historical procedures: procedure manifests are often discoverable through canonical Task.attachedFiles, but the frontend only inspected Procedure.metadata and only loaded the first page of account tasks. The loader now paginates score procedures and account tasks until it finds the relevant procedure tasks, then uses task attachments to load optimizer manifests for version-touch filtering. Focused procedure/evaluation list tests pass.",
+      "created_at": "2026-04-28T02:32:21.484514Z"
+    },
+    {
+      "id": "08dc65bb-c250-4dfb-bb9e-4f63c2129948",
+      "author": "ryan",
+      "text": "Schema fix selected for score-version procedure lists. The schema had ScoreVersion.procedures / Procedure.scoreVersionId, but no Procedure GSI on scoreVersionId, so the UI had no efficient query equivalent to evaluations. Added one Procedure-table GSI: scoreVersionId + updatedAt. This is intentionally one GSI change on one table for CloudFormation safety.",
+      "created_at": "2026-04-28T02:39:42.544815Z"
     }
   ],
   "created_at": "2026-04-20T19:12:14.848643Z",
-  "updated_at": "2026-04-20T19:39:57.057885Z",
+  "updated_at": "2026-04-28T02:39:42.544815Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
## Summary
- Add a Procedure secondary index on scoreVersionId sorted by updatedAt.
- This creates the direct score-version procedure query needed for the scorecards dashboard version Procedures tab.
- Scope is intentionally limited to one GSI change on the Procedure table for CloudFormation safety.

## Validation
- Reviewed schema diff: exactly one Procedure-table index added.
- No UI workaround changes included; UI can be updated after this schema deploy exposes the generated query.
