### PR TITLE
fix(amplify): use valid rubric memory storage path

### DIFF
--- a/dashboard/amplify/storage/resource.ts
+++ b/dashboard/amplify/storage/resource.ts
@@ -69,7 +69,7 @@ export const taskAttachments = defineStorage({
 export const rubricMemory = defineStorage({
   name: 'rubricMemory',
   access: (allow) => ({
-    '*': [
+    'rubric-memory/*': [
       allow.authenticated.to(['read', 'write', 'delete'])
     ]
   })

--- a/project/events/2026-04-28T16:18:48.360Z__b0df1ce4-5c81-460e-b011-23c3ba8eb588.json
+++ b/project/events/2026-04-28T16:18:48.360Z__b0df1ce4-5c81-460e-b011-23c3ba8eb588.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "b0df1ce4-5c81-460e-b011-23c3ba8eb588",
+  "issue_id": "plx-fb173067-6c14-48ba-bff3-0e533f9a82ec",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-28T16:18:48.360Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Investigate failed Amplify deployment after PR 225 merge"
+  }
+}

--- a/project/events/2026-04-28T16:19:21.940Z__654d462b-2aec-4a29-87f7-c9246d32a21f.json
+++ b/project/events/2026-04-28T16:19:21.940Z__654d462b-2aec-4a29-87f7-c9246d32a21f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "654d462b-2aec-4a29-87f7-c9246d32a21f",
+  "issue_id": "plx-fb173067-6c14-48ba-bff3-0e533f9a82ec",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-28T16:19:21.940Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-28T16:19:21.961Z__bf14d766-52d9-4762-98ff-bd4049f8c8b7.json
+++ b/project/events/2026-04-28T16:19:21.961Z__bf14d766-52d9-4762-98ff-bd4049f8c8b7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bf14d766-52d9-4762-98ff-bd4049f8c8b7",
+  "issue_id": "plx-fb173067-6c14-48ba-bff3-0e533f9a82ec",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T16:19:21.961Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "3411352f-4160-4fd4-9fcd-8decfcb9f9fb"
+  }
+}

--- a/project/events/2026-04-28T16:21:07.855Z__4e715f78-6710-4250-bf4e-5c44975aad40.json
+++ b/project/events/2026-04-28T16:21:07.855Z__4e715f78-6710-4250-bf4e-5c44975aad40.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4e715f78-6710-4250-bf4e-5c44975aad40",
+  "issue_id": "plx-fb173067-6c14-48ba-bff3-0e533f9a82ec",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T16:21:07.855Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "454c03bf-2ded-48f5-999f-501bb1f5a581"
+  }
+}

--- a/project/events/2026-04-28T16:23:32.964Z__ec446d82-c938-4def-bf65-32c16c0f971a.json
+++ b/project/events/2026-04-28T16:23:32.964Z__ec446d82-c938-4def-bf65-32c16c0f971a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ec446d82-c938-4def-bf65-32c16c0f971a",
+  "issue_id": "plx-fb173067-6c14-48ba-bff3-0e533f9a82ec",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T16:23:32.964Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "34ed64e3-cac3-4576-b6e9-f0f40a04d12c"
+  }
+}

--- a/project/issues/plx-fb173067-6c14-48ba-bff3-0e533f9a82ec.json
+++ b/project/issues/plx-fb173067-6c14-48ba-bff3-0e533f9a82ec.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-fb173067-6c14-48ba-bff3-0e533f9a82ec",
+  "title": "Investigate failed Amplify deployment after PR 225 merge",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "3411352f-4160-4fd4-9fcd-8decfcb9f9fb",
+      "author": "ryan",
+      "text": "Investigating failed Amplify deployment for app d1cegb1ft4iove after PR #225 merge; starting with AWS Amplify job/status logs.",
+      "created_at": "2026-04-28T16:19:21.961591Z"
+    },
+    {
+      "id": "454c03bf-2ded-48f5-999f-501bb1f5a581",
+      "author": "ryan",
+      "text": "Root cause found in Amplify job 1036: backend build fails during CDK assembly with InvalidStorageAccessPathError because rubricMemory storage access used bare '*' instead of a required '*/' prefix. Applying hotfix to use rubric-memory/* as the single valid bucket prefix.",
+      "created_at": "2026-04-28T16:21:07.854921Z"
+    }
+  ],
+  "created_at": "2026-04-28T16:18:48.359438Z",
+  "updated_at": "2026-04-28T16:21:07.854921Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-fb173067-6c14-48ba-bff3-0e533f9a82ec.json
+++ b/project/issues/plx-fb173067-6c14-48ba-bff3-0e533f9a82ec.json
@@ -22,10 +22,16 @@
       "author": "ryan",
       "text": "Root cause found in Amplify job 1036: backend build fails during CDK assembly with InvalidStorageAccessPathError because rubricMemory storage access used bare '*' instead of a required '*/' prefix. Applying hotfix to use rubric-memory/* as the single valid bucket prefix.",
       "created_at": "2026-04-28T16:21:07.854921Z"
+    },
+    {
+      "id": "34ed64e3-cac3-4576-b6e9-f0f40a04d12c",
+      "author": "ryan",
+      "text": "Verified original failed main deployment job 1034 and latest release job 1036 both failed with the same CDK assembly error: InvalidStorageAccessPathError for storage access path '*'. Opened hotfix PR #235 to change rubricMemory access to rubric-memory/*; Amplify deploy can only validate after that PR is approved/merged to main.",
+      "created_at": "2026-04-28T16:23:32.964445Z"
     }
   ],
   "created_at": "2026-04-28T16:18:48.359438Z",
-  "updated_at": "2026-04-28T16:21:07.854921Z",
+  "updated_at": "2026-04-28T16:23:32.964445Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
## Summary
- Fix Amplify Gen2 backend assembly failure on main by replacing the invalid rubricMemory storage access path `*` with `rubric-memory/*`
- Records the failed Amplify job investigation in Kanbus

## Root cause
Amplify job 1036 failed during backend build/CDK assembly:
`InvalidStorageAccessPathError: Storage access paths must end with "/*". Found [*].`

The invalid path was introduced in the rubric memory storage bucket definition.

## Validation
- Inspected Amplify main job 1036 logs for app `d1cegb1ft4iove` in account `695039645615`, region `us-west-2`
- Local `ampx pipeline-deploy` intentionally did not run outside CI; this PR should be validated by Amplify CI/CD on `main` after merge