### PR TITLE
fix(test): accept PR 225 code quality suggestions

### DIFF
--- a/dashboard/amplify/functions/consoleRunWorker/local_worker_test.py
+++ b/dashboard/amplify/functions/consoleRunWorker/local_worker_test.py
@@ -75,7 +75,7 @@ def test_main_uses_next_public_response_target_from_env(monkeypatch):
     monkeypatch.delenv("CONSOLE_RESPONSE_TARGET", raising=False)
     monkeypatch.setenv("NEXT_PUBLIC_CONSOLE_RESPONSE_TARGET", "local:ryan")
     monkeypatch.setenv("CONSOLE_LOCAL_WORKER_POLL_SECONDS", "0")
-    monkeypatch.setattr(worker, "_resolve_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(worker, "_resolve_client", SimpleNamespace)
     monkeypatch.setattr(worker, "_load_local_env", lambda: None)
     monkeypatch.setattr(
         worker,
@@ -99,7 +99,7 @@ def test_main_processes_pending_messages_with_local_owner(monkeypatch):
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "local:ryan")
     monkeypatch.setenv("CONSOLE_LOCAL_WORKER_POLL_SECONDS", "0")
-    monkeypatch.setattr(worker, "_resolve_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(worker, "_resolve_client", SimpleNamespace)
     monkeypatch.setattr(
         worker,
         "process_pending_local_messages",

--- a/project/events/2026-04-28T03:31:08.822Z__ce10ac6a-1114-41b6-b621-4bca7d6b9c3d.json
+++ b/project/events/2026-04-28T03:31:08.822Z__ce10ac6a-1114-41b6-b621-4bca7d6b9c3d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ce10ac6a-1114-41b6-b621-4bca7d6b9c3d",
+  "issue_id": "plx-fd6855ca-3fe8-4be0-ae8a-e7c4c1177115",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T03:31:08.822Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e3c06fe2-491f-4b74-aabc-9cecd1252217"
+  }
+}

--- a/project/events/2026-04-28T03:32:10.361Z__d7a83059-30bc-49a6-ae97-b8c5b8542f84.json
+++ b/project/events/2026-04-28T03:32:10.361Z__d7a83059-30bc-49a6-ae97-b8c5b8542f84.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d7a83059-30bc-49a6-ae97-b8c5b8542f84",
+  "issue_id": "plx-fd6855ca-3fe8-4be0-ae8a-e7c4c1177115",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T03:32:10.361Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "665fe82b-100f-40c6-bf6f-42ca49991fc3"
+  }
+}

--- a/project/issues/plx-fd6855ca-3fe8-4be0-ae8a-e7c4c1177115.json
+++ b/project/issues/plx-fd6855ca-3fe8-4be0-ae8a-e7c4c1177115.json
@@ -28,10 +28,22 @@
       "author": "ryan",
       "text": "Committed pending Kanbus state files on develop: 8f63c27c4 (chore(project): commit pending Kanbus issue/event updates).",
       "created_at": "2026-04-14T22:15:51.179792Z"
+    },
+    {
+      "id": "e3c06fe2-491f-4b74-aabc-9cecd1252217",
+      "author": "ryan",
+      "text": "Investigating new CodeQL/code-quality suggestions on active develop->main PR #225 after latest develop updates; will apply concrete suggestions only.",
+      "created_at": "2026-04-28T03:31:08.821206Z"
+    },
+    {
+      "id": "665fe82b-100f-40c6-bf6f-42ca49991fc3",
+      "author": "ryan",
+      "text": "Applied the two unresolved PR #225 github-code-quality suggestions in consoleRunWorker local worker tests and verified with py311 pytest: dashboard/amplify/functions/consoleRunWorker/local_worker_test.py.",
+      "created_at": "2026-04-28T03:32:10.360743Z"
     }
   ],
   "created_at": "2026-04-14T13:06:37.216868Z",
-  "updated_at": "2026-04-14T22:15:51.179792Z",
+  "updated_at": "2026-04-28T03:32:10.360743Z",
   "closed_at": null,
   "custom": {
     "project_label": "plx",


### PR DESCRIPTION
## Summary
- Replace redundant local worker test lambdas with direct SimpleNamespace callables
- Updates Kanbus task fd6855 for PR #225 CodeQL/code-quality cleanup

## Validation
- /Users/ryan/miniconda3/envs/py311/bin/python -m pytest dashboard/amplify/functions/consoleRunWorker/local_worker_test.py