### PR TITLE
Add S3 rubric memory runtime and RCA resilience

### DIFF
--- a/plexus/Evaluation.py
+++ b/plexus/Evaluation.py
@@ -374,8 +374,26 @@ class Evaluation:
         score_name = None
         if self.subset_of_score_names and len(self.subset_of_score_names) == 1:
             score_name = self.subset_of_score_names[0]
+        if not score_name:
+            try:
+                score_names = self.score_names_to_process()
+                if len(score_names) == 1:
+                    score_name = score_names[0]
+            except Exception as exc:
+                self.logger.warning("Could not resolve score name for rubric-memory RCA context: %s", exc)
         if not score_name or not getattr(self, "score_id", None):
-            return {}
+            return {
+                "markdown_context": "",
+                "citation_index": [],
+                "diagnostics": [
+                    {
+                        "code": "rubric_memory_unavailable",
+                        "message": "Could not resolve single score name or score ID for RCA rubric-memory context.",
+                        "failed_stage": "rubric_memory_resolution",
+                        "exception_type": "",
+                    }
+                ],
+            }
         try:
             from plexus.rubric_memory import RubricMemoryContextProvider
 
@@ -389,15 +407,26 @@ class Evaluation:
                 )
                 self._rubric_memory_available_for_rca = status["available"]
                 if not status["available"]:
-                    self.logging.warning(
+                    self.logger.warning(
                         "Rubric memory not available for RCA; missing canonical folders: %s",
                         ", ".join(
                             root["path"] for root in status["roots"] if not root["exists"]
                         ),
                     )
             if not getattr(self, "_rubric_memory_available_for_rca", False):
-                return {}
-            context = await provider.generate_for_score_item(
+                return {
+                    "markdown_context": "",
+                    "citation_index": [],
+                    "diagnostics": [
+                        {
+                            "code": "rubric_memory_unavailable",
+                            "message": "Canonical rubric-memory corpus is unavailable for this score.",
+                            "failed_stage": "rubric_memory_resolution",
+                            "exception_type": "",
+                        }
+                    ],
+                }
+            context = await provider.retrieve_for_score_item(
                 scorecard_identifier=self.scorecard_name,
                 score_identifier=score_name,
                 score_id=self.score_id,
@@ -410,8 +439,19 @@ class Evaluation:
             )
             return context.model_dump(mode="json")
         except Exception as exc:
-            self.logging.warning("Could not build rubric-memory RCA context: %s", exc)
-            return {}
+            self.logger.warning("Could not build rubric-memory RCA context: %s", exc)
+            return {
+                "markdown_context": "",
+                "citation_index": [],
+                "diagnostics": [
+                    {
+                        "code": "rubric_memory_unavailable",
+                        "message": str(exc),
+                        "failed_stage": "rubric_memory_retrieval",
+                        "exception_type": exc.__class__.__name__,
+                    }
+                ],
+            }
 
     def time_execution(func):
         async def async_wrapper(self, *args, **kwargs):
@@ -3350,6 +3390,10 @@ class FeedbackEvaluation(Evaluation):
                 if k != "item_classifications_all"
             }
 
+        raw_item_failures = root_cause_payload.get("rca_item_failures")
+        if isinstance(raw_item_failures, list):
+            compact_payload["rca_item_failures_total"] = len(raw_item_failures)
+
         return compact_payload
 
     def _persist_root_cause_for_parameters(self, root_cause_payload: dict) -> dict:
@@ -3889,9 +3933,12 @@ class FeedbackEvaluation(Evaluation):
                 build_misclassification_classification_contract,
                 build_misclassification_analysis_summary,
                 build_misclassification_item_context,
+                build_rca_analysis_failure_classification,
+                build_rca_analysis_failure_details,
                 classify_misclassification_item,
                 extract_misclassification_evidence_flags,
                 explain_misclassification_item_classification,
+                rubric_memory_state_from_item_context,
                 resolve_final_output_classes_from_yaml_text,
             )
 
@@ -4006,6 +4053,7 @@ class FeedbackEvaluation(Evaluation):
             texts = []
             canonical_item_classifications = []
             canonical_item_by_feedback_id = {}
+            rca_item_failures = []
             item_context_cache = {}
             if dashboard_client:
                 from plexus.dashboard.api.models.item import Item as DashboardItem
@@ -4068,6 +4116,7 @@ class FeedbackEvaluation(Evaluation):
             async def _process_single_candidate(fi):
                 """Process one candidate item: build context, extract evidence, classify, explain."""
                 async with rca_sem:
+                    item_failure_diagnostics = []
                     ts = fi.editedAt or getattr(fi, 'updatedAt', None) or getattr(fi, 'createdAt', None)
                     ts_str = (
                         (ts if ts.tzinfo else ts.replace(tzinfo=_tz.utc)).isoformat()
@@ -4138,14 +4187,42 @@ class FeedbackEvaluation(Evaluation):
                                 fi.itemId, _proc_exc,
                             )
 
-                    rubric_memory_context = await self._rubric_memory_context_for_misclassification(
-                        primary_input_text=primary_input_text,
-                        predicted_value=metadata.get("initial_answer_value", "") or "",
-                        score_explanation=metadata.get("score_explanation", "") or "",
-                        correct_value=metadata.get("final_answer_value", "") or "",
-                        feedback_comment=metadata.get("edit_comment", ""),
-                        topic_hint="Evaluation RCA misclassification evidence",
-                    )
+                    rubric_memory_context = {}
+                    try:
+                        rubric_memory_context = await self._rubric_memory_context_for_misclassification(
+                            primary_input_text=primary_input_text,
+                            predicted_value=metadata.get("initial_answer_value", "") or "",
+                            score_explanation=metadata.get("score_explanation", "") or "",
+                            correct_value=metadata.get("final_answer_value", "") or "",
+                            feedback_comment=metadata.get("edit_comment", ""),
+                            topic_hint="Evaluation RCA misclassification evidence",
+                        )
+                    except Exception as exc:
+                        failure = build_rca_analysis_failure_details("rubric_memory_retrieval", exc)
+                        failure.update({
+                            "feedback_item_id": fi.id,
+                            "item_id": fi.itemId or "",
+                        })
+                        item_failure_diagnostics.append(failure)
+                        self.logger.warning(
+                            "RCA rubric-memory retrieval failed for feedback_item_id=%s item_id=%s: %s: %s",
+                            fi.id,
+                            fi.itemId or "",
+                            failure["exception_type"],
+                            failure["message"],
+                        )
+                        rubric_memory_context = {
+                            "markdown_context": "",
+                            "citation_index": [],
+                            "diagnostics": [
+                                {
+                                    "code": "rubric_memory_unavailable",
+                                    "message": failure["message"],
+                                    "failed_stage": failure["failed_stage"],
+                                    "exception_type": failure["exception_type"],
+                                }
+                            ],
+                        }
                     misclassification_item_context = build_misclassification_item_context(
                         feedback_item_id=fi.id,
                         item_id=fi.itemId or "",
@@ -4172,36 +4249,109 @@ class FeedbackEvaluation(Evaluation):
                         processors_config_summary=processors_config_summary,
                         rubric_memory_context=rubric_memory_context,
                     )
-                    misclassification_evidence_flags = await asyncio.to_thread(
-                        extract_misclassification_evidence_flags,
-                        item_context=misclassification_item_context,
-                    )
-                    misclassification_classification = classify_misclassification_item(
-                        misclassification_item_context,
-                        misclassification_evidence_flags,
-                    )
-                    triage_explainer = await asyncio.to_thread(
-                        explain_misclassification_item_classification,
-                        item_context=misclassification_item_context,
-                        classification=misclassification_classification,
-                    )
-                    misclassification_classification["rationale_paragraph"] = triage_explainer.get(
-                        "rationale_paragraph", ""
-                    )
-                    misclassification_classification["evidence_quote"] = triage_explainer.get(
-                        "evidence_quote", ""
-                    )
-                    misclassification_classification["config_fixability"] = triage_explainer.get(
-                        "config_fixability", ""
-                    )
-                    misclassification_classification["citation_ids"] = triage_explainer.get(
-                        "citation_ids",
-                        misclassification_classification.get("citation_ids", []),
-                    )
-                    misclassification_classification["citation_validation"] = triage_explainer.get(
-                        "citation_validation",
-                        {},
-                    )
+                    rca_failure = None
+                    try:
+                        misclassification_evidence_flags = await asyncio.to_thread(
+                            extract_misclassification_evidence_flags,
+                            item_context=misclassification_item_context,
+                        )
+                    except Exception as exc:
+                        rca_failure = build_rca_analysis_failure_details("evidence_flag_extraction", exc)
+                        misclassification_evidence_flags = {}
+                        misclassification_classification = build_rca_analysis_failure_classification(
+                            item_context=misclassification_item_context,
+                            stage="evidence_flag_extraction",
+                            exc=exc,
+                        )
+                    else:
+                        try:
+                            misclassification_classification = classify_misclassification_item(
+                                misclassification_item_context,
+                                misclassification_evidence_flags,
+                            )
+                        except Exception as exc:
+                            rca_failure = build_rca_analysis_failure_details("deterministic_classification", exc)
+                            misclassification_classification = build_rca_analysis_failure_classification(
+                                item_context=misclassification_item_context,
+                                stage="deterministic_classification",
+                                exc=exc,
+                                evidence_flags=misclassification_evidence_flags,
+                            )
+
+                    if rca_failure is None:
+                        try:
+                            triage_explainer = await asyncio.to_thread(
+                                explain_misclassification_item_classification,
+                                item_context=misclassification_item_context,
+                                classification=misclassification_classification,
+                            )
+                        except Exception as exc:
+                            rca_failure = build_rca_analysis_failure_details("explainer", exc)
+                            triage_explainer = {
+                                "rationale_paragraph": (
+                                    misclassification_classification.get("rationale")
+                                    or "RCA explainer failed; deterministic classification was preserved."
+                                ),
+                                "evidence_quote": (
+                                    f"explainer: {rca_failure['exception_type']}: {rca_failure['message']}"
+                                ),
+                                "config_fixability": (
+                                    "blocked_by_mechanical"
+                                    if misclassification_classification.get("primary_category") == "mechanical_malfunction"
+                                    else "likely_fixable"
+                                ),
+                                "citation_ids": misclassification_classification.get("citation_ids", []),
+                                "citation_validation": misclassification_classification.get(
+                                    "citation_validation", {}
+                                ),
+                            }
+                        misclassification_classification["rationale_paragraph"] = triage_explainer.get(
+                            "rationale_paragraph", ""
+                        )
+                        misclassification_classification["evidence_quote"] = triage_explainer.get(
+                            "evidence_quote", ""
+                        )
+                        misclassification_classification["config_fixability"] = triage_explainer.get(
+                            "config_fixability", ""
+                        )
+                        misclassification_classification["citation_ids"] = triage_explainer.get(
+                            "citation_ids",
+                            misclassification_classification.get("citation_ids", []),
+                        )
+                        misclassification_classification["citation_validation"] = triage_explainer.get(
+                            "citation_validation",
+                            {},
+                        )
+                    else:
+                        triage_explainer = {
+                            "rationale_paragraph": misclassification_classification.get(
+                                "rationale_paragraph", ""
+                            ),
+                            "evidence_quote": misclassification_classification.get(
+                                "evidence_quote", ""
+                            ),
+                            "config_fixability": misclassification_classification.get(
+                                "config_fixability", "blocked_by_mechanical"
+                            ),
+                            "citation_ids": misclassification_classification.get("citation_ids", []),
+                            "citation_validation": misclassification_classification.get(
+                                "citation_validation", {}
+                            ),
+                        }
+                    if rca_failure:
+                        rca_failure.update({
+                            "feedback_item_id": fi.id,
+                            "item_id": fi.itemId or "",
+                        })
+                        item_failure_diagnostics.append(rca_failure)
+                        self.logger.warning(
+                            "RCA item failed at %s for feedback_item_id=%s item_id=%s: %s: %s",
+                            rca_failure["failed_stage"],
+                            fi.id,
+                            fi.itemId or "",
+                            rca_failure["exception_type"],
+                            rca_failure["message"],
+                        )
                     primary_category = (
                         misclassification_classification.get("primary_category")
                         or "score_configuration_problem"
@@ -4242,6 +4392,9 @@ class FeedbackEvaluation(Evaluation):
                         "config_fixability": triage_explainer.get("config_fixability", ""),
                         "citation_ids": triage_explainer.get("citation_ids", []),
                         "citation_validation": triage_explainer.get("citation_validation", {}),
+                        **rubric_memory_state_from_item_context(misclassification_item_context),
+                        "rca_failure": rca_failure,
+                        "rca_failures": item_failure_diagnostics,
                         "evidence_snippets": misclassification_classification.get("evidence_snippets", []),
                         "mechanical_subtype": (
                             mechanical_subtype if mechanical_subtype != "none" else None
@@ -4269,7 +4422,7 @@ class FeedbackEvaluation(Evaluation):
                         metadata=metadata,
                     )
 
-                    return timestamped, canonical_row
+                    return timestamped, canonical_row, item_failure_diagnostics
 
             _rca_completed = [0]  # mutable counter for closure
             _rca_total = len(candidate_items)
@@ -4288,12 +4441,17 @@ class FeedbackEvaluation(Evaluation):
             for result in rca_results:
                 if isinstance(result, Exception):
                     rca_errors += 1
-                    self.logger.debug("RCA item failed: %s: %s", type(result).__name__, result)
+                    self.logger.warning(
+                        "RCA item failed before fallback preservation: %s: %s",
+                        type(result).__name__,
+                        result,
+                    )
                     continue
-                timestamped, canonical_row = result
+                timestamped, canonical_row, item_failure_diagnostics = result
                 texts.append(timestamped)
                 canonical_item_classifications.append(canonical_row)
                 canonical_item_by_feedback_id[canonical_row["feedback_item_id"]] = canonical_row
+                rca_item_failures.extend(item_failure_diagnostics or [])
             if rca_errors:
                 self.logger.warning(f"RCA: {rca_errors}/{len(candidate_items)} items failed (continuing with {len(texts)} successful)")
 
@@ -4712,6 +4870,7 @@ class FeedbackEvaluation(Evaluation):
                     "classified_items_total": len(item_classifications_all),
                     "texts_analyzed_total": len(texts),
                     "topics_found": len(topics),
+                    "rca_item_failures_total": len(rca_item_failures),
                     "topic_assignment_scope": "exemplar_only",
                     "topic_assignment_unavailable_count": topic_assignment_unavailable_count,
                 },
@@ -4724,6 +4883,7 @@ class FeedbackEvaluation(Evaluation):
                 "overall_improvement_suggestion": overall_improvement_suggestion,
                 "misclassification_classification_contract": build_misclassification_classification_contract(),
                 "misclassification_analysis": misclassification_analysis,
+                "rca_item_failures": rca_item_failures,
             }
 
         except Exception as e:
@@ -4749,9 +4909,12 @@ class FeedbackEvaluation(Evaluation):
             build_misclassification_classification_contract,
             build_misclassification_analysis_summary,
             build_misclassification_item_context,
+            build_rca_analysis_failure_classification,
+            build_rca_analysis_failure_details,
             classify_misclassification_item,
             extract_misclassification_evidence_flags,
             explain_misclassification_item_classification,
+            rubric_memory_state_from_item_context,
             resolve_final_output_classes_from_yaml_text,
         )
 
@@ -4929,7 +5092,9 @@ class FeedbackEvaluation(Evaluation):
                 ex["detailed_cause"] = detailed_cause
             if suggested_fix:
                 ex["suggested_fix"] = suggested_fix
+        rca_item_failures = []
         for ex in exemplars:
+            item_failure_diagnostics = []
             item_context_record = item_context_cache.get(ex.get("item_id"))
             primary_input_text = (
                 item_context_record.get("primary_input") if item_context_record else ""
@@ -4955,14 +5120,42 @@ class FeedbackEvaluation(Evaluation):
                         "Failed to apply processors for small-set RCA context (item %s): %s",
                         ex.get("item_id"), _proc_exc,
                     )
-            rubric_memory_context = await self._rubric_memory_context_for_misclassification(
-                primary_input_text=primary_input_text,
-                predicted_value=ex.get("initial_answer_value", "") or "",
-                score_explanation=ex.get("score_explanation", "") or "",
-                correct_value=ex.get("final_answer_value", "") or "",
-                feedback_comment=ex.get("edit_comment", "") or "",
-                topic_hint="Evaluation small-set RCA misclassification evidence",
-            )
+            rubric_memory_context = {}
+            try:
+                rubric_memory_context = await self._rubric_memory_context_for_misclassification(
+                    primary_input_text=primary_input_text,
+                    predicted_value=ex.get("initial_answer_value", "") or "",
+                    score_explanation=ex.get("score_explanation", "") or "",
+                    correct_value=ex.get("final_answer_value", "") or "",
+                    feedback_comment=ex.get("edit_comment", "") or "",
+                    topic_hint="Evaluation small-set RCA misclassification evidence",
+                )
+            except Exception as exc:
+                failure = build_rca_analysis_failure_details("rubric_memory_retrieval", exc)
+                failure.update({
+                    "feedback_item_id": ex.get("feedback_item_id", ""),
+                    "item_id": ex.get("item_id", ""),
+                })
+                item_failure_diagnostics.append(failure)
+                self.logger.warning(
+                    "Small-set RCA rubric-memory retrieval failed for feedback_item_id=%s item_id=%s: %s: %s",
+                    ex.get("feedback_item_id", ""),
+                    ex.get("item_id", ""),
+                    failure["exception_type"],
+                    failure["message"],
+                )
+                rubric_memory_context = {
+                    "markdown_context": "",
+                    "citation_index": [],
+                    "diagnostics": [
+                        {
+                            "code": "rubric_memory_unavailable",
+                            "message": failure["message"],
+                            "failed_stage": failure["failed_stage"],
+                            "exception_type": failure["exception_type"],
+                        }
+                    ],
+                }
             ex["misclassification_item_context"] = build_misclassification_item_context(
                 feedback_item_id=ex.get("feedback_item_id", ""),
                 item_id=ex.get("item_id", ""),
@@ -4991,28 +5184,86 @@ class FeedbackEvaluation(Evaluation):
                 processors_config_summary=processors_config_summary,
                 rubric_memory_context=rubric_memory_context,
             )
-            misclassification_evidence_flags = await asyncio.to_thread(
-                extract_misclassification_evidence_flags,
-                item_context=ex["misclassification_item_context"],
-            )
-            classification = classify_misclassification_item(
-                ex["misclassification_item_context"],
-                misclassification_evidence_flags,
-            )
-            explainer = await asyncio.to_thread(
-                explain_misclassification_item_classification,
-                item_context=ex["misclassification_item_context"],
-                classification=classification,
-            )
-            classification["rationale_paragraph"] = explainer.get("rationale_paragraph", "")
-            classification["evidence_quote"] = explainer.get("evidence_quote", "")
-            classification["config_fixability"] = explainer.get("config_fixability", "")
-            classification["citation_ids"] = explainer.get(
-                "citation_ids",
-                classification.get("citation_ids", []),
-            )
-            classification["citation_validation"] = explainer.get("citation_validation", {})
+            rca_failure = None
+            try:
+                misclassification_evidence_flags = await asyncio.to_thread(
+                    extract_misclassification_evidence_flags,
+                    item_context=ex["misclassification_item_context"],
+                )
+            except Exception as exc:
+                rca_failure = build_rca_analysis_failure_details("evidence_flag_extraction", exc)
+                misclassification_evidence_flags = {}
+                classification = build_rca_analysis_failure_classification(
+                    item_context=ex["misclassification_item_context"],
+                    stage="evidence_flag_extraction",
+                    exc=exc,
+                )
+            else:
+                try:
+                    classification = classify_misclassification_item(
+                        ex["misclassification_item_context"],
+                        misclassification_evidence_flags,
+                    )
+                except Exception as exc:
+                    rca_failure = build_rca_analysis_failure_details("deterministic_classification", exc)
+                    classification = build_rca_analysis_failure_classification(
+                        item_context=ex["misclassification_item_context"],
+                        stage="deterministic_classification",
+                        exc=exc,
+                        evidence_flags=misclassification_evidence_flags,
+                    )
+
+            if rca_failure is None:
+                try:
+                    explainer = await asyncio.to_thread(
+                        explain_misclassification_item_classification,
+                        item_context=ex["misclassification_item_context"],
+                        classification=classification,
+                    )
+                except Exception as exc:
+                    rca_failure = build_rca_analysis_failure_details("explainer", exc)
+                    explainer = {
+                        "rationale_paragraph": (
+                            classification.get("rationale")
+                            or "RCA explainer failed; deterministic classification was preserved."
+                        ),
+                        "evidence_quote": (
+                            f"explainer: {rca_failure['exception_type']}: {rca_failure['message']}"
+                        ),
+                        "config_fixability": (
+                            "blocked_by_mechanical"
+                            if classification.get("primary_category") == "mechanical_malfunction"
+                            else "likely_fixable"
+                        ),
+                        "citation_ids": classification.get("citation_ids", []),
+                        "citation_validation": classification.get("citation_validation", {}),
+                    }
+                classification["rationale_paragraph"] = explainer.get("rationale_paragraph", "")
+                classification["evidence_quote"] = explainer.get("evidence_quote", "")
+                classification["config_fixability"] = explainer.get("config_fixability", "")
+                classification["citation_ids"] = explainer.get(
+                    "citation_ids",
+                    classification.get("citation_ids", []),
+                )
+                classification["citation_validation"] = explainer.get("citation_validation", {})
+            if rca_failure:
+                rca_failure.update({
+                    "feedback_item_id": ex.get("feedback_item_id", ""),
+                    "item_id": ex.get("item_id", ""),
+                })
+                item_failure_diagnostics.append(rca_failure)
+                self.logger.warning(
+                    "Small-set RCA item failed at %s for feedback_item_id=%s item_id=%s: %s: %s",
+                    rca_failure["failed_stage"],
+                    ex.get("feedback_item_id", ""),
+                    ex.get("item_id", ""),
+                    rca_failure["exception_type"],
+                    rca_failure["message"],
+                )
             ex["misclassification_classification"] = classification
+            ex["rca_failure"] = rca_failure
+            ex["rca_failures"] = item_failure_diagnostics
+            rca_item_failures.extend(item_failure_diagnostics)
 
         def _bedrock_converse(system: str, prompt: str, max_tokens: int = 500) -> str:
             import boto3 as _boto3
@@ -5103,6 +5354,7 @@ class FeedbackEvaluation(Evaluation):
         item_classifications_all = []
         for ex in exemplars:
             classification = ex.get("misclassification_classification") or {}
+            misclassification_item_context = ex.get("misclassification_item_context") or {}
             item_classifications_all.append({
                 "feedback_item_id": ex.get("feedback_item_id", ""),
                 "item_id": ex.get("item_id", ""),
@@ -5135,9 +5387,14 @@ class FeedbackEvaluation(Evaluation):
                 "mechanical_details": classification.get("mechanical_details"),
                 "information_gap_subtype": classification.get("information_gap_subtype"),
                 "triage_evidence_flags": classification.get("evidence_flags"),
+                "citation_ids": classification.get("citation_ids", []),
+                "citation_validation": classification.get("citation_validation", {}),
+                **rubric_memory_state_from_item_context(misclassification_item_context),
+                "rca_failure": ex.get("rca_failure"),
+                "rca_failures": ex.get("rca_failures", []),
                 "detailed_cause": ex.get("detailed_cause"),
                 "suggested_fix": ex.get("suggested_fix"),
-                "misclassification_item_context": ex.get("misclassification_item_context") or {},
+                "misclassification_item_context": misclassification_item_context,
                 "misclassification_classification": classification,
             })
         misclassification_analysis = build_misclassification_analysis_summary(
@@ -5148,6 +5405,7 @@ class FeedbackEvaluation(Evaluation):
                 "classified_items_total": len(item_classifications_all),
                 "texts_analyzed_total": len(exemplars),
                 "topics_found": 1,
+                "rca_item_failures_total": len(rca_item_failures),
                 "topic_assignment_scope": "exemplar_only",
                 "topic_assignment_unavailable_count": 0,
             },
@@ -5159,6 +5417,7 @@ class FeedbackEvaluation(Evaluation):
             "overall_improvement_suggestion": improvement_suggestion,
             "misclassification_classification_contract": build_misclassification_classification_contract(),
             "misclassification_analysis": misclassification_analysis,
+            "rca_item_failures": rca_item_failures,
         }
 
 class AccuracyEvaluation(Evaluation):

--- a/plexus/Evaluation_feedback_test.py
+++ b/plexus/Evaluation_feedback_test.py
@@ -64,6 +64,75 @@ class TestFeedbackEvaluation:
         assert evaluation.evaluation_id == "eval-789"
         assert evaluation.account_id == "account-123"
         assert evaluation.task_id == "task-999"
+
+    @pytest.mark.asyncio
+    async def test_rca_rubric_memory_context_uses_retrieval_only_provider(
+        self,
+        monkeypatch,
+        mock_api_client,
+    ):
+        """RCA should inject KB context without running evidence-pack synthesis."""
+
+        class _Context:
+            def model_dump(self, mode=None):
+                return {
+                    "markdown_context": "retrieved citation context",
+                    "citation_index": [{"id": "evidence:01:test"}],
+                    "diagnostics": [{"kind": "rubric_memory_retrieval_context"}],
+                }
+
+        class _Provider:
+            instances = []
+
+            def __init__(self, *, api_client):
+                self.api_client = api_client
+                self.generate_calls = 0
+                self.retrieve_calls = []
+                _Provider.instances.append(self)
+
+            def local_corpus_status(self, *, scorecard_identifier, score_identifier):
+                return {"available": True, "roots": []}
+
+            async def retrieve_for_score_item(self, **kwargs):
+                self.retrieve_calls.append(kwargs)
+                return _Context()
+
+            async def generate_for_score_item(self, **kwargs):
+                self.generate_calls += 1
+                raise AssertionError("RCA must not synthesize evidence packs per item")
+
+        monkeypatch.setattr(
+            "plexus.rubric_memory.RubricMemoryContextProvider",
+            _Provider,
+        )
+        evaluation = FeedbackEvaluation(
+            scorecard_name="Test Scorecard",
+            scorecard=None,
+            api_client=mock_api_client,
+            days=7,
+            scorecard_id="scorecard-123",
+            score_id="score-456",
+            evaluation_id="eval-789",
+            account_id="account-123",
+            account_key="test-account-key",
+            subset_of_score_names=["Medication Review: Dosage"],
+        )
+
+        context = await evaluation._rubric_memory_context_for_misclassification(
+            primary_input_text="call transcript",
+            predicted_value="No",
+            score_explanation="Missing dosage.",
+            correct_value="Yes",
+            feedback_comment="Dosage was verified.",
+            topic_hint="dosage",
+        )
+
+        provider = _Provider.instances[-1]
+        assert provider.generate_calls == 0
+        assert provider.retrieve_calls
+        assert provider.retrieve_calls[0]["score_identifier"] == "Medication Review: Dosage"
+        assert context["markdown_context"] == "retrieved citation context"
+        assert context["citation_index"] == [{"id": "evidence:01:test"}]
     
     @pytest.mark.asyncio
     async def test_fetch_feedback_items(self, mock_api_client, mock_feedback_items):
@@ -1188,6 +1257,19 @@ class TestCompactRootCauseForParameters:
         )
         applicability = result["misclassification_analysis"]["optimization_applicability"]
         assert applicability["status"] == "applicable"
+
+    def test_rca_item_failure_count_preserved(self):
+        payload = self._make_full_payload(
+            rca_item_failures=[
+                {
+                    "failed_stage": "evidence_flag_extraction",
+                    "exception_type": "ValueError",
+                    "message": "empty response",
+                }
+            ]
+        )
+        result = FeedbackEvaluation._compact_root_cause_for_parameters(payload, self.ATTACHMENT)
+        assert result["rca_item_failures_total"] == 1
 
     def test_missing_misclassification_analysis_is_tolerated(self):
         payload = self._make_full_payload()

--- a/plexus/cli/evaluation/evaluations.py
+++ b/plexus/cli/evaluation/evaluations.py
@@ -1164,6 +1164,7 @@ async def _run_shared_feedback_root_cause_orchestration(
     scorecard_id: str,
     score_id: str,
     score_version_id: Optional[str],
+    score_identifier: Optional[str] = None,
     max_items: int,
     sampling_mode: str,
     sample_seed: Optional[int],
@@ -1193,6 +1194,7 @@ async def _run_shared_feedback_root_cause_orchestration(
         sampling_mode=sampling_mode,
         sample_seed=sample_seed,
         max_category_summary_items=max_category_summary_items,
+        subset_of_score_names=[score_identifier] if score_identifier else None,
     )
     # FeedbackEvaluation constructor does not accept score_version_id directly.
     # Set it on the instance for RCA prompt/context usage.
@@ -3112,6 +3114,11 @@ def accuracy(
                             scorecard_id=scorecard_id,
                             score_id=score_id_for_eval,
                             score_version_id=score_version_id_for_eval,
+                            score_identifier=(
+                                subset_of_score_names[0]
+                                if subset_of_score_names and len(subset_of_score_names) == 1
+                                else None
+                            ),
                             max_items=len(labeled_samples_data),
                             sampling_mode="newest",
                             sample_seed=None,
@@ -4567,6 +4574,7 @@ def feedback(
                             scorecard_id=scorecard_id,
                             score_id=score_id,
                             score_version_id=version,
+                            score_identifier=score_name_for_dataset,
                             max_items=max_items,
                             sampling_mode=normalized_sampling_mode,
                             sample_seed=sample_seed,

--- a/plexus/cli/procedure/logging_utils.py
+++ b/plexus/cli/procedure/logging_utils.py
@@ -164,6 +164,40 @@ def capture_llm_context_for_agent(
     return {"markdown_path": str(markdown_path), "json_path": str(json_path)}
 
 
+def capture_tactus_dspy_context_for_agent(
+    agent_name: str,
+    prompt_context: Dict[str, Any],
+    *,
+    turn_count: int | None = None,
+    call_site: str = "tactus_dspy_agent_turn",
+) -> Dict[str, str] | None:
+    """Persist a Tactus/DSPy prompt_context using the standard capture format."""
+    messages: List[Any] = []
+
+    system_prompt = prompt_context.get("system_prompt")
+    if system_prompt:
+        messages.append({"role": "system", "content": str(system_prompt)})
+
+    history = prompt_context.get("history", [])
+    if hasattr(history, "messages"):
+        history = history.messages
+    if isinstance(history, list):
+        messages.extend(history)
+
+    user_message = prompt_context.get("user_message")
+    if user_message:
+        messages.append({"role": "user", "content": str(user_message)})
+
+    context = f"turn {turn_count}" if turn_count is not None else ""
+    return capture_llm_context_for_agent(
+        agent_name=agent_name,
+        chat_history=messages,
+        context=context,
+        call_site=call_site,
+        tools=prompt_context.get("tools") or [],
+    )
+
+
 def log_filtered_vs_full_history(agent_name: str,
                                 full_history: List[Any],
                                 filtered_history: List[Any],
@@ -193,6 +227,17 @@ def log_filtered_vs_full_history(agent_name: str,
 
 def _get_message_type(message: Any) -> str:
     """Get a readable message type string."""
+    if isinstance(message, dict):
+        role = str(message.get("role") or "").lower()
+        if role in {"system", "user", "assistant", "tool", "tool_result"}:
+            return {
+                "system": "SYSTEM",
+                "user": "USER",
+                "assistant": "ASSISTANT",
+                "tool": "TOOL_RESULT",
+                "tool_result": "TOOL_RESULT",
+            }[role]
+        return "DICT"
     if isinstance(message, SystemMessage):
         return "SYSTEM"
     elif isinstance(message, HumanMessage):
@@ -302,7 +347,8 @@ def _format_context_capture_markdown(payload: Dict[str, Any]) -> str:
                     f"`{json.dumps(tool_call['args'], ensure_ascii=False, default=str)}`"
                 )
             lines.append("")
-        lines.extend(["```text", message["content"], "```", ""])
+        markdown_content = str(message["content"]).replace("\x00", "\\0")
+        lines.extend(["```text", markdown_content, "```", ""])
     return "\n".join(lines)
 
 

--- a/plexus/cli/procedure/logging_utils_test.py
+++ b/plexus/cli/procedure/logging_utils_test.py
@@ -7,7 +7,10 @@ try:
 except ImportError:  # pragma: no cover - compatibility only
     from langchain.schema import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from plexus.cli.procedure.logging_utils import capture_llm_context_for_agent
+from plexus.cli.procedure.logging_utils import (
+    capture_llm_context_for_agent,
+    capture_tactus_dspy_context_for_agent,
+)
 
 
 def test_capture_llm_context_disabled_writes_no_files(monkeypatch, tmp_path):
@@ -88,3 +91,64 @@ def test_capture_llm_context_preserves_rubric_memory_briefing(monkeypatch, tmp_p
     assert "=== RUBRIC MEMORY BRIEFING" in markdown
     assert "corpus:01:abc" in markdown
     assert "Information Accuracy policy memory" in payload["messages"][1]["content"]
+
+
+def test_capture_tactus_dspy_context_serializes_prompt_context(monkeypatch, tmp_path):
+    monkeypatch.setenv("PLEXUS_CAPTURE_LLM_CONTEXT_DIR", str(tmp_path))
+    prompt_context = {
+        "system_prompt": "Optimizer system prompt",
+        "history": [
+            {
+                "role": "user",
+                "content": (
+                    "Planning context\n\n"
+                    "=== RUBRIC MEMORY BRIEFING ===\n"
+                    "`support:01:abc` prefix evidence\n"
+                    "=== END RUBRIC MEMORY BRIEFING ==="
+                ),
+            },
+            {"role": "assistant", "content": "Previous answer"},
+        ],
+        "user_message": "Generate the next hypothesis.",
+        "tools": ["plexus_rubric_memory_evidence_pack"],
+    }
+
+    result = capture_tactus_dspy_context_for_agent(
+        "Tactus DSPy Agent: hypothesis_planner",
+        prompt_context,
+        turn_count=1,
+        call_site="tactus_dspy_agent_non_streaming",
+    )
+
+    assert result is not None
+    payload = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+    markdown = next(tmp_path.glob("*.md")).read_text(encoding="utf-8")
+
+    assert payload["agent_name"] == "Tactus DSPy Agent: hypothesis_planner"
+    assert payload["call_site"] == "tactus_dspy_agent_non_streaming"
+    assert payload["context"] == "turn 1"
+    assert [message["role"] for message in payload["messages"]] == [
+        "SYSTEM",
+        "USER",
+        "ASSISTANT",
+        "USER",
+    ]
+    assert "=== RUBRIC MEMORY BRIEFING" in markdown
+    assert "plexus_rubric_memory_evidence_pack" in payload["tools"]
+
+
+def test_capture_markdown_escapes_nul_bytes_but_json_preserves_content(monkeypatch, tmp_path):
+    monkeypatch.setenv("PLEXUS_CAPTURE_LLM_CONTEXT_DIR", str(tmp_path))
+
+    capture_llm_context_for_agent(
+        "Binary-ish Agent",
+        [HumanMessage(content="before\x00after")],
+        call_site="unit_test",
+    )
+
+    markdown_bytes = next(tmp_path.glob("*.md")).read_bytes()
+    payload = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+
+    assert b"\x00" not in markdown_bytes
+    assert "before\\0after" in markdown_bytes.decode("utf-8")
+    assert payload["messages"][0]["content"] == "before\x00after"

--- a/plexus/cli/procedure/procedure_executor.py
+++ b/plexus/cli/procedure/procedure_executor.py
@@ -19,6 +19,51 @@ from typing import Dict, Any, Optional, List
 logger = logging.getLogger(__name__)
 
 
+def _install_tactus_dspy_context_capture_patch() -> None:
+    """Capture Tactus DSPy agent prompt_context before model invocation."""
+    try:
+        from tactus.dspy.agent import DSPyAgentHandle
+    except Exception as exc:  # pragma: no cover - optional dependency variance
+        logger.debug("Could not import Tactus DSPy agent for context capture: %s", exc)
+        return
+
+    if getattr(DSPyAgentHandle, "_plexus_context_capture_patched", False):
+        return
+
+    from .logging_utils import capture_tactus_dspy_context_for_agent
+
+    original_streaming = DSPyAgentHandle._turn_with_streaming
+    original_non_streaming = DSPyAgentHandle._turn_without_streaming
+
+    def _capture(agent: Any, prompt_context: Dict[str, Any], call_site: str) -> None:
+        try:
+            capture_tactus_dspy_context_for_agent(
+                agent_name=f"Tactus DSPy Agent: {getattr(agent, 'name', 'unknown')}",
+                prompt_context=prompt_context,
+                turn_count=getattr(agent, "_turn_count", None),
+                call_site=call_site,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to capture Tactus DSPy LLM context for agent %s: %s",
+                getattr(agent, "name", "unknown"),
+                exc,
+            )
+
+    def patched_streaming(self, opts: Dict[str, Any], prompt_context: Dict[str, Any]):
+        _capture(self, prompt_context, "tactus_dspy_agent_streaming")
+        return original_streaming(self, opts, prompt_context)
+
+    def patched_non_streaming(self, opts: Dict[str, Any], prompt_context: Dict[str, Any]):
+        _capture(self, prompt_context, "tactus_dspy_agent_non_streaming")
+        return original_non_streaming(self, opts, prompt_context)
+
+    DSPyAgentHandle._turn_with_streaming = patched_streaming
+    DSPyAgentHandle._turn_without_streaming = patched_non_streaming
+    DSPyAgentHandle._plexus_context_capture_patched = True
+    logger.debug("Installed Tactus DSPy context capture patch")
+
+
 def _to_float(value: Any) -> Optional[float]:
     try:
         if value is None:
@@ -1014,6 +1059,8 @@ async def _execute_tactus(
         # Ensure DSPy agents can stream even when runtime constructor does not expose log_handler.
         if getattr(runtime, "log_handler", None) is None:
             runtime.log_handler = log_bridge
+
+        _install_tactus_dspy_context_capture_patch()
 
         # Bridge legacy in-process MCP server to Tactus toolset registry.
         # Newer Tactus versions resolve agent tools through named toolsets.

--- a/plexus/cli/rubric_memory/commands.py
+++ b/plexus/cli/rubric_memory/commands.py
@@ -1,16 +1,55 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import click
 
+from plexus.cli.shared.shared import sanitize_path_name
 from plexus.rubric_memory import (
     LocalRubricMemoryCorpusResolver,
+    RUBRIC_MEMORY_BUCKET_ENV_VAR,
     RubricMemoryPreparedCorpusManager,
+    S3RubricMemoryCorpusResolver,
 )
 
 
 @click.group(name="rubric-memory")
 def rubric_memory() -> None:
-    """Commands for preparing and inspecting local rubric memory."""
+    """Commands for syncing and preparing rubric memory."""
+
+
+@rubric_memory.command(name="sync")
+@click.option("--scorecard", "scorecard_name", required=True, help="Scorecard name.")
+@click.option("--score", "score_name", help="Optional score name.")
+def sync(
+    *,
+    scorecard_name: str,
+    score_name: str | None,
+) -> None:
+    """Upload local .knowledge-base folders to the rubric-memory S3 bucket."""
+
+    bucket_name = _rubric_memory_bucket_name()
+    local_roots = _local_sync_roots(
+        scorecard_name=scorecard_name,
+        score_name=score_name,
+    )
+    import boto3
+
+    s3_client = boto3.client("s3")
+    uploaded = 0
+    for root in local_roots:
+        for source_file in _source_files(root):
+            key = _s3_key_for_local_source(
+                scorecard_name=scorecard_name,
+                source_file=source_file,
+            )
+            s3_client.upload_file(str(source_file), bucket_name, key)
+            uploaded += 1
+    click.echo(f"bucket: {bucket_name}")
+    click.echo(f"uploaded_file_count: {uploaded}")
+    for root in local_roots:
+        click.echo(f"synced_knowledge_base: {root}")
 
 
 @rubric_memory.command(name="prewarm")
@@ -34,9 +73,10 @@ def prewarm(
     retriever_id: str,
     force: bool,
 ) -> None:
-    """Prepare the canonical local rubric-memory corpus for a score."""
+    """Prepare the canonical S3 rubric-memory corpus for a score."""
 
-    paths = LocalRubricMemoryCorpusResolver().resolve(
+    _rubric_memory_bucket_name()
+    paths = S3RubricMemoryCorpusResolver().resolve(
         scorecard_name=scorecard_name,
         score_name=score_name,
     )
@@ -47,14 +87,112 @@ def prewarm(
     )
 
     click.echo(f"status: {prepared.status}")
+    click.echo(f"bucket: {paths.bucket_name}")
     click.echo(f"retriever_id: {prepared.retriever_id}")
     click.echo(f"fingerprint: {prepared.fingerprint}")
     click.echo(f"prepared_corpus_path: {prepared.corpus_root}")
     click.echo(f"manifest_path: {prepared.manifest_path}")
     click.echo(f"source_file_count: {prepared.source_file_count}")
     for source in paths.sources:
-        click.echo(f"included_knowledge_base[{source.scope_level}]: {source.root}")
-    click.echo(f"scorecard_knowledge_base: {paths.scorecard_knowledge_base}")
-    for prefix_knowledge_base in paths.prefix_knowledge_bases:
-        click.echo(f"prefix_knowledge_base: {prefix_knowledge_base}")
-    click.echo(f"score_knowledge_base: {paths.score_knowledge_base}")
+        click.echo(
+            f"included_knowledge_base[{source.scope_level}]: "
+            f"s3://{source.bucket_name}/{source.prefix} "
+            f"({len(source.objects)} files)"
+        )
+    click.echo(
+        f"scorecard_knowledge_base: "
+        f"s3://{paths.bucket_name}/{paths.scorecard_knowledge_base_prefix}"
+    )
+    for prefix_knowledge_base in paths.prefix_knowledge_base_prefixes:
+        click.echo(
+            f"prefix_knowledge_base: s3://{paths.bucket_name}/{prefix_knowledge_base}"
+        )
+    click.echo(
+        f"score_knowledge_base: "
+        f"s3://{paths.bucket_name}/{paths.score_knowledge_base_prefix}"
+    )
+
+
+def _rubric_memory_bucket_name() -> str:
+    bucket_name = os.environ.get(RUBRIC_MEMORY_BUCKET_ENV_VAR)
+    if not bucket_name:
+        raise click.ClickException(
+            f"Missing required environment variable: {RUBRIC_MEMORY_BUCKET_ENV_VAR}"
+        )
+    return bucket_name
+
+
+def _local_scorecard_root(scorecard_name: str) -> Path:
+    return Path(os.environ.get("SCORECARD_CACHE_DIR", "scorecards")) / sanitize_path_name(
+        scorecard_name
+    )
+
+
+def _local_sync_roots(
+    *,
+    scorecard_name: str,
+    score_name: str | None,
+) -> list[Path]:
+    scorecard_root = _local_scorecard_root(scorecard_name)
+    if not scorecard_root.is_dir():
+        raise click.ClickException(
+            f"Local scorecard folder does not exist: {scorecard_root}"
+        )
+    if score_name:
+        paths = LocalRubricMemoryCorpusResolver().resolve(
+            scorecard_name=scorecard_name,
+            score_name=score_name,
+        )
+        roots = [
+            paths.scorecard_knowledge_base,
+            *paths.prefix_knowledge_bases,
+            paths.score_knowledge_base,
+        ]
+    else:
+        roots = sorted(
+            path
+            for path in scorecard_root.glob("*.knowledge-base")
+            if path.is_dir()
+        )
+    if not roots:
+        raise click.ClickException(
+            f"No local .knowledge-base folders found under {scorecard_root}"
+        )
+    missing = [root for root in roots if not root.is_dir()]
+    if missing:
+        raise click.ClickException(
+            "Missing local .knowledge-base folders: "
+            + ", ".join(str(root) for root in missing)
+        )
+    return roots
+
+
+def _source_files(root: Path) -> list[Path]:
+    ignored_dirs = {
+        ".biblicus",
+        "analysis",
+        "extracted",
+        "graph",
+        "metadata",
+        "retrieval",
+    }
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name.endswith(".biblicus.yml"):
+            continue
+        if any(part in ignored_dirs for part in path.relative_to(root).parts):
+            continue
+        files.append(path)
+    return files
+
+
+def _s3_key_for_local_source(
+    *,
+    scorecard_name: str,
+    source_file: Path,
+) -> str:
+    scorecard_root = _local_scorecard_root(scorecard_name)
+    relative_path = source_file.relative_to(scorecard_root).as_posix()
+    return f"{sanitize_path_name(scorecard_name)}/{relative_path}"

--- a/plexus/config/loader.py
+++ b/plexus/config/loader.py
@@ -56,6 +56,7 @@ class ConfigLoader:
         'aws.storage.datasets_bucket': 'AMPLIFY_STORAGE_DATASETS_BUCKET_NAME',
         'aws.storage.task_attachments_bucket': 'AMPLIFY_STORAGE_TASKATTACHMENTS_BUCKET_NAME',
         'aws.storage.score_result_attachments_bucket': 'AMPLIFY_STORAGE_SCORERESULTATTACHMENTS_BUCKET_NAME',
+        'aws.storage.rubric_memory_bucket': 'AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME',
         
         # Data Lake
         'aws.data_lake.database_name': 'PLEXUS_TRAINING_DATA_LAKE_DATABASE_NAME',

--- a/plexus/docs/rubric-memory.md
+++ b/plexus/docs/rubric-memory.md
@@ -1,6 +1,6 @@
 # Rubric Memory and Scorecard Knowledge Bases
 
-Rubric memory is Plexus's local knowledge-base system for adding policy history, meeting notes, emails, chat excerpts, scripts, and other supporting material to score analysis. It does not replace the official rubric. The official policy authority is the active `ScoreVersion` for the score, usually the score's champion version through `Score.championVersionId`.
+Rubric memory is Plexus's scorecard knowledge-base system for adding policy history, meeting notes, emails, chat excerpts, scripts, and other supporting material to score analysis. It does not replace the official rubric. The official policy authority is the active `ScoreVersion` for the score, usually the score's champion version through `Score.championVersionId`.
 
 In current storage, rubric text is still stored in fields named `guidelines`, and score code is stored in `configuration`. New rubric-memory code uses `rubric` terminology and translates from `guidelines` only at the storage adapter boundary.
 
@@ -15,29 +15,28 @@ Rubric memory helps agents and reports answer questions such as:
 
 Corpus evidence can explain, support, conflict with, or contextualize the official rubric. It cannot silently override the active `ScoreVersion` rubric.
 
-## Local Folder Convention
+## S3 Folder Convention
 
-Rubric memory uses the same pulled-score workspace convention as local score YAML and Markdown files. It does not use a separate root and does not require a per-score configuration file.
+Rubric memory runtime reads from the dedicated Amplify `rubricMemory` S3 bucket. The bucket name must be provided with `AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME`. There is no fallback bucket and no runtime fallback to local folders.
 
-The score YAML path is derived with `get_score_yaml_path(scorecard_name, score_name)`. The adjacent knowledge-base folders are then derived from that same location.
-
-```text
-<SCORECARD_CACHE_DIR>/
-  <Scorecard Name>/
-    scorecard.knowledge-base/
-    <Prefix>.knowledge-base/
-    <Score Name Stem>.knowledge-base/
-    <Score Name Stem>.yaml
-    <Score Name Stem>.md
-```
-
-For example, if `SCORECARD_CACHE_DIR=dashboard/scorecards` and the score is `SelectQuote HCS Medium-Risk` / `Medication Review: Dosage`, the score-level knowledge base is:
+The S3 key hierarchy intentionally mirrors the existing pulled-score folder names:
 
 ```text
-dashboard/scorecards/SelectQuote HCS Medium-Risk/Medication Review- Dosage.knowledge-base/
+<Scorecard Name>/
+  scorecard.knowledge-base/
+  <Prefix>.knowledge-base/
+  <Score Name Stem>.knowledge-base/
 ```
 
-The name must match the sanitized score file stem used by the pulled-score convention. This keeps the `.yaml`, `.md`, and `.knowledge-base` artifacts visibly aligned.
+For `SelectQuote HCS Medium-Risk` / `Medication Review: Dosage`, the score-level knowledge base prefix is:
+
+```text
+SelectQuote HCS Medium-Risk/Medication Review- Dosage.knowledge-base/
+```
+
+The name must match the sanitized score file stem used by the pulled-score convention. This keeps the `.yaml`, `.md`, local `.knowledge-base`, and S3 `.knowledge-base` artifacts visibly aligned.
+
+Local `.knowledge-base` folders are now authoring and sync input only. They are not the runtime source of truth.
 
 ## Scope Levels
 
@@ -56,11 +55,9 @@ Prefix knowledge bases apply to multiple related scores in a scorecard. They are
 Example:
 
 ```text
-dashboard/scorecards/SelectQuote HCS Medium-Risk/
+SelectQuote HCS Medium-Risk/
   Information Accuracy.knowledge-base/
-  Information Accuracy- High-Pressure Sales Tactics.yaml
   Information Accuracy- High-Pressure Sales Tactics.knowledge-base/
-  Information Accuracy (Composite).yaml
 ```
 
 `Information Accuracy.knowledge-base/` applies to scores whose sanitized score names begin with `Information Accuracy` at a clear boundary, such as a space, hyphen, or parenthesis. It applies to both `Information Accuracy: High-Pressure Sales Tactics` and `Information Accuracy (Composite)`.
@@ -88,7 +85,7 @@ The date means the meeting date, email date, chat date, or document date. Plexus
 
 Files under `unknown-date/` remain retrievable but have no `source_timestamp`, so they do not contribute to chronological history ordering.
 
-Plexus never rewrites raw knowledge-base files to add metadata. Inferred timestamps and scope metadata are attached only in the prepared working corpus.
+Plexus never rewrites raw S3 knowledge-base files to add metadata. Inferred timestamps and scope metadata are attached only in the prepared working corpus.
 
 ## Raw Source Files
 
@@ -96,9 +93,23 @@ V1 intentionally keeps raw source organization simple. You do not need separate 
 
 Overlap and duplication are acceptable. A source can be copied into a scorecard-level folder and a score-level folder if both scopes should retrieve it. Retrieval deduplication and ranking happen at runtime.
 
+## Syncing Local Folders To S3
+
+Use local folders next to pulled score YAML/Markdown files as the authoring workspace. Sync uploads those raw files to the dedicated rubric-memory bucket using the same relative hierarchy.
+
+```bash
+plexus rubric-memory sync --scorecard "SelectQuote HCS Medium-Risk"
+
+plexus rubric-memory sync \
+  --scorecard "SelectQuote HCS Medium-Risk" \
+  --score "Medication Review: Dosage"
+```
+
+The score-specific sync uploads the scorecard-level folder, matching prefix folders, and the exact score folder. Missing required local scorecard or score folders fail clearly. Prefix folders remain optional.
+
 ## Prepared Corpora
 
-Before retrieval, Plexus prepares the local corpus under ignored repo-local storage:
+Before retrieval, Plexus downloads the S3 corpus into ignored repo-local storage:
 
 ```text
 tmp/rubric-memory/prepared/<stable-cache-key>/
@@ -106,17 +117,17 @@ tmp/rubric-memory/prepared/<stable-cache-key>/
 
 The prepared corpus manager:
 
-- resolves the scorecard, prefix, and score roots using the canonical folder convention;
-- copies raw files into the prepared cache;
+- resolves the scorecard, prefix, and score S3 prefixes using the canonical folder convention;
+- downloads raw files into the prepared cache;
 - writes Biblicus sidecar metadata only inside `tmp/rubric-memory/prepared/...`;
-- records a manifest with source roots, file counts, retriever id, schema version, fingerprint, and prepared timestamp;
+- records a manifest with source prefixes, file counts, retriever id, schema version, fingerprint, and prepared timestamp;
 - reuses the cache when the source fingerprint is unchanged;
-- rebuilds when paths, sizes, mtimes, inferred timestamps, scope levels, retriever id, or sidecar schema version change.
+- rebuilds when S3 keys, sizes, ETags, LastModified values, inferred timestamps, scope levels, retriever id, or sidecar schema version change.
 
 Manual prewarming uses the same code path as just-in-time runtime preparation:
 
 ```bash
-SCORECARD_CACHE_DIR=dashboard/scorecards plexus rubric-memory prewarm \
+AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME=<bucket> plexus rubric-memory prewarm \
   --scorecard "SelectQuote HCS Medium-Risk" \
   --score "Medication Review: Dosage"
 ```
@@ -183,4 +194,3 @@ The official rubric always wins over contradictory low-authority corpus evidence
 If the corpus answers a question but the rubric is unclear, agents should transform the question from "What is the policy?" into "Should the rubric be updated to explicitly say this?" with citations.
 
 If evidence is sparse, conflicting, or undated, agents should lower confidence and produce open questions rather than confident policy claims.
-

--- a/plexus/rca_analysis.py
+++ b/plexus/rca_analysis.py
@@ -25,24 +25,46 @@ def _invoke_rca_openai_text(
     system: str,
     messages: list[dict[str, str]],
     max_output_tokens: int,
+    call_site: str = "rca_openai_text",
 ) -> str:
     """Invoke the RCA standard OpenAI model and return plain response text."""
     from dotenv import load_dotenv
     from openai import OpenAI
+    from plexus.cli.procedure.logging_utils import capture_llm_context_for_agent
 
     load_dotenv(override=False)
     client = OpenAI()
-    response = client.responses.create(
-        model=RCA_OPENAI_MODEL,
-        instructions=system,
-        input=messages,
-        max_output_tokens=max_output_tokens,
-    )
-    text = getattr(response, "output_text", "") or ""
-    text = text.strip()
-    if not text:
+    current_messages = list(messages)
+    last_empty = False
+    for attempt in range(2):
+        capture_llm_context_for_agent(
+            "RCA",
+            [{"role": "system", "content": system}, *current_messages],
+            call_site=call_site if attempt == 0 else f"{call_site}_retry_empty",
+        )
+        response = client.responses.create(
+            model=RCA_OPENAI_MODEL,
+            instructions=system,
+            input=current_messages,
+            max_output_tokens=max_output_tokens,
+        )
+        text = (getattr(response, "output_text", "") or "").strip()
+        if text:
+            return text
+        last_empty = True
+        current_messages = [
+            *current_messages,
+            {
+                "role": "user",
+                "content": (
+                    "Your previous response was empty. Return the requested "
+                    "structured text exactly in the specified format."
+                ),
+            },
+        ]
+    if last_empty:
         raise ValueError(f"{RCA_OPENAI_MODEL} returned an empty response")
-    return text
+    raise ValueError(f"{RCA_OPENAI_MODEL} returned no usable response")
 
 
 MISCLASSIFICATION_CATEGORIES = (
@@ -69,6 +91,7 @@ MECHANICAL_SUBTYPES = (
     "runtime_error",
     "parse_or_schema_error",
     "invalid_output_class",
+    "rca_analysis_failure",
     "unknown_mechanical",
 )
 
@@ -687,90 +710,114 @@ def extract_misclassification_evidence_flags(
         f"Item context JSON:\n{json.dumps(_compact_context_for_triage(item_context), ensure_ascii=True)}\n"
     )
 
-    text = _invoke_rca_openai_text(
-        system=system,
-        messages=[{"role": "user", "content": prompt}],
-        max_output_tokens=320,
-    )
-    if not isinstance(text, str) or not text.strip():
-        raise ValueError("Invalid evidence flag output: empty response")
+    def _parse_flag_text(text: str) -> Dict[str, Any]:
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("Invalid evidence flag output: empty response")
 
-    kv: Dict[str, str] = {}
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line or ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        kv[key.strip().upper()] = value.strip()
+        kv: Dict[str, str] = {}
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line or ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            kv[key.strip().upper()] = value.strip()
 
-    required = (
-        "FLAG_EXTERNAL_INFORMATION_GAP",
-        "FLAG_GUIDELINE_GAP",
-        "FLAG_SYSTEM_MISSING_CONTEXT",
-        "FLAG_RUNTIME_OR_PARSER_FAILURE",
-        "FLAG_INVALID_OUTPUT_CLASS",
-        "FLAG_PREPROCESSING_EVIDENCE_LOSS",
-        "BEST_EVIDENCE_SOURCE",
-        "BEST_EVIDENCE_QUOTE",
-    )
-    missing = [key for key in required if key not in kv]
-    if missing:
-        raise ValueError(
-            f"Invalid evidence flag output: missing keys {missing}. Raw output: {text[:500]}"
-        )
-
-    def _parse_bool(value: str, key: str) -> bool:
-        low = str(value or "").strip().lower()
-        if low in {"true", "yes"}:
-            return True
-        if low in {"false", "no"}:
-            return False
-        raise ValueError(f"Invalid boolean for {key}: {value}")
-
-    raw_source = _normalize_label(kv["BEST_EVIDENCE_SOURCE"]).lower()
-    source = normalize_best_evidence_source(raw_source)
-    allowed_sources = {
-        "edit_comment",
-        "score_explanation",
-        "guidelines",
-        "score_yaml",
-        "primary_input",
-        "processed_input",
-        "metadata",
-        "rubric_memory",
-        "none",
-    }
-    if source not in allowed_sources:
-        raise ValueError(f"Invalid BEST_EVIDENCE_SOURCE: {raw_source}")
-
-    return {
-        "external_information_missing_or_degraded": _parse_bool(
-            kv["FLAG_EXTERNAL_INFORMATION_GAP"],
+        required = (
             "FLAG_EXTERNAL_INFORMATION_GAP",
-        ),
-        "guideline_or_policy_ambiguity": _parse_bool(
-            kv["FLAG_GUIDELINE_GAP"],
             "FLAG_GUIDELINE_GAP",
-        ),
-        "missing_required_context_due_system": _parse_bool(
-            kv["FLAG_SYSTEM_MISSING_CONTEXT"],
             "FLAG_SYSTEM_MISSING_CONTEXT",
-        ),
-        "runtime_or_parsing_failure": _parse_bool(
-            kv["FLAG_RUNTIME_OR_PARSER_FAILURE"],
             "FLAG_RUNTIME_OR_PARSER_FAILURE",
-        ),
-        "invalid_output_class_signal": _parse_bool(
-            kv["FLAG_INVALID_OUTPUT_CLASS"],
             "FLAG_INVALID_OUTPUT_CLASS",
-        ),
-        "preprocessing_evidence_loss": _parse_bool(
-            kv["FLAG_PREPROCESSING_EVIDENCE_LOSS"],
             "FLAG_PREPROCESSING_EVIDENCE_LOSS",
-        ),
-        "best_evidence_source": source,
-        "best_evidence_quote": _excerpt(kv["BEST_EVIDENCE_QUOTE"], 260),
-    }
+            "BEST_EVIDENCE_SOURCE",
+            "BEST_EVIDENCE_QUOTE",
+        )
+        missing = [key for key in required if key not in kv]
+        if missing:
+            raise ValueError(
+                f"Invalid evidence flag output: missing keys {missing}. Raw output: {text[:500]}"
+            )
+
+        def _parse_bool(value: str, key: str) -> bool:
+            low = str(value or "").strip().lower()
+            if low in {"true", "yes"}:
+                return True
+            if low in {"false", "no"}:
+                return False
+            raise ValueError(f"Invalid boolean for {key}: {value}")
+
+        raw_source = _normalize_label(kv["BEST_EVIDENCE_SOURCE"]).lower()
+        source = normalize_best_evidence_source(raw_source)
+        allowed_sources = {
+            "edit_comment",
+            "score_explanation",
+            "guidelines",
+            "score_yaml",
+            "primary_input",
+            "processed_input",
+            "metadata",
+            "rubric_memory",
+            "none",
+        }
+        if source not in allowed_sources:
+            raise ValueError(f"Invalid BEST_EVIDENCE_SOURCE: {raw_source}")
+
+        return {
+            "external_information_missing_or_degraded": _parse_bool(
+                kv["FLAG_EXTERNAL_INFORMATION_GAP"],
+                "FLAG_EXTERNAL_INFORMATION_GAP",
+            ),
+            "guideline_or_policy_ambiguity": _parse_bool(
+                kv["FLAG_GUIDELINE_GAP"],
+                "FLAG_GUIDELINE_GAP",
+            ),
+            "missing_required_context_due_system": _parse_bool(
+                kv["FLAG_SYSTEM_MISSING_CONTEXT"],
+                "FLAG_SYSTEM_MISSING_CONTEXT",
+            ),
+            "runtime_or_parsing_failure": _parse_bool(
+                kv["FLAG_RUNTIME_OR_PARSER_FAILURE"],
+                "FLAG_RUNTIME_OR_PARSER_FAILURE",
+            ),
+            "invalid_output_class_signal": _parse_bool(
+                kv["FLAG_INVALID_OUTPUT_CLASS"],
+                "FLAG_INVALID_OUTPUT_CLASS",
+            ),
+            "preprocessing_evidence_loss": _parse_bool(
+                kv["FLAG_PREPROCESSING_EVIDENCE_LOSS"],
+                "FLAG_PREPROCESSING_EVIDENCE_LOSS",
+            ),
+            "best_evidence_source": source,
+            "best_evidence_quote": _excerpt(kv["BEST_EVIDENCE_QUOTE"], 260),
+        }
+
+    messages = [{"role": "user", "content": prompt}]
+    last_error: Optional[Exception] = None
+    for attempt in range(2):
+        text = _invoke_rca_openai_text(
+            system=system,
+            messages=messages,
+            max_output_tokens=320,
+            call_site="rca_evidence_flags" if attempt == 0 else "rca_evidence_flags_repair",
+        )
+        try:
+            return _parse_flag_text(text)
+        except ValueError as exc:
+            last_error = exc
+            if attempt == 1:
+                break
+            messages = [
+                *messages,
+                {"role": "assistant", "content": text[:1000]},
+                {
+                    "role": "user",
+                    "content": (
+                        "Your previous response did not match the required eight-line schema. "
+                        "Return exactly the eight requested lines and no extra prose."
+                    ),
+                },
+            ]
+    raise last_error or ValueError("Invalid evidence flag output")
 
 
 def normalize_best_evidence_source(raw_source: str) -> str:
@@ -818,6 +865,79 @@ def _rubric_memory_citation_ids(item_context: dict, limit: int = 3) -> list[str]
         if isinstance(raw, dict) and raw.get("id"):
             citation_ids.append(str(raw["id"]))
     return citation_ids[:limit]
+
+
+def rubric_memory_state_from_item_context(item_context: dict) -> dict:
+    """Return compact rubric-memory availability/provenance state for RCA artifacts."""
+    rubric_memory = (item_context or {}).get("rubric_memory", {}) or {}
+    citation_index = rubric_memory.get("citation_index") or []
+    diagnostics = rubric_memory.get("diagnostics") or []
+    return {
+        "rubric_memory_available": bool(citation_index),
+        "citation_index_count": len(citation_index),
+        "rubric_memory_diagnostics": diagnostics,
+    }
+
+
+def build_rca_analysis_failure_details(stage: str, exc: BaseException) -> dict:
+    """Build a serializable RCA item-stage failure diagnostic."""
+    return {
+        "failed_stage": _normalize_label(stage) or "unknown",
+        "exception_type": exc.__class__.__name__,
+        "message": _excerpt(str(exc), 1000),
+    }
+
+
+def build_rca_analysis_failure_classification(
+    *,
+    item_context: dict,
+    stage: str,
+    exc: BaseException,
+    evidence_flags: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Preserve an RCA item as a mechanical failure row when RCA analysis itself fails."""
+    failure = build_rca_analysis_failure_details(stage, exc)
+    citation_ids = _rubric_memory_citation_ids(item_context)
+    citation_validation = validate_rubric_memory_citations(
+        citation_ids,
+        (item_context or {}).get("rubric_memory"),
+        require_citation=False,
+    )
+    return {
+        "primary_category": "mechanical_malfunction",
+        "rationale": (
+            "RCA item analysis failed before a reliable triage classification could be produced."
+        ),
+        "confidence": "high",
+        "mechanical_subtype": "rca_analysis_failure",
+        "mechanical_details": (
+            f"failed_stage={failure['failed_stage']}; "
+            f"exception_type={failure['exception_type']}; "
+            f"message={failure['message']}"
+        ),
+        "information_gap_subtype": None,
+        "evidence_snippets": [
+            {
+                "source": "metadata",
+                "quote_or_fact": (
+                    f"RCA analysis failed at {failure['failed_stage']}: "
+                    f"{failure['exception_type']}: {failure['message']}"
+                ),
+            }
+        ],
+        "evidence_flags": evidence_flags or {},
+        "rationale_paragraph": (
+            "RCA item analysis failed before this item could be categorized. "
+            "The item is preserved for debugging instead of being dropped."
+        ),
+        "evidence_quote": (
+            f"{failure['failed_stage']}: {failure['exception_type']}: {failure['message']}"
+        ),
+        "config_fixability": "blocked_by_mechanical",
+        "citation_ids": citation_validation.valid_ids,
+        "citation_validation": citation_validation.model_dump(mode="json"),
+        "rca_failure": failure,
+    }
 
 
 def classify_misclassification_item(item_context: dict, evidence_flags: Dict[str, Any]) -> dict:
@@ -1163,48 +1283,73 @@ def explain_misclassification_item_classification(
         f"Item context JSON:\n{json.dumps(item_context, ensure_ascii=True)}\n\n"
         f"Deterministic classification JSON:\n{json.dumps(classification, ensure_ascii=True)}\n"
     )
-    raw_text = _invoke_rca_openai_text(
-        system=system,
-        messages=[{"role": "user", "content": prompt}],
-        max_output_tokens=320,
-    )
-    line_map = {}
-    for line in str(raw_text or "").splitlines():
-        if ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        line_map[_normalize_label(key).upper()] = _normalize_label(value)
+    def _parse_explainer_text(raw_text: str) -> Dict[str, Any]:
+        line_map = {}
+        for line in str(raw_text or "").splitlines():
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            line_map[_normalize_label(key).upper()] = _normalize_label(value)
 
-    rationale_paragraph = line_map.get("RATIONALE_PARAGRAPH", "")
-    evidence_quote = line_map.get("EVIDENCE_QUOTE", "")
-    config_fixability = line_map.get("CONFIG_FIXABILITY", "")
-    citation_ids = [
-        value.strip()
-        for value in re.split(r"[,\\s]+", line_map.get("CITATION_IDS", ""))
-        if value.strip()
-    ]
+        rationale_paragraph = line_map.get("RATIONALE_PARAGRAPH", "")
+        evidence_quote = line_map.get("EVIDENCE_QUOTE", "")
+        config_fixability = line_map.get("CONFIG_FIXABILITY", "")
+        citation_ids = [
+            value.strip()
+            for value in re.split(r"[,\\s]+", line_map.get("CITATION_IDS", ""))
+            if value.strip()
+        ]
 
-    if not rationale_paragraph:
-        raise ValueError(f"Triage explainer output missing RATIONALE_PARAGRAPH: {raw_text}")
-    if not evidence_quote:
-        raise ValueError(f"Triage explainer output missing EVIDENCE_QUOTE: {raw_text}")
-    if config_fixability not in CONFIG_FIXABILITY_OPTIONS:
-        raise ValueError(
-            f"Triage explainer output has invalid config_fixability '{config_fixability}'. "
-            f"Allowed: {CONFIG_FIXABILITY_OPTIONS}. Raw output: {raw_text}"
+        if not rationale_paragraph:
+            raise ValueError(f"Triage explainer output missing RATIONALE_PARAGRAPH: {raw_text}")
+        if not evidence_quote:
+            raise ValueError(f"Triage explainer output missing EVIDENCE_QUOTE: {raw_text}")
+        if config_fixability not in CONFIG_FIXABILITY_OPTIONS:
+            raise ValueError(
+                f"Triage explainer output has invalid config_fixability '{config_fixability}'. "
+                f"Allowed: {CONFIG_FIXABILITY_OPTIONS}. Raw output: {raw_text}"
+            )
+        citation_validation = validate_rubric_memory_citations(
+            citation_ids,
+            item_context.get("rubric_memory"),
+            require_citation=bool(item_context.get("rubric_memory", {}).get("citation_index")),
         )
-    citation_validation = validate_rubric_memory_citations(
-        citation_ids,
-        item_context.get("rubric_memory"),
-        require_citation=bool(item_context.get("rubric_memory", {}).get("citation_index")),
-    )
-    return {
-        "rationale_paragraph": _excerpt(rationale_paragraph, 320),
-        "evidence_quote": _excerpt(evidence_quote, 180),
-        "config_fixability": config_fixability,
-        "citation_ids": citation_validation.valid_ids,
-        "citation_validation": citation_validation.model_dump(mode="json"),
-    }
+        return {
+            "rationale_paragraph": _excerpt(rationale_paragraph, 320),
+            "evidence_quote": _excerpt(evidence_quote, 180),
+            "config_fixability": config_fixability,
+            "citation_ids": citation_validation.valid_ids,
+            "citation_validation": citation_validation.model_dump(mode="json"),
+        }
+
+    messages = [{"role": "user", "content": prompt}]
+    last_error: Optional[Exception] = None
+    for attempt in range(2):
+        raw_text = _invoke_rca_openai_text(
+            system=system,
+            messages=messages,
+            max_output_tokens=320,
+            call_site="rca_triage_explainer" if attempt == 0 else "rca_triage_explainer_repair",
+        )
+        try:
+            return _parse_explainer_text(raw_text)
+        except ValueError as exc:
+            last_error = exc
+            if attempt == 1:
+                break
+            messages = [
+                *messages,
+                {"role": "assistant", "content": raw_text[:1000]},
+                {
+                    "role": "user",
+                    "content": (
+                        "Your previous response did not match the required four-line schema. "
+                        "Return exactly RATIONALE_PARAGRAPH, EVIDENCE_QUOTE, CONFIG_FIXABILITY, "
+                        "and CITATION_IDS lines with no extra prose."
+                    ),
+                },
+            ]
+    raise last_error or ValueError("Invalid triage explainer output")
 
 
 def build_misclassification_analysis_summary(
@@ -1234,6 +1379,7 @@ def build_misclassification_analysis_summary(
     for raw in item_classifications_all:
         context = raw.get("misclassification_item_context") or {}
         availability = context.get("source_availability", {})
+        rubric_state = rubric_memory_state_from_item_context(context)
         row = {
             "topic_id": raw.get("topic_id"),
             "topic_label": raw.get("topic_label", ""),
@@ -1260,6 +1406,11 @@ def build_misclassification_analysis_summary(
             "config_fixability": raw.get("config_fixability", ""),
             "citation_ids": raw.get("citation_ids", []),
             "citation_validation": raw.get("citation_validation", {}),
+            "rubric_memory_available": bool(rubric_state["rubric_memory_available"]),
+            "citation_index_count": int(rubric_state["citation_index_count"]),
+            "rubric_memory_diagnostics": rubric_state["rubric_memory_diagnostics"],
+            "rca_failure": raw.get("rca_failure"),
+            "rca_failures": raw.get("rca_failures", []),
             "has_primary_input": bool(availability.get("has_primary_input")),
             "missing_required_context": bool(availability.get("missing_required_context_keys")),
             "detailed_cause": raw.get("detailed_cause"),
@@ -1739,15 +1890,13 @@ def analyze_score_result(
     )
 
     try:
-        def _gpt5_mini_call(messages: list[dict[str, str]], max_tokens: int) -> str:
-            return _invoke_rca_openai_text(
-                system=system,
-                messages=messages,
-                max_output_tokens=max_tokens,
-            )
-
         messages = [{"role": "user", "content": turn1_prompt}]
-        detailed_cause = _gpt5_mini_call(messages, max_tokens=200)
+        detailed_cause = _invoke_rca_openai_text(
+            system=system,
+            messages=messages,
+            max_output_tokens=200,
+            call_site="rca_score_result_detailed_cause",
+        )
 
         messages.append({"role": "assistant", "content": detailed_cause})
         messages.append({"role": "user", "content": (
@@ -1755,7 +1904,12 @@ def analyze_score_result(
             "suggest one concrete change to the score code that would prevent "
             "this specific misclassification. Be specific and brief (1-2 sentences)."
         )})
-        suggested_fix = _gpt5_mini_call(messages, max_tokens=150)
+        suggested_fix = _invoke_rca_openai_text(
+            system=system,
+            messages=messages,
+            max_output_tokens=150,
+            call_site="rca_score_result_suggested_fix",
+        )
 
         return detailed_cause, suggested_fix
     except Exception as exc:

--- a/plexus/rca_analysis_test.py
+++ b/plexus/rca_analysis_test.py
@@ -1,13 +1,23 @@
+import json
+import sys
+import types
+
+import pytest
+
 from plexus.rca_analysis import (
     CONFIG_FIXABILITY_OPTIONS,
     MECHANICAL_SUBTYPES,
     MISCLASSIFICATION_CATEGORIES,
     MISCLASSIFICATION_EXCLUDED_ANALYSES,
     MISCLASSIFICATION_LABEL_PROVENANCE_SOURCES,
+    _invoke_rca_openai_text,
+    build_rca_analysis_failure_classification,
     build_misclassification_analysis_summary,
     build_misclassification_classification_contract,
     build_misclassification_item_context,
     classify_misclassification_item,
+    explain_misclassification_item_classification,
+    extract_misclassification_evidence_flags,
     normalize_best_evidence_source,
 )
 
@@ -523,3 +533,186 @@ def test_misclassification_analysis_summary_contains_v2_contract_fields():
         assert isinstance(topic["example_item_ids"], list)
     mech_node = next(node for node in summary["category_hierarchy"] if node["category_key"] == "mechanical_malfunction")
     assert "mechanical_subtype_totals" in mech_node
+
+
+def test_build_rca_analysis_failure_classification_preserves_failed_item():
+    context = _base_item_context()
+    context["rubric_memory"] = {
+        "citation_index": [{"id": "rubric:version-1"}],
+        "diagnostics": [{"code": "ok"}],
+    }
+
+    result = build_rca_analysis_failure_classification(
+        item_context=context,
+        stage="evidence_flag_extraction",
+        exc=ValueError("empty model response"),
+    )
+
+    assert result["primary_category"] == "mechanical_malfunction"
+    assert result["mechanical_subtype"] == "rca_analysis_failure"
+    assert result["config_fixability"] == "blocked_by_mechanical"
+    assert result["rca_failure"]["failed_stage"] == "evidence_flag_extraction"
+    assert result["rca_failure"]["exception_type"] == "ValueError"
+    assert result["citation_ids"] == ["rubric:version-1"]
+    assert result["citation_validation"]["missing_ids"] == []
+
+
+def test_summary_retains_rca_failure_and_rubric_memory_state():
+    context = _base_item_context()
+    context["rubric_memory"] = {
+        "citation_index": [{"id": "rubric:version-1"}],
+        "diagnostics": [{"code": "rubric_memory_unavailable"}],
+    }
+    failure = {
+        "failed_stage": "explainer",
+        "exception_type": "ValueError",
+        "message": "invalid explainer output",
+    }
+
+    summary = build_misclassification_analysis_summary(
+        [],
+        item_classifications_all=[
+            {
+                "feedback_item_id": "fb-1",
+                "item_id": "item-1",
+                "timestamp": "2026-04-04T10:00:00Z",
+                "primary_category": "mechanical_malfunction",
+                "confidence": "low",
+                "mechanical_subtype": "rca_analysis_failure",
+                "config_fixability": "blocked_by_mechanical",
+                "misclassification_item_context": context,
+                "rca_failure": failure,
+                "rca_failures": [failure],
+            }
+        ],
+        analysis_scope={
+            "candidate_items_total": 1,
+            "classified_items_total": 1,
+            "texts_analyzed_total": 1,
+            "topics_found": 0,
+            "rca_item_failures_total": 1,
+        },
+    )
+
+    row = summary["item_classifications_all"][0]
+    assert row["rca_failure"] == failure
+    assert row["rca_failures"] == [failure]
+    assert row["rubric_memory_available"] is True
+    assert row["citation_index_count"] == 1
+    assert row["rubric_memory_diagnostics"] == [{"code": "rubric_memory_unavailable"}]
+    assert summary["analysis_scope"]["rca_item_failures_total"] == 1
+
+
+def test_extract_evidence_flags_retries_invalid_output(monkeypatch):
+    calls = []
+
+    def fake_invoke(*, call_site, **kwargs):
+        calls.append(call_site)
+        if len(calls) == 1:
+            return "{}"
+        return "\n".join([
+            "FLAG_EXTERNAL_INFORMATION_GAP: false",
+            "FLAG_GUIDELINE_GAP: false",
+            "FLAG_SYSTEM_MISSING_CONTEXT: false",
+            "FLAG_RUNTIME_OR_PARSER_FAILURE: true",
+            "FLAG_INVALID_OUTPUT_CLASS: false",
+            "FLAG_PREPROCESSING_EVIDENCE_LOSS: false",
+            "BEST_EVIDENCE_SOURCE: none",
+            "BEST_EVIDENCE_QUOTE:",
+        ])
+
+    monkeypatch.setattr("plexus.rca_analysis._invoke_rca_openai_text", fake_invoke)
+
+    result = extract_misclassification_evidence_flags(item_context=_base_item_context())
+
+    assert result["runtime_or_parsing_failure"] is True
+    assert calls == ["rca_evidence_flags", "rca_evidence_flags_repair"]
+
+
+def test_explainer_retries_invalid_output(monkeypatch):
+    calls = []
+
+    def fake_invoke(*, call_site, **kwargs):
+        calls.append(call_site)
+        if len(calls) == 1:
+            return "{}"
+        return "\n".join([
+            "RATIONALE_PARAGRAPH: The deterministic classification is preserved.",
+            "EVIDENCE_QUOTE: Runtime error: timeout",
+            "CONFIG_FIXABILITY: blocked_by_mechanical",
+            "CITATION_IDS:",
+        ])
+
+    monkeypatch.setattr("plexus.rca_analysis._invoke_rca_openai_text", fake_invoke)
+
+    classification = build_rca_analysis_failure_classification(
+        item_context=_base_item_context(),
+        stage="evidence_flag_extraction",
+        exc=ValueError("empty"),
+    )
+    result = explain_misclassification_item_classification(
+        item_context=_base_item_context(),
+        classification=classification,
+    )
+
+    assert result["config_fixability"] == "blocked_by_mechanical"
+    assert calls == ["rca_triage_explainer", "rca_triage_explainer_repair"]
+
+
+def test_invoke_rca_openai_text_captures_context(tmp_path, monkeypatch):
+    class FakeResponses:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(output_text="ok")
+
+    class FakeOpenAI:
+        def __init__(self):
+            self.responses = FakeResponses()
+
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=FakeOpenAI))
+    monkeypatch.setenv("PLEXUS_CAPTURE_LLM_CONTEXT_DIR", str(tmp_path))
+
+    result = _invoke_rca_openai_text(
+        system="system prompt",
+        messages=[{"role": "user", "content": "hello"}],
+        max_output_tokens=10,
+        call_site="rca_unit",
+    )
+
+    assert result == "ok"
+    json_files = list(tmp_path.glob("*.json"))
+    markdown_files = list(tmp_path.glob("*.md"))
+    assert len(json_files) == 1
+    assert len(markdown_files) == 1
+    payload = json.loads(json_files[0].read_text())
+    assert payload["agent_name"] == "RCA"
+    assert payload["call_site"] == "rca_unit"
+    assert [message["role"] for message in payload["messages"]] == ["SYSTEM", "USER"]
+
+
+def test_invoke_rca_openai_text_retries_empty_response(tmp_path, monkeypatch):
+    outputs = ["", "repaired"]
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(output_text=outputs.pop(0))
+
+    class FakeOpenAI:
+        def __init__(self):
+            self.responses = FakeResponses()
+
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=FakeOpenAI))
+    monkeypatch.setenv("PLEXUS_CAPTURE_LLM_CONTEXT_DIR", str(tmp_path))
+
+    result = _invoke_rca_openai_text(
+        system="system prompt",
+        messages=[{"role": "user", "content": "hello"}],
+        max_output_tokens=10,
+        call_site="rca_unit_empty",
+    )
+
+    assert result == "repaired"
+    payloads = [json.loads(path.read_text()) for path in tmp_path.glob("*.json")]
+    assert {payload["call_site"] for payload in payloads} == {
+        "rca_unit_empty",
+        "rca_unit_empty_retry_empty",
+    }

--- a/plexus/rubric_memory/__init__.py
+++ b/plexus/rubric_memory/__init__.py
@@ -26,6 +26,13 @@ from .preparation import PreparedRubricMemoryCorpus, RubricMemoryPreparedCorpusM
 from .provider import RubricMemoryContextProvider
 from .query_planner import RubricMemoryQueryPlan, RubricMemoryQueryPlanner
 from .retrieval import BiblicusRubricEvidenceRetriever, RubricEvidenceRetriever
+from .s3_corpus import (
+    RUBRIC_MEMORY_BUCKET_ENV_VAR,
+    S3RubricMemoryCorpusPaths,
+    S3RubricMemoryCorpusResolver,
+    S3RubricMemoryObject,
+    S3RubricMemorySource,
+)
 from .service import RubricEvidencePackService
 from .sme_question_gate import (
     RubricMemoryGatedSMEQuestion,
@@ -72,6 +79,11 @@ __all__ = [
     "RubricMemorySMEQuestionGateRequest",
     "RubricMemorySMEQuestionGateResult",
     "RubricMemorySMEQuestionGateService",
+    "RUBRIC_MEMORY_BUCKET_ENV_VAR",
+    "S3RubricMemoryCorpusPaths",
+    "S3RubricMemoryCorpusResolver",
+    "S3RubricMemoryObject",
+    "S3RubricMemorySource",
     "SMEQuestionAnswerStatus",
     "SMEQuestionGateAction",
     "TactusRubricMemorySMEQuestionGateSynthesizer",

--- a/plexus/rubric_memory/preparation.py
+++ b/plexus/rubric_memory/preparation.py
@@ -6,15 +6,19 @@ import shutil
 from dataclasses import dataclass
 from datetime import date, datetime, time, timezone
 from pathlib import Path
+from pathlib import PurePosixPath
 import re
 from typing import Any, Sequence
 
 from .local_corpus import LocalRubricMemorySource
+from .s3_corpus import S3RubricMemorySource
+
+RubricMemoryCorpusSource = LocalRubricMemorySource | S3RubricMemorySource
 
 
 @dataclass(frozen=True)
 class PreparedRubricMemoryCorpus:
-    """A prepared Biblicus corpus built from local rubric-memory source folders."""
+    """A prepared Biblicus corpus built from rubric-memory sources."""
 
     corpus_root: Path
     prepared_root: Path
@@ -27,7 +31,7 @@ class PreparedRubricMemoryCorpus:
 
 
 class RubricMemoryPreparedCorpusManager:
-    """Prepare local rubric-memory sources into a reusable Biblicus corpus."""
+    """Prepare rubric-memory sources into a reusable Biblicus corpus."""
 
     SIDECAR_SCHEMA_VERSION = "rubric-memory-sidecar-v1"
     _SIDECAR_SUFFIX = ".biblicus.yml"
@@ -49,17 +53,11 @@ class RubricMemoryPreparedCorpusManager:
     def prepare(
         self,
         *,
-        corpus_sources: Sequence[LocalRubricMemorySource],
+        corpus_sources: Sequence[RubricMemoryCorpusSource],
         retriever_id: str = "scan",
         force: bool = False,
     ) -> PreparedRubricMemoryCorpus:
-        sources = [
-            LocalRubricMemorySource(
-                root=source.root.resolve(),
-                scope_level=source.scope_level,
-            )
-            for source in corpus_sources
-        ]
+        sources = [self._normalize_source(source) for source in corpus_sources]
         for source in sources:
             self._validate_source(source)
 
@@ -98,8 +96,12 @@ class RubricMemoryPreparedCorpusManager:
         )
         for index, source in enumerate(sources):
             destination = corpus_root / f"{index:02d}-{source.scope_level}"
-            shutil.copytree(source.root, destination, ignore=self._ignore_generated)
-            self._write_metadata_sidecars(source, destination)
+            if isinstance(source, LocalRubricMemorySource):
+                shutil.copytree(source.root, destination, ignore=self._ignore_generated)
+                self._write_local_metadata_sidecars(source, destination)
+            else:
+                destination.mkdir(parents=True, exist_ok=True)
+                self._download_s3_source(source, destination)
 
         self._build_biblicus_snapshot(
             corpus_root=corpus_root,
@@ -163,34 +165,69 @@ class RubricMemoryPreparedCorpusManager:
     def _fingerprint_payload(
         self,
         *,
-        sources: Sequence[LocalRubricMemorySource],
+        sources: Sequence[RubricMemoryCorpusSource],
         retriever_id: str,
     ) -> dict[str, Any]:
         source_payloads = []
         file_payloads = []
         for source in sources:
-            source_payloads.append(
-                {
-                    "root": str(source.root),
-                    "scope_level": source.scope_level,
-                }
-            )
-            for file_path in self._source_files(source.root):
-                relative_path = file_path.relative_to(source.root)
-                stat = file_path.stat()
-                timestamp = self.infer_source_timestamp(relative_path)
-                file_payloads.append(
+            if isinstance(source, LocalRubricMemorySource):
+                source_payloads.append(
                     {
-                        "source_root": str(source.root),
+                        "source_type": "local",
+                        "root": str(source.root),
                         "scope_level": source.scope_level,
-                        "relative_path": relative_path.as_posix(),
-                        "size": stat.st_size,
-                        "mtime_ns": stat.st_mtime_ns,
-                        "source_timestamp": (
-                            timestamp.isoformat() if timestamp is not None else None
-                        ),
                     }
                 )
+                for file_path in self._source_files(source.root):
+                    relative_path = file_path.relative_to(source.root)
+                    stat = file_path.stat()
+                    timestamp = self.infer_source_timestamp(relative_path)
+                    file_payloads.append(
+                        {
+                            "source_type": "local",
+                            "source_root": str(source.root),
+                            "scope_level": source.scope_level,
+                            "relative_path": relative_path.as_posix(),
+                            "size": stat.st_size,
+                            "mtime_ns": stat.st_mtime_ns,
+                            "source_timestamp": (
+                                timestamp.isoformat() if timestamp is not None else None
+                            ),
+                        }
+                    )
+            else:
+                source_payloads.append(
+                    {
+                        "source_type": "s3",
+                        "bucket_name": source.bucket_name,
+                        "prefix": source.prefix,
+                        "scope_level": source.scope_level,
+                    }
+                )
+                for obj in source.objects:
+                    relative_path = self._s3_relative_path(source, obj.key)
+                    timestamp = self.infer_source_timestamp(relative_path)
+                    file_payloads.append(
+                        {
+                            "source_type": "s3",
+                            "bucket_name": source.bucket_name,
+                            "source_prefix": source.prefix,
+                            "scope_level": source.scope_level,
+                            "key": obj.key,
+                            "relative_path": relative_path.as_posix(),
+                            "size": obj.size,
+                            "etag": obj.etag,
+                            "last_modified": (
+                                obj.last_modified.isoformat()
+                                if obj.last_modified is not None
+                                else None
+                            ),
+                            "source_timestamp": (
+                                timestamp.isoformat() if timestamp is not None else None
+                            ),
+                        }
+                    )
         return {
             "retriever_id": retriever_id,
             "sidecar_schema_version": self.SIDECAR_SCHEMA_VERSION,
@@ -198,7 +235,7 @@ class RubricMemoryPreparedCorpusManager:
             "files": sorted(
                 file_payloads,
                 key=lambda item: (
-                    item["source_root"],
+                    item.get("source_root") or item.get("source_prefix"),
                     item["scope_level"],
                     item["relative_path"],
                 ),
@@ -236,7 +273,7 @@ class RubricMemoryPreparedCorpusManager:
                 ignored.append(name)
         return ignored
 
-    def _write_metadata_sidecars(
+    def _write_local_metadata_sidecars(
         self,
         source: LocalRubricMemorySource,
         destination_root: Path,
@@ -262,7 +299,39 @@ class RubricMemoryPreparedCorpusManager:
                 encoding="utf-8",
             )
 
-    def infer_source_timestamp(self, relative_path: Path) -> datetime | None:
+    def _download_s3_source(
+        self,
+        source: S3RubricMemorySource,
+        destination_root: Path,
+    ) -> None:
+        import boto3
+
+        s3_client = boto3.client("s3")
+        for obj in source.objects:
+            relative_path = self._s3_relative_path(source, obj.key)
+            destination_path = destination_root / Path(*relative_path.parts)
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+            s3_client.download_file(source.bucket_name, obj.key, str(destination_path))
+            metadata: dict[str, Any] = {
+                "scope_level": source.scope_level,
+                "source_uri": f"s3://{source.bucket_name}/{obj.key}",
+                "bucket_name": source.bucket_name,
+                "source_key": obj.key,
+            }
+            source_timestamp = self.infer_source_timestamp(relative_path)
+            if source_timestamp is not None:
+                metadata["source_timestamp"] = source_timestamp.isoformat()
+            destination_path.with_name(
+                destination_path.name + self._SIDECAR_SUFFIX
+            ).write_text(
+                json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+    def infer_source_timestamp(
+        self,
+        relative_path: Path | PurePosixPath,
+    ) -> datetime | None:
         for part in reversed(relative_path.parts[:-1]):
             if not self._DATE_FOLDER_PATTERN.match(part):
                 continue
@@ -272,7 +341,14 @@ class RubricMemoryPreparedCorpusManager:
                 return None
         return None
 
-    def _validate_source(self, source: LocalRubricMemorySource) -> None:
+    def _validate_source(self, source: RubricMemoryCorpusSource) -> None:
+        if isinstance(source, S3RubricMemorySource):
+            if not source.objects:
+                raise FileNotFoundError(
+                    "Rubric memory knowledge-base S3 prefix does not exist or has "
+                    f"no source files: s3://{source.bucket_name}/{source.prefix}"
+                )
+            return
         if not source.root.exists():
             raise FileNotFoundError(
                 f"Rubric memory knowledge-base folder does not exist: {source.root}"
@@ -281,6 +357,28 @@ class RubricMemoryPreparedCorpusManager:
             raise NotADirectoryError(
                 f"Rubric memory knowledge-base path is not a directory: {source.root}"
             )
+
+    def _normalize_source(
+        self,
+        source: RubricMemoryCorpusSource,
+    ) -> RubricMemoryCorpusSource:
+        if isinstance(source, LocalRubricMemorySource):
+            return LocalRubricMemorySource(
+                root=source.root.resolve(),
+                scope_level=source.scope_level,
+            )
+        return source
+
+    def _s3_relative_path(
+        self,
+        source: S3RubricMemorySource,
+        key: str,
+    ) -> PurePosixPath:
+        if not key.startswith(source.prefix):
+            raise ValueError(
+                f"S3 object key is outside rubric-memory source prefix: {key}"
+            )
+        return PurePosixPath(key[len(source.prefix) :])
 
     def _read_manifest(self, manifest_path: Path) -> dict[str, Any] | None:
         if not manifest_path.exists():

--- a/plexus/rubric_memory/provider.py
+++ b/plexus/rubric_memory/provider.py
@@ -7,11 +7,11 @@ from .citations import (
     RubricMemoryCitationContext,
     RubricMemoryCitationFormatter,
 )
-from .local_corpus import LocalRubricMemoryCorpusResolver
 from .models import RubricEvidencePackRequest
 from .models import RubricAuthority
 from .retrieval import BiblicusRubricEvidenceRetriever
 from .service import RubricEvidencePackService
+from .s3_corpus import S3RubricMemoryCorpusResolver
 from .synthesis import TactusRubricEvidenceSynthesizer
 
 
@@ -99,7 +99,7 @@ class RubricMemoryContextProvider:
     ) -> dict[str, RubricMemoryCitationContext]:
         """Retrieve citation context for existing LLM consumers without synthesis."""
         authority = await RubricAuthorityResolver(self.api_client).resolve(score_id)
-        retriever = BiblicusRubricEvidenceRetriever.from_local_score(
+        retriever = BiblicusRubricEvidenceRetriever.from_score(
             scorecard_name=scorecard_identifier,
             score_name=score_identifier,
         )
@@ -133,7 +133,7 @@ class RubricMemoryContextProvider:
         self,
         request: RubricEvidencePackRequest,
     ) -> RubricMemoryCitationContext:
-        retriever = BiblicusRubricEvidenceRetriever.from_local_score(
+        retriever = BiblicusRubricEvidenceRetriever.from_score(
             scorecard_name=request.scorecard_identifier,
             score_name=request.score_identifier,
         )
@@ -236,15 +236,15 @@ class RubricMemoryContextProvider:
         scorecard_identifier: str,
         score_identifier: str,
     ) -> dict[str, Any]:
-        paths = LocalRubricMemoryCorpusResolver().resolve(
+        paths = S3RubricMemoryCorpusResolver().resolve(
             scorecard_name=scorecard_identifier,
             score_name=score_identifier,
         )
         roots = [
             {
                 "scope_level": source.scope_level,
-                "path": str(source.root),
-                "exists": source.root.exists(),
+                "path": f"s3://{source.bucket_name}/{source.prefix}",
+                "exists": bool(source.objects),
             }
             for source in paths.sources
         ]

--- a/plexus/rubric_memory/retrieval.py
+++ b/plexus/rubric_memory/retrieval.py
@@ -10,9 +10,11 @@ from .local_corpus import LocalRubricMemoryCorpusResolver, LocalRubricMemorySour
 from .models import EvidenceClassification, EvidenceSnippet, RubricEvidencePackRequest
 from .preparation import (
     PreparedRubricMemoryCorpus,
+    RubricMemoryCorpusSource,
     RubricMemoryPreparedCorpusManager,
 )
 from .query_planner import RubricMemoryQueryPlan, RubricMemoryQueryPlanner
+from .s3_corpus import S3RubricMemoryCorpusResolver
 
 
 class RubricEvidenceRetriever(Protocol):
@@ -23,7 +25,7 @@ class RubricEvidenceRetriever(Protocol):
 
 
 class BiblicusRubricEvidenceRetriever:
-    """Retrieve rubric-memory evidence from one local Biblicus corpus folder."""
+    """Retrieve rubric-memory evidence from one prepared Biblicus corpus."""
 
     _SOURCE_POLICY_ANCHORS = {
         "required to confirm",
@@ -40,7 +42,7 @@ class BiblicusRubricEvidenceRetriever:
         self,
         corpus_root: str | Path | None = None,
         *,
-        corpus_sources: Sequence[LocalRubricMemorySource] | None = None,
+        corpus_sources: Sequence[RubricMemoryCorpusSource] | None = None,
         retriever_id: str = "scan",
         max_total_items: int = 16,
         maximum_total_characters: int = 60000,
@@ -60,13 +62,7 @@ class BiblicusRubricEvidenceRetriever:
                 )
             ]
         else:
-            self.corpus_sources = [
-                LocalRubricMemorySource(
-                    root=source.root.resolve(),
-                    scope_level=source.scope_level,
-                )
-                for source in corpus_sources
-            ]
+            self.corpus_sources = list(corpus_sources)
         self.retriever_id = retriever_id
         self.max_total_items = max_total_items
         self.maximum_total_characters = maximum_total_characters
@@ -92,6 +88,32 @@ class BiblicusRubricEvidenceRetriever:
         prepared_corpus_manager: RubricMemoryPreparedCorpusManager | None = None,
     ) -> "BiblicusRubricEvidenceRetriever":
         paths = LocalRubricMemoryCorpusResolver().resolve(
+            scorecard_name=scorecard_name,
+            score_name=score_name,
+        )
+        return cls(
+            corpus_sources=paths.sources,
+            retriever_id=retriever_id,
+            max_total_items=max_total_items,
+            maximum_total_characters=maximum_total_characters,
+            source_window_characters=source_window_characters,
+            prepared_corpus_manager=prepared_corpus_manager,
+        )
+
+    @classmethod
+    def from_score(
+        cls,
+        *,
+        scorecard_name: str,
+        score_name: str,
+        retriever_id: str = "scan",
+        max_total_items: int = 16,
+        maximum_total_characters: int = 60000,
+        source_window_characters: int = 6000,
+        prepared_corpus_manager: RubricMemoryPreparedCorpusManager | None = None,
+        s3_client: Any | None = None,
+    ) -> "BiblicusRubricEvidenceRetriever":
+        paths = S3RubricMemoryCorpusResolver(s3_client=s3_client).resolve(
             scorecard_name=scorecard_name,
             score_name=score_name,
         )
@@ -229,9 +251,28 @@ class BiblicusRubricEvidenceRetriever:
 
     def _source_uri_to_path(self, source_uri: str) -> Path | None:
         parsed = urlparse(source_uri)
-        if parsed.scheme != "file":
+        if parsed.scheme == "file":
+            return Path(unquote(parsed.path))
+        if parsed.scheme != "s3" or self.last_prepared_corpus is None:
             return None
-        return Path(unquote(parsed.path))
+        bucket_name = parsed.netloc
+        key = unquote(parsed.path.lstrip("/"))
+        for index, source in enumerate(self.last_prepared_corpus.sources):
+            if source.get("source_type") != "s3":
+                continue
+            if source.get("bucket_name") != bucket_name:
+                continue
+            prefix = str(source.get("prefix") or "")
+            if not key.startswith(prefix):
+                continue
+            relative = key[len(prefix) :]
+            if not relative:
+                continue
+            scope_level = str(source.get("scope_level") or "unknown")
+            return self.last_prepared_corpus.corpus_root / (
+                f"{index:02d}-{scope_level}"
+            ) / relative
+        return None
 
     def _strip_markdown_frontmatter(self, text: str) -> str:
         if not text.startswith("---\n"):

--- a/plexus/rubric_memory/rubric_evidence_pack_test.py
+++ b/plexus/rubric_memory/rubric_evidence_pack_test.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Sequence
 
@@ -32,6 +34,8 @@ from plexus.rubric_memory import (
     RubricMemorySMEQuestionGateService,
     SMEQuestionAnswerStatus,
     SMEQuestionGateAction,
+    S3RubricMemoryCorpusResolver,
+    S3RubricMemorySource,
     TactusRubricEvidenceSynthesizer,
     TactusRubricMemorySMEQuestionGateSynthesizer,
     candidate_agenda_items_from_markdown,
@@ -63,6 +67,96 @@ class _StaticRetriever:
         self, _request: RubricEvidencePackRequest
     ) -> Sequence[EvidenceSnippet]:
         return self.evidence
+
+
+class _FakeS3Paginator:
+    def __init__(self, client):
+        self.client = client
+
+    def paginate(self, **kwargs):
+        yield self.client.list_objects_v2(**kwargs)
+
+
+class _FakeS3Client:
+    def __init__(self):
+        self.objects: dict[str, dict] = {}
+        self.uploads: list[tuple[str, str]] = []
+        self.downloads: list[tuple[str, str]] = []
+
+    def put_text(
+        self,
+        key: str,
+        text: str,
+        *,
+        last_modified: datetime | None = None,
+        etag: str | None = None,
+    ) -> None:
+        body = text.encode("utf-8")
+        self.objects[key] = {
+            "Body": body,
+            "Size": len(body),
+            "ETag": etag or f"etag-{len(self.objects) + 1}",
+            "LastModified": (
+                last_modified or datetime(2026, 4, 24, tzinfo=timezone.utc)
+            ),
+        }
+
+    def get_paginator(self, operation_name: str):
+        assert operation_name == "list_objects_v2"
+        return _FakeS3Paginator(self)
+
+    def list_objects_v2(
+        self,
+        *,
+        Bucket: str,
+        Prefix: str,
+        Delimiter: str | None = None,
+    ) -> dict:
+        del Bucket
+        matching_keys = sorted(key for key in self.objects if key.startswith(Prefix))
+        if Delimiter:
+            common_prefixes = set()
+            contents = []
+            for key in matching_keys:
+                suffix = key[len(Prefix) :]
+                if Delimiter in suffix:
+                    common_prefixes.add(
+                        Prefix + suffix.split(Delimiter, 1)[0] + Delimiter
+                    )
+                else:
+                    contents.append(self._content(key))
+            return {
+                "CommonPrefixes": [
+                    {"Prefix": prefix} for prefix in sorted(common_prefixes)
+                ],
+                "Contents": contents,
+            }
+        return {"Contents": [self._content(key) for key in matching_keys]}
+
+    def upload_file(self, filename: str, bucket: str, key: str) -> None:
+        del bucket
+        self.uploads.append((filename, key))
+        body = Path(filename).read_bytes()
+        self.objects[key] = {
+            "Body": body,
+            "Size": len(body),
+            "ETag": f"upload-{len(self.uploads)}",
+            "LastModified": datetime(2026, 4, 24, tzinfo=timezone.utc),
+        }
+
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        del bucket
+        self.downloads.append((key, filename))
+        Path(filename).write_bytes(self.objects[key]["Body"])
+
+    def _content(self, key: str) -> dict:
+        obj = self.objects[key]
+        return {
+            "Key": key,
+            "Size": obj["Size"],
+            "ETag": obj["ETag"],
+            "LastModified": obj["LastModified"],
+        }
 
 
 class _CapturingSynthesizer:
@@ -436,14 +530,72 @@ def test_local_corpus_resolver_treats_missing_prefix_as_optional(
     assert [source.scope_level for source in paths.sources] == ["scorecard", "score"]
 
 
+def test_s3_corpus_resolver_maps_scorecard_prefix_and_score_roots(monkeypatch):
+    fake_s3 = _FakeS3Client()
+    fake_s3.put_text(
+        "SelectQuote HCS Medium-Risk/scorecard.knowledge-base/2026-04-01/source.md",
+        "Scorecard memory.",
+    )
+    fake_s3.put_text(
+        "SelectQuote HCS Medium-Risk/Medication Review.knowledge-base/2026-04-10/source.md",
+        "Prefix memory.",
+    )
+    fake_s3.put_text(
+        "SelectQuote HCS Medium-Risk/Medication Review- Dosage.knowledge-base/2026-04-24/source.md",
+        "Score memory.",
+    )
+    monkeypatch.setenv("AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME", "rubric-bucket")
+
+    paths = S3RubricMemoryCorpusResolver(s3_client=fake_s3).resolve(
+        scorecard_name="SelectQuote HCS Medium-Risk",
+        score_name="Medication Review: Dosage",
+    )
+
+    assert paths.bucket_name == "rubric-bucket"
+    assert paths.scorecard_knowledge_base_prefix == (
+        "SelectQuote HCS Medium-Risk/scorecard.knowledge-base/"
+    )
+    assert paths.prefix_knowledge_base_prefixes == [
+        "SelectQuote HCS Medium-Risk/Medication Review.knowledge-base/"
+    ]
+    assert paths.score_knowledge_base_prefix == (
+        "SelectQuote HCS Medium-Risk/Medication Review- Dosage.knowledge-base/"
+    )
+    assert [source.scope_level for source in paths.sources] == [
+        "scorecard",
+        "prefix",
+        "score",
+    ]
+
+
+def test_s3_corpus_resolver_requires_scorecard_and_score_prefixes(monkeypatch):
+    fake_s3 = _FakeS3Client()
+    fake_s3.put_text(
+        "SelectQuote HCS Medium-Risk/scorecard.knowledge-base/2026-04-01/source.md",
+        "Scorecard memory.",
+    )
+    monkeypatch.setenv("AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME", "rubric-bucket")
+
+    with pytest.raises(FileNotFoundError, match="Medication Review- Dosage"):
+        S3RubricMemoryCorpusResolver(s3_client=fake_s3).resolve(
+            scorecard_name="SelectQuote HCS Medium-Risk",
+            score_name="Medication Review: Dosage",
+        )
+
+
 def test_rubric_memory_prewarm_cli_reports_prepared_corpus(
     monkeypatch,
     tmp_path,
 ):
+    import boto3
+
+    fake_s3 = _FakeS3Client()
+    monkeypatch.setattr(boto3, "client", lambda service_name: fake_s3)
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
         cache_root = tmp_path / "dashboard" / "scorecards"
         monkeypatch.setenv("SCORECARD_CACHE_DIR", str(cache_root))
+        monkeypatch.setenv("AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME", "rubric-bucket")
         paths = LocalRubricMemoryCorpusResolver().resolve(
             scorecard_name="SelectQuote HCS Medium-Risk",
             score_name="Medication Review: Dosage",
@@ -466,6 +618,17 @@ def test_rubric_memory_prewarm_cli_reports_prepared_corpus(
         prefix_file.write_text("Medication review policy memory.", encoding="utf-8")
         score_file.write_text("Dosage-specific policy memory.", encoding="utf-8")
 
+        sync_result = runner.invoke(
+            cli,
+            [
+                "rubric-memory",
+                "sync",
+                "--scorecard",
+                "SelectQuote HCS Medium-Risk",
+                "--score",
+                "Medication Review: Dosage",
+            ],
+        )
         first = runner.invoke(
             cli,
             [
@@ -489,10 +652,17 @@ def test_rubric_memory_prewarm_cli_reports_prepared_corpus(
             ],
         )
 
+    assert sync_result.exit_code == 0, sync_result.output
+    assert "uploaded_file_count: 3" in sync_result.output
+    assert any(
+        key.endswith("Medication Review- Dosage.knowledge-base/2026-04-24/dosage.md")
+        for _filename, key in fake_s3.uploads
+    )
     assert first.exit_code == 0, first.output
     assert second.exit_code == 0, second.output
     assert "status: rebuilt" in first.output
     assert "status: reused" in second.output
+    assert "bucket: rubric-bucket" in first.output
     assert "retriever_id: scan" in first.output
     assert "fingerprint:" in first.output
     assert "prepared_corpus_path:" in first.output
@@ -502,6 +672,26 @@ def test_rubric_memory_prewarm_cli_reports_prepared_corpus(
     assert "included_knowledge_base[score]:" in first.output
     assert "Medication Review- Dosage.knowledge-base" in first.output
     assert "Medication Review.knowledge-base" in first.output
+
+
+def test_rubric_memory_prewarm_cli_requires_s3_bucket(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.delenv("AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME", raising=False)
+
+    result = runner.invoke(
+        cli,
+        [
+            "rubric-memory",
+            "prewarm",
+            "--scorecard",
+            "SelectQuote HCS Medium-Risk",
+            "--score",
+            "Medication Review: Dosage",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME" in result.output
 
 
 def test_query_planner_derives_retrieval_phrases_from_request():
@@ -747,6 +937,106 @@ def test_prepared_corpus_combines_scorecard_prefix_and_score_scopes(tmp_path):
     assert scorecard_metadata["source_timestamp"] == "2026-04-01T00:00:00"
     assert prefix_metadata["source_timestamp"] == "2026-04-10T00:00:00"
     assert score_metadata["source_timestamp"] == "2026-04-24T00:00:00"
+
+
+def test_prepared_corpus_downloads_s3_objects_with_sidecar_metadata(
+    monkeypatch,
+    tmp_path,
+):
+    import boto3
+
+    fake_s3 = _FakeS3Client()
+    fake_s3.put_text(
+        "SelectQuote HCS Medium-Risk/scorecard.knowledge-base/2026-04-01/source.md",
+        "S3 scorecard note.",
+    )
+    fake_s3.put_text(
+        "SelectQuote HCS Medium-Risk/Medication Review- Dosage.knowledge-base/2026-04-24/client/source.md",
+        "S3 dosage calibration note.",
+        etag="source-etag",
+    )
+    monkeypatch.setattr(boto3, "client", lambda service_name: fake_s3)
+    source = S3RubricMemorySource(
+        bucket_name="rubric-bucket",
+        prefix="SelectQuote HCS Medium-Risk/Medication Review- Dosage.knowledge-base/",
+        scope_level="score",
+        objects=tuple(
+            S3RubricMemoryCorpusResolver(
+                bucket_name="rubric-bucket",
+                s3_client=fake_s3,
+            )
+            .resolve(
+                scorecard_name="SelectQuote HCS Medium-Risk",
+                score_name="Medication Review: Dosage",
+            )
+            .sources[-1]
+            .objects
+        ),
+    )
+
+    prepared = RubricMemoryPreparedCorpusManager(
+        cache_root=tmp_path / "prepared"
+    ).prepare(corpus_sources=[source])
+    copied_file = (
+        prepared.corpus_root / "00-score" / "2026-04-24" / "client" / "source.md"
+    )
+    metadata = json.loads(
+        copied_file.with_name("source.md.biblicus.yml").read_text(encoding="utf-8")
+    )
+
+    assert "S3 dosage calibration note." in copied_file.read_text(encoding="utf-8")
+    assert (
+        fake_s3.objects[
+            "SelectQuote HCS Medium-Risk/Medication Review- Dosage.knowledge-base/2026-04-24/client/source.md"
+        ]["Body"]
+        == b"S3 dosage calibration note."
+    )
+    assert metadata["scope_level"] == "score"
+    assert metadata["source_uri"] == (
+        "s3://rubric-bucket/SelectQuote HCS Medium-Risk/"
+        "Medication Review- Dosage.knowledge-base/2026-04-24/client/source.md"
+    )
+    assert metadata["bucket_name"] == "rubric-bucket"
+    assert metadata["source_timestamp"] == "2026-04-24T00:00:00"
+    assert prepared.sources[0]["source_type"] == "s3"
+    assert prepared.source_file_count == 1
+
+
+def test_prepared_corpus_rebuilds_when_s3_etag_changes(monkeypatch, tmp_path):
+    import boto3
+
+    fake_s3 = _FakeS3Client()
+    fake_s3.put_text(
+        "SelectQuote HCS Medium-Risk/scorecard.knowledge-base/2026-04-01/source.md",
+        "S3 scorecard note.",
+    )
+    key = (
+        "SelectQuote HCS Medium-Risk/Medication Review- Dosage.knowledge-base/"
+        "2026-04-24/source.md"
+    )
+    fake_s3.put_text(key, "S3 dosage calibration note.", etag="etag-1")
+    monkeypatch.setattr(boto3, "client", lambda service_name: fake_s3)
+
+    resolver = S3RubricMemoryCorpusResolver(
+        bucket_name="rubric-bucket",
+        s3_client=fake_s3,
+    )
+    first_source = resolver.resolve(
+        scorecard_name="SelectQuote HCS Medium-Risk",
+        score_name="Medication Review: Dosage",
+    ).sources[-1]
+    manager = RubricMemoryPreparedCorpusManager(cache_root=tmp_path / "prepared")
+    first = manager.prepare(corpus_sources=[first_source])
+
+    fake_s3.put_text(key, "S3 dosage calibration note.", etag="etag-2")
+    second_source = resolver.resolve(
+        scorecard_name="SelectQuote HCS Medium-Risk",
+        score_name="Medication Review: Dosage",
+    ).sources[-1]
+    second = manager.prepare(corpus_sources=[second_source])
+
+    assert second.status == "rebuilt"
+    assert second.fingerprint != first.fingerprint
 
 
 def test_prepared_corpus_rejects_missing_knowledge_base_folder(tmp_path):
@@ -1095,7 +1385,7 @@ async def test_context_provider_records_prepared_corpus_and_query_plan_diagnosti
     retriever = _DiagnosticRetriever()
 
     monkeypatch.setattr(
-        "plexus.rubric_memory.provider.BiblicusRubricEvidenceRetriever.from_local_score",
+        "plexus.rubric_memory.provider.BiblicusRubricEvidenceRetriever.from_score",
         lambda **_kwargs: retriever,
     )
     monkeypatch.setattr(
@@ -1164,7 +1454,7 @@ async def test_context_provider_retrieves_item_context_without_synthesis(monkeyp
         _AuthorityResolver,
     )
     monkeypatch.setattr(
-        "plexus.rubric_memory.provider.BiblicusRubricEvidenceRetriever.from_local_score",
+        "plexus.rubric_memory.provider.BiblicusRubricEvidenceRetriever.from_score",
         lambda **_kwargs: created_retrievers.append(retriever) or retriever,
     )
     monkeypatch.setattr(

--- a/plexus/rubric_memory/s3_corpus.py
+++ b/plexus/rubric_memory/s3_corpus.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import PurePosixPath
+from typing import Any
+
+from plexus.cli.shared.shared import sanitize_path_name
+
+
+RUBRIC_MEMORY_BUCKET_ENV_VAR = "AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME"
+
+
+@dataclass(frozen=True)
+class S3RubricMemoryObject:
+    """One raw S3 object in a rubric-memory corpus source."""
+
+    key: str
+    size: int
+    etag: str
+    last_modified: datetime | None
+
+
+@dataclass(frozen=True)
+class S3RubricMemorySource:
+    """An S3 rubric-memory prefix with its score hierarchy scope."""
+
+    bucket_name: str
+    prefix: str
+    scope_level: str
+    objects: tuple[S3RubricMemoryObject, ...]
+
+
+@dataclass(frozen=True)
+class S3RubricMemoryCorpusPaths:
+    """Convention-derived S3 rubric-memory prefixes for one score."""
+
+    bucket_name: str
+    scorecard_prefix: str
+    scorecard_knowledge_base_prefix: str
+    prefix_knowledge_base_prefixes: list[str]
+    score_knowledge_base_prefix: str
+    sources: list[S3RubricMemorySource]
+
+
+class S3RubricMemoryCorpusResolver:
+    """Resolve rubric-memory S3 prefixes using the name-based hierarchy."""
+
+    def __init__(
+        self,
+        *,
+        bucket_name: str | None = None,
+        s3_client: Any | None = None,
+    ):
+        self.bucket_name = bucket_name or os.environ.get(RUBRIC_MEMORY_BUCKET_ENV_VAR)
+        if not self.bucket_name:
+            raise ValueError(
+                f"Missing required environment variable: {RUBRIC_MEMORY_BUCKET_ENV_VAR}"
+            )
+        if s3_client is None:
+            import boto3
+
+            s3_client = boto3.client("s3")
+        self.s3_client = s3_client
+
+    def resolve(
+        self,
+        *,
+        scorecard_name: str,
+        score_name: str,
+    ) -> S3RubricMemoryCorpusPaths:
+        scorecard_prefix = self._prefix(scorecard_name)
+        scorecard_knowledge_base_prefix = (
+            f"{scorecard_prefix}scorecard.knowledge-base/"
+        )
+        score_knowledge_base_prefix = (
+            f"{scorecard_prefix}{sanitize_path_name(score_name)}.knowledge-base/"
+        )
+        prefix_knowledge_base_prefixes = self._matching_prefix_knowledge_bases(
+            scorecard_prefix=scorecard_prefix,
+            score_name=score_name,
+            score_knowledge_base_prefix=score_knowledge_base_prefix,
+        )
+        sources = [
+            self._source_for_prefix(
+                prefix=scorecard_knowledge_base_prefix,
+                scope_level="scorecard",
+                required=True,
+            ),
+            *[
+                self._source_for_prefix(
+                    prefix=prefix,
+                    scope_level="prefix",
+                    required=False,
+                )
+                for prefix in prefix_knowledge_base_prefixes
+            ],
+            self._source_for_prefix(
+                prefix=score_knowledge_base_prefix,
+                scope_level="score",
+                required=True,
+            ),
+        ]
+        sources = [source for source in sources if source.objects]
+        return S3RubricMemoryCorpusPaths(
+            bucket_name=self.bucket_name,
+            scorecard_prefix=scorecard_prefix,
+            scorecard_knowledge_base_prefix=scorecard_knowledge_base_prefix,
+            prefix_knowledge_base_prefixes=prefix_knowledge_base_prefixes,
+            score_knowledge_base_prefix=score_knowledge_base_prefix,
+            sources=sources,
+        )
+
+    def _matching_prefix_knowledge_bases(
+        self,
+        *,
+        scorecard_prefix: str,
+        score_name: str,
+        score_knowledge_base_prefix: str,
+    ) -> list[str]:
+        sanitized_score_name = sanitize_path_name(score_name)
+        candidates: list[str] = []
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(
+            Bucket=self.bucket_name,
+            Prefix=scorecard_prefix,
+            Delimiter="/",
+        ):
+            for common_prefix in page.get("CommonPrefixes", []):
+                prefix = str(common_prefix.get("Prefix") or "")
+                folder_name = PurePosixPath(prefix.rstrip("/")).name
+                if folder_name == "scorecard.knowledge-base":
+                    continue
+                if prefix == score_knowledge_base_prefix:
+                    continue
+                if not folder_name.endswith(".knowledge-base"):
+                    continue
+                stem = folder_name[: -len(".knowledge-base")]
+                if self._is_prefix_match(
+                    prefix=stem,
+                    sanitized_score_name=sanitized_score_name,
+                ):
+                    candidates.append(prefix)
+
+        return sorted(
+            set(candidates),
+            key=lambda prefix: (
+                -len(PurePosixPath(prefix.rstrip("/")).name),
+                prefix,
+            ),
+        )
+
+    def _source_for_prefix(
+        self,
+        *,
+        prefix: str,
+        scope_level: str,
+        required: bool,
+    ) -> S3RubricMemorySource:
+        objects = tuple(self._objects_for_prefix(prefix))
+        if required and not objects:
+            raise FileNotFoundError(
+                "Rubric memory knowledge-base S3 prefix does not exist or has "
+                f"no source files: s3://{self.bucket_name}/{prefix}"
+            )
+        return S3RubricMemorySource(
+            bucket_name=self.bucket_name,
+            prefix=prefix,
+            scope_level=scope_level,
+            objects=objects,
+        )
+
+    def _objects_for_prefix(self, prefix: str) -> list[S3RubricMemoryObject]:
+        objects: list[S3RubricMemoryObject] = []
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
+            for item in page.get("Contents", []):
+                key = str(item.get("Key") or "")
+                if not key or key.endswith("/"):
+                    continue
+                relative_path = PurePosixPath(key[len(prefix) :])
+                if self._is_generated_or_derived(relative_path):
+                    continue
+                objects.append(
+                    S3RubricMemoryObject(
+                        key=key,
+                        size=int(item.get("Size") or 0),
+                        etag=str(item.get("ETag") or "").strip('"'),
+                        last_modified=item.get("LastModified"),
+                    )
+                )
+        return sorted(objects, key=lambda obj: obj.key)
+
+    def _is_generated_or_derived(self, relative_path: PurePosixPath) -> bool:
+        if relative_path.name.endswith(".biblicus.yml"):
+            return True
+        return any(
+            part
+            in {
+                ".biblicus",
+                "analysis",
+                "extracted",
+                "graph",
+                "metadata",
+                "retrieval",
+            }
+            for part in relative_path.parts
+        )
+
+    def _prefix(self, scorecard_name: str) -> str:
+        cleaned = sanitize_path_name(scorecard_name).strip("/")
+        if not cleaned:
+            raise ValueError("scorecard_name must not be empty")
+        return f"{cleaned}/"
+
+    def _is_prefix_match(self, *, prefix: str, sanitized_score_name: str) -> bool:
+        if not prefix or not sanitized_score_name.startswith(prefix):
+            return False
+        if len(sanitized_score_name) == len(prefix):
+            return False
+        boundary = sanitized_score_name[len(prefix)]
+        return boundary in {" ", "-", "("}


### PR DESCRIPTION
## Summary

This PR finishes the next rubric-memory runtime slice and hardens RCA based on the real SelectQuote validation failure we observed.

### Rubric memory S3 runtime
- Adds S3-backed rubric-memory corpus resolution using `AMPLIFY_STORAGE_RUBRICMEMORY_BUCKET_NAME` as the single runtime source of truth.
- Preserves the canonical scorecard / prefix / score `.knowledge-base` hierarchy in S3.
- Downloads S3 corpus objects into prepared local working corpora under `tmp/rubric-memory/prepared/...` with sidecar metadata and fingerprint reuse.
- Extends rubric-memory CLI support for S3 sync/prewarm and documents the scorecard KB structure.

### RCA reliability and observability
- RCA now preserves failed item rows instead of dropping them, using `mechanical_malfunction` / `rca_analysis_failure` with stage/type/message diagnostics.
- RCA records per-item rubric-memory availability, citation index counts, citation IDs, citation validation, and failure diagnostics in the full artifact.
- RCA LLM calls use the durable context-capture helper when `PLEXUS_CAPTURE_LLM_CONTEXT_DIR` is set.
- GPT-5 mini empty/invalid responses retry once and then produce deterministic mechanical diagnostics instead of aborting item classification.
- RCA now injects retrieval-only rubric-memory citation context, not per-item synthesized evidence packs.

## Real validation

Ran a real feedback evaluation for:

- Scorecard: `SelectQuote HCS Medium-Risk`
- Score: `Medication Review: Dosage`
- Version: `43f4c1bb-c56e-41f2-b503-9277284f4028`
- Evaluation: `123473cc-fe59-4035-b83e-493372313cd4`

Result:
- `root_cause.full.json` uploaded successfully.
- RCA produced `item_classifications_all: 2` and `topics: 1` instead of dropping all failed items.
- Both RCA rows had `rubric_memory_available=true`, `citation_index_count=17`, and S3 citation provenance including SelectRx script evidence.
- RCA context artifacts were captured under `tmp/llm-context/` and included retrieval-only rubric-memory citation context.

Known remaining issue: GPT-5 mini still returned empty responses for both RCA evidence-flag calls in this run. This PR makes that failure observable and non-destructive; improving the RCA prompt/model behavior should be a follow-up.

## Tests

- `PYTHONPATH=/Users/ryan/Projects/Plexus-3:/Users/ryan/Projects/Plexus-3/MCP pytest plexus/rca_analysis_test.py plexus/Evaluation_feedback_test.py::TestCompactRootCauseForParameters plexus/Evaluation_feedback_test.py::TestFeedbackEvaluation::test_rca_rubric_memory_context_uses_retrieval_only_provider plexus/rubric_memory/rubric_evidence_pack_test.py plexus/cli/procedure/logging_utils_test.py -q`
- `PYTHONPATH=/Users/ryan/Projects/Plexus-3:/Users/ryan/Projects/Plexus-3/MCP python -m py_compile plexus/cli/evaluation/evaluations.py plexus/Evaluation.py plexus/rca_analysis.py plexus/rubric_memory/s3_corpus.py plexus/rubric_memory/preparation.py plexus/rubric_memory/retrieval.py plexus/rubric_memory/provider.py`
- `flake8 plexus/rca_analysis.py plexus/Evaluation.py plexus/rca_analysis_test.py plexus/Evaluation_feedback_test.py plexus/rubric_memory plexus/cli/rubric_memory plexus/cli/procedure/logging_utils.py plexus/cli/procedure/logging_utils_test.py`
- `kbs validate`
