### PR TITLE
chore(kanbus): close PR 225 code quality task

### DIFF
--- a/project/events/2026-04-28T03:33:27.280Z__d74b963d-97d1-452f-ac02-4f0fc20ca071.json
+++ b/project/events/2026-04-28T03:33:27.280Z__d74b963d-97d1-452f-ac02-4f0fc20ca071.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d74b963d-97d1-452f-ac02-4f0fc20ca071",
+  "issue_id": "plx-fd6855ca-3fe8-4be0-ae8a-e7c4c1177115",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-28T03:33:27.280Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-fd6855ca-3fe8-4be0-ae8a-e7c4c1177115.json
+++ b/project/issues/plx-fd6855ca-3fe8-4be0-ae8a-e7c4c1177115.json
@@ -3,7 +3,7 @@
   "title": "Accept and apply CodeQL suggestions for develop->main PR",
   "description": "",
   "type": "bug",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 2,
   "assignee": null,
   "creator": null,
@@ -43,8 +43,8 @@
     }
   ],
   "created_at": "2026-04-14T13:06:37.216868Z",
-  "updated_at": "2026-04-28T03:32:10.360743Z",
-  "closed_at": null,
+  "updated_at": "2026-04-28T03:33:27.280304Z",
+  "closed_at": "2026-04-28T03:33:27.280304Z",
   "custom": {
     "project_label": "plx",
     "source": "shared"


### PR DESCRIPTION
## Summary
- Close Kanbus task fd6855 after the PR #225 code-quality suggestions were applied and review threads resolved

## Validation
- No code changes in this follow-up; prior focused test passed:
  - /Users/ryan/miniconda3/envs/py311/bin/python -m pytest dashboard/amplify/functions/consoleRunWorker/local_worker_test.py