### PR TITLE
fix(metrics): switch metrics aggregator AppSync auth to IAM SigV4

### DIFF
--- a/infrastructure/.env.example
+++ b/infrastructure/.env.example
@@ -17,7 +17,6 @@
 #   AMPLIFY_STACK_PATTERN=amplify-YOURAPPID-main-branch
 AMPLIFY_STACK_PATTERN=
 
-# REQUIRED: GraphQL API credentials (from dashboard/amplify_outputs.json)
-# These are used by the Lambda function to update AggregatedMetrics
+# REQUIRED: GraphQL API endpoint (from dashboard/amplify_outputs.json)
+# Lambda authenticates to AppSync via IAM role credentials (SigV4)
 PLEXUS_API_URL=
-PLEXUS_API_KEY=

--- a/infrastructure/lambda_functions/metrics_aggregator/README.md
+++ b/infrastructure/lambda_functions/metrics_aggregator/README.md
@@ -69,12 +69,11 @@ This matches the existing client-side system's behavior.
 
 Required in Lambda environment:
 - `PLEXUS_API_URL` or `GRAPHQL_ENDPOINT`: AppSync GraphQL endpoint
-- `PLEXUS_API_KEY` or `GRAPHQL_API_KEY`: API key for authentication
+- AWS IAM credentials from the Lambda execution role (for SigV4 AppSync auth)
 
 For local testing, create `.env` file in `infrastructure/` directory:
 ```bash
 PLEXUS_API_URL=https://your-appsync-endpoint.com/graphql
-PLEXUS_API_KEY=da2-xxxxxxxxxxxxx
 AMPLIFY_STACK_PATTERN=amplify-xxxxx-main-branch
 ```
 

--- a/infrastructure/lambda_functions/metrics_aggregator/graphql_client.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/graphql_client.py
@@ -4,28 +4,36 @@ GraphQL client for updating AggregatedMetrics table.
 
 import json
 import os
-import requests
-from typing import Dict, Any, Optional
 from datetime import datetime
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+import boto3
+import requests
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
 
 
 class GraphQLClient:
     """Client for interacting with the Plexus GraphQL API."""
     
-    def __init__(self, endpoint: str, api_key: str):
+    def __init__(self, endpoint: str):
         """
         Initialize GraphQL client.
         
         Args:
             endpoint: GraphQL API endpoint URL
-            api_key: API key for authentication
         """
         self.endpoint = endpoint
-        self.api_key = api_key
-        self.headers = {
-            'Content-Type': 'application/json',
-            'x-api-key': api_key
-        }
+        parsed_endpoint = urlparse(endpoint)
+        hostname = parsed_endpoint.netloc
+        parts = hostname.split(".")
+        if len(parts) < 5 or parts[1] != "appsync-api":
+            raise ValueError(f"Invalid AppSync endpoint format: {endpoint}")
+
+        self.host = hostname
+        self.region = parts[2]
+        self.session = boto3.Session()
     
     def execute_query(self, query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -45,11 +53,31 @@ class GraphQLClient:
             'query': query,
             'variables': variables
         }
+        payload_json = json.dumps(payload)
+
+        credentials = self.session.get_credentials()
+        if credentials is None:
+            raise ValueError(
+                "AWS credentials not found. Metrics aggregator requires IAM credentials for SigV4 GraphQL auth."
+            )
+
+        frozen_credentials = credentials.get_frozen_credentials()
+        aws_request = AWSRequest(
+            method='POST',
+            url=self.endpoint,
+            data=payload_json,
+            headers={
+                'Content-Type': 'application/json',
+                'Host': self.host
+            }
+        )
+        SigV4Auth(frozen_credentials, 'appsync', self.region).add_auth(aws_request)
+        signed_headers = dict(aws_request.headers.items())
         
         response = requests.post(
             self.endpoint,
-            headers=self.headers,
-            json=payload,
+            headers=signed_headers,
+            data=payload_json,
             timeout=30
         )
         
@@ -286,8 +314,8 @@ def get_client_from_env() -> GraphQLClient:
     """
     Create a GraphQL client from environment variables.
     
-    Looks for PLEXUS_API_URL and PLEXUS_API_KEY (developer .env format)
-    or GRAPHQL_ENDPOINT and GRAPHQL_API_KEY (Lambda environment format).
+    Looks for PLEXUS_API_URL (developer .env format)
+    or GRAPHQL_ENDPOINT (Lambda environment format).
     
     Returns:
         Configured GraphQL client
@@ -297,16 +325,10 @@ def get_client_from_env() -> GraphQLClient:
     """
     # Try developer .env format first
     endpoint = os.environ.get('PLEXUS_API_URL') or os.environ.get('GRAPHQL_ENDPOINT')
-    api_key = os.environ.get('PLEXUS_API_KEY') or os.environ.get('GRAPHQL_API_KEY')
     
     if not endpoint:
         raise ValueError(
             "GraphQL endpoint not found. Set PLEXUS_API_URL or GRAPHQL_ENDPOINT environment variable."
         )
-    if not api_key:
-        raise ValueError(
-            "GraphQL API key not found. Set PLEXUS_API_KEY or GRAPHQL_API_KEY environment variable."
-        )
     
-    return GraphQLClient(endpoint, api_key)
-
+    return GraphQLClient(endpoint)

--- a/infrastructure/stacks/metrics_aggregation_stack.py
+++ b/infrastructure/stacks/metrics_aggregation_stack.py
@@ -178,7 +178,6 @@ class MetricsAggregationStack(Stack):
             memory_size=512,
             environment={
                 'GRAPHQL_ENDPOINT': config.get_value("api-url"),
-                'GRAPHQL_API_KEY': config.get_value("api-key"),
                 'ENVIRONMENT': environment
             },
             description=f"Processes DynamoDB streams to update AggregatedMetrics ({environment})"

--- a/project/events/2026-04-28T17:43:20.254Z__e7a64374-3757-4f18-8cb4-2b7b92859bde.json
+++ b/project/events/2026-04-28T17:43:20.254Z__e7a64374-3757-4f18-8cb4-2b7b92859bde.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "e7a64374-3757-4f18-8cb4-2b7b92859bde",
+  "issue_id": "plx-2b205fdf-e22e-4077-82b6-fe38ef5de848",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-28T17:43:20.254Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "initiative",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Production deployment reliability"
+  }
+}

--- a/project/events/2026-04-28T17:43:22.066Z__6e7e41a9-05ea-4d0b-9050-f53e697553ab.json
+++ b/project/events/2026-04-28T17:43:22.066Z__6e7e41a9-05ea-4d0b-9050-f53e697553ab.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "6e7e41a9-05ea-4d0b-9050-f53e697553ab",
+  "issue_id": "plx-f87c86e2-f5a5-417c-a520-ae2957f6b459",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-28T17:43:22.066Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": "plx-2b205fdf-e22e-4077-82b6-fe38ef5de848",
+    "priority": 1,
+    "status": "open",
+    "title": "Stabilize production infrastructure pipeline deployments"
+  }
+}

--- a/project/events/2026-04-28T17:43:26.200Z__e796f81e-b7c7-4c08-8e8a-ed207b1d4d47.json
+++ b/project/events/2026-04-28T17:43:26.200Z__e796f81e-b7c7-4c08-8e8a-ed207b1d4d47.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "e796f81e-b7c7-4c08-8e8a-ed207b1d4d47",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-28T17:43:26.200Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "## Summary\nInvestigate why  fails while deploying .\n\n## Scope\n- Retrieve failing pipeline execution details\n- Identify exact failed action and CloudFormation stack event/reason\n- Provide root cause and recommended remediation\n\n## Done\n- Root cause identified with concrete AWS evidence\n- Next remediation steps documented",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-f87c86e2-f5a5-417c-a520-ae2957f6b459",
+    "priority": 1,
+    "status": "open",
+    "title": "Investigate CodePipeline failure for plexus-metrics-aggregation-production stack"
+  }
+}

--- a/project/events/2026-04-28T17:43:31.711Z__01bb1c1e-36a5-4de8-bfc0-08e911cc100c.json
+++ b/project/events/2026-04-28T17:43:31.711Z__01bb1c1e-36a5-4de8-bfc0-08e911cc100c.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "01bb1c1e-36a5-4de8-bfc0-08e911cc100c",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-28T17:43:31.711Z",
+  "actor_id": "derek",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "## Summary\nInvestigate why  fails while deploying .\n\n## Scope\n- Retrieve failing pipeline execution details\n- Identify exact failed action and CloudFormation stack event/reason\n- Provide root cause and recommended remediation\n\n## Done\n- Root cause identified with concrete AWS evidence\n- Next remediation steps documented",
+        "to": "## Summary\nInvestigate why `plexus-infrastructure-production-pipeline` fails while deploying `plexus-metrics-aggregation-production`.\n\n## Scope\n- Retrieve failing pipeline execution details\n- Identify exact failed action and CloudFormation stack event/reason\n- Provide root cause and recommended remediation\n\n## Done\n- Root cause identified with concrete AWS evidence\n- Next remediation steps documented"
+      }
+    }
+  }
+}

--- a/project/events/2026-04-28T17:43:31.724Z__f735138d-b388-4be6-ae19-6664522288d3.json
+++ b/project/events/2026-04-28T17:43:31.724Z__f735138d-b388-4be6-ae19-6664522288d3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f735138d-b388-4be6-ae19-6664522288d3",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-28T17:43:31.724Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-28T17:43:31.736Z__c8cb2ce1-6e0a-43ac-a72d-ee28081185eb.json
+++ b/project/events/2026-04-28T17:43:31.736Z__c8cb2ce1-6e0a-43ac-a72d-ee28081185eb.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c8cb2ce1-6e0a-43ac-a72d-ee28081185eb",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T17:43:31.736Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "7ad9a08c-9997-4c6d-bab1-6af5507e7b01"
+  }
+}

--- a/project/events/2026-04-28T17:45:19.128Z__941cd13c-d00d-4116-b60c-3d7d8014997e.json
+++ b/project/events/2026-04-28T17:45:19.128Z__941cd13c-d00d-4116-b60c-3d7d8014997e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "941cd13c-d00d-4116-b60c-3d7d8014997e",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T17:45:19.128Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "d53b2f7d-bad2-41c2-b7af-ec972ac6511f"
+  }
+}

--- a/project/events/2026-04-28T17:45:54.937Z__b1834229-2ef7-4de0-9541-b1254ca7f2ec.json
+++ b/project/events/2026-04-28T17:45:54.937Z__b1834229-2ef7-4de0-9541-b1254ca7f2ec.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b1834229-2ef7-4de0-9541-b1254ca7f2ec",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T17:45:54.937Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "ef643b29-59f4-4060-bea2-1d04103d6c89"
+  }
+}

--- a/project/events/2026-04-28T17:49:31.801Z__c4a96e0c-5e1d-48eb-8ecb-fe84b256b254.json
+++ b/project/events/2026-04-28T17:49:31.801Z__c4a96e0c-5e1d-48eb-8ecb-fe84b256b254.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c4a96e0c-5e1d-48eb-8ecb-fe84b256b254",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T17:49:31.801Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "5044a9fb-9ffb-41b1-b3a1-98c4727d0ecf"
+  }
+}

--- a/project/events/2026-04-28T17:56:05.920Z__1e206af9-e3ba-4699-a8c4-e39245093587.json
+++ b/project/events/2026-04-28T17:56:05.920Z__1e206af9-e3ba-4699-a8c4-e39245093587.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1e206af9-e3ba-4699-a8c4-e39245093587",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T17:56:05.920Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "3cbd8ea0-3eac-495a-a383-d939d929780b"
+  }
+}

--- a/project/events/2026-04-28T18:01:28.207Z__f4c1715c-cc60-4633-98ca-12ac523ec056.json
+++ b/project/events/2026-04-28T18:01:28.207Z__f4c1715c-cc60-4633-98ca-12ac523ec056.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f4c1715c-cc60-4633-98ca-12ac523ec056",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T18:01:28.207Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "6ef169d3-433d-4f82-b90c-648e697b14fa"
+  }
+}

--- a/project/events/2026-04-28T18:02:44.772Z__cc77ae26-2313-4553-b7f6-6eab7696843a.json
+++ b/project/events/2026-04-28T18:02:44.772Z__cc77ae26-2313-4553-b7f6-6eab7696843a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cc77ae26-2313-4553-b7f6-6eab7696843a",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T18:02:44.772Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "a93c9148-ee31-4407-a908-1669970b4203"
+  }
+}

--- a/project/events/2026-04-28T18:05:55.909Z__7783e991-8489-4630-9863-005bcbb7d39a.json
+++ b/project/events/2026-04-28T18:05:55.909Z__7783e991-8489-4630-9863-005bcbb7d39a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7783e991-8489-4630-9863-005bcbb7d39a",
+  "issue_id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T18:05:55.909Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "252c3933-c145-4fe0-b0ff-a4cb631c0102"
+  }
+}

--- a/project/issues/plx-0c8df847-996b-4097-8256-5ff1c3ef99da.json
+++ b/project/issues/plx-0c8df847-996b-4097-8256-5ff1c3ef99da.json
@@ -1,0 +1,67 @@
+{
+  "id": "plx-0c8df847-996b-4097-8256-5ff1c3ef99da",
+  "title": "Investigate CodePipeline failure for plexus-metrics-aggregation-production stack",
+  "description": "## Summary\nInvestigate why `plexus-infrastructure-production-pipeline` fails while deploying `plexus-metrics-aggregation-production`.\n\n## Scope\n- Retrieve failing pipeline execution details\n- Identify exact failed action and CloudFormation stack event/reason\n- Provide root cause and recommended remediation\n\n## Done\n- Root cause identified with concrete AWS evidence\n- Next remediation steps documented",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-f87c86e2-f5a5-417c-a520-ae2957f6b459",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "7ad9a08c-9997-4c6d-bab1-6af5507e7b01",
+      "author": "derek",
+      "text": "Started investigation via AWS CLI.\n\nPlan:\n1. Identify latest failed pipeline execution and failed action.\n2. Pull CloudFormation stack events for `plexus-metrics-aggregation-production`.\n3. Correlate failure timestamp/action to root cause and recommend fix.",
+      "created_at": "2026-04-28T17:43:31.736399911Z"
+    },
+    {
+      "id": "d53b2f7d-bad2-41c2-b7af-ec972ac6511f",
+      "author": "derek",
+      "text": "AWS evidence captured (us-west-2):\n\n- Pipeline `plexus-infrastructure-production-pipeline` latest execution `9372b098-a23a-4b66-948f-f70d0475cd06` failed in action `plexus-metrics-aggregation-production.Deploy`.\n- CloudFormation stack `plexus-metrics-aggregation-production` entered `UPDATE_ROLLBACK_COMPLETE`.\n- Failing event on resource `MetricsAggregatorRoleDefaultPolicy2B6831DE`:\n  `UPDATE_FAILED: Could not find a value associated with JSONKey in SecretString`.\n- Inspected failed change set `PipelineChange/d93b7d14-76de-4263-bb1a-1cedc6e3d881` template:\n  IAM policy Resource list includes dynamic ref to\n  `...:SecretString:table-procedure-stream-arn::`.\n- Verified production secret `plexus/production/config` does NOT contain key `table-procedure-stream-arn` (`has(...) == false`).\n\nConclusion: deployment fails because new metrics aggregation policy references `table-procedure-stream-arn` before that key exists in production secret.",
+      "created_at": "2026-04-28T17:45:19.128205093Z"
+    },
+    {
+      "id": "ef643b29-59f4-4060-bea2-1d04103d6c89",
+      "author": "derek",
+      "text": "Remediation recommendation:\n1) Add `table-procedure-stream-arn` (and optionally `table-procedure-name`/`table-procedure-arn`) to secret `plexus/production/config`.\n2) Re-run `plexus-infrastructure-production-pipeline`.\n\nLikely correct value for this production env prefix (`qh4jgzgazfd2ncwbekhi4woj7a`):\n`arn:aws:dynamodb:us-west-2:695039645615:table/Procedure-qh4jgzgazfd2ncwbekhi4woj7a-NONE/stream/2025-09-01T00:54:54.193`\n\nEvidence source: CloudFormation export `qh4jgzgazfd2ncwbekhi4woj7a:GetAtt:ProcedureTable:StreamArn`.",
+      "created_at": "2026-04-28T17:45:54.937259078Z"
+    },
+    {
+      "id": "5044a9fb-9ffb-41b1-b3a1-98c4727d0ecf",
+      "author": "derek",
+      "text": "Applied remediation to production secret:\n- Updated `plexus/production/config` to include `table-procedure-stream-arn`\n- Resolved value from CloudFormation export `qh4jgzgazfd2ncwbekhi4woj7a:GetAtt:ProcedureTable:StreamArn`\n- Corrected value to exact ARN (no trailing newline/None artifacts)\n\nNext: trigger `plexus-infrastructure-production-pipeline` and monitor result.",
+      "created_at": "2026-04-28T17:49:31.801301786Z"
+    },
+    {
+      "id": "3cbd8ea0-3eac-495a-a383-d939d929780b",
+      "author": "derek",
+      "text": "Checked current AppSync auth modes for production endpoint used by metrics aggregation (`https://7ubj23ym5vekxagab2damu2euy.appsync-api.us-west-2.amazonaws.com/graphql`, API ID `qh4jgzgazfd2ncwbekhi4woj7a`).\n\nCurrent auth config:\n- Primary: `AMAZON_COGNITO_USER_POOLS`\n- Additional: `API_KEY`, `AWS_IAM`\n\nAlso verified currently deployed Lambda env on `plexus-lambda-production-metrics-aggregator`:\n- `GRAPHQL_API_KEY=da2-6eczifxvjbclbecxu5ofpjx4g4`\n- This key is present on API and expires at epoch `1807635600` (2027-04-13 17:00:00 UTC).\n}",
+      "created_at": "2026-04-28T17:56:05.920240192Z"
+    },
+    {
+      "id": "6ef169d3-433d-4f82-b90c-648e697b14fa",
+      "author": "derek",
+      "text": "Starting implementation work to switch metrics aggregation Lambda from AppSync API key auth to IAM SigV4 auth.\n\nPlan:\n1) Create feature branch from develop.\n2) Update GraphQL client auth flow to IAM signing.\n3) Remove API-key env dependency in stack/config/docs.\n4) Run targeted validation checks.",
+      "created_at": "2026-04-28T18:01:28.207247169Z"
+    },
+    {
+      "id": "a93c9148-ee31-4407-a908-1669970b4203",
+      "author": "derek",
+      "text": "Implemented IAM auth migration for metrics aggregation Lambda on branch `feature/plx-0c8df8-metrics-iam-appsync`.\n\nChanges made:\n- `infrastructure/lambda_functions/metrics_aggregator/graphql_client.py`\n  - Removed API key auth path.\n  - Added SigV4 signing using Lambda IAM credentials (`botocore` SigV4Auth with service `appsync`).\n  - `get_client_from_env()` now requires endpoint only (`PLEXUS_API_URL` or `GRAPHQL_ENDPOINT`).\n- `infrastructure/stacks/metrics_aggregation_stack.py`\n  - Removed `GRAPHQL_API_KEY` from Lambda environment variables.\n- `infrastructure/lambda_functions/metrics_aggregator/README.md`\n  - Updated env requirements to IAM role-based auth; removed API key requirement.\n- `infrastructure/.env.example`\n  - Removed `PLEXUS_API_KEY`; clarified IAM role auth.\n\nValidation:\n- `python -m py_compile infrastructure/lambda_functions/metrics_aggregator/graphql_client.py infrastructure/stacks/metrics_aggregation_stack.py` ✅\n- `pytest` unavailable in this shell (`ModuleNotFoundError: No module named pytest`).}",
+      "created_at": "2026-04-28T18:02:44.772208564Z"
+    },
+    {
+      "id": "252c3933-c145-4fe0-b0ff-a4cb631c0102",
+      "author": "derek",
+      "text": "Validation rerun in project virtualenv:\n- Python: /home/derek/.venvs/cc-local/call-criteria-python-o9nOlyIe-py3.12/bin/python (3.12.4)\n- Command: `python -m pytest -q infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py`\n- Result: 3 passed (0.38s).}",
+      "created_at": "2026-04-28T18:05:55.909623177Z"
+    }
+  ],
+  "created_at": "2026-04-28T17:43:26.200654915Z",
+  "updated_at": "2026-04-28T18:05:55.909623177Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-2b205fdf-e22e-4077-82b6-fe38ef5de848.json
+++ b/project/issues/plx-2b205fdf-e22e-4077-82b6-fe38ef5de848.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-2b205fdf-e22e-4077-82b6-fe38ef5de848",
+  "title": "Production deployment reliability",
+  "description": "",
+  "type": "initiative",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-28T17:43:20.254185795Z",
+  "updated_at": "2026-04-28T17:43:20.254185795Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-f87c86e2-f5a5-417c-a520-ae2957f6b459.json
+++ b/project/issues/plx-f87c86e2-f5a5-417c-a520-ae2957f6b459.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-f87c86e2-f5a5-417c-a520-ae2957f6b459",
+  "title": "Stabilize production infrastructure pipeline deployments",
+  "description": "",
+  "type": "epic",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2b205fdf-e22e-4077-82b6-fe38ef5de848",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-28T17:43:22.066018532Z",
+  "updated_at": "2026-04-28T17:43:22.066018532Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
Switch metrics aggregation Lambda GraphQL calls from AppSync API key auth to IAM SigV4 auth using the Lambda execution role.

## Changes
- Replace `x-api-key` GraphQL auth in `metrics_aggregator/graphql_client.py` with SigV4-signed requests (`appsync` service).
- Remove API-key env requirement from metrics client env loader.
- Remove `GRAPHQL_API_KEY` injection from `MetricsAggregationStack` Lambda environment.
- Update metrics aggregator docs and infrastructure `.env.example` to reflect IAM-based auth.
- Include Kanbus issue/event artifacts for plx-0c8df8 tracking.

## Validation
- `/home/derek/.venvs/cc-local/call-criteria-python-o9nOlyIe-py3.12/bin/python -m pytest -q infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py`
- `python -m py_compile infrastructure/lambda_functions/metrics_aggregator/graphql_client.py infrastructure/stacks/metrics_aggregation_stack.py`

## Context
This removes API-key expiration/rotation risk for the backend metrics path while using existing `AWS_IAM` AppSync auth mode.