### PR TITLE
fix(console): remove worker plaintext credentials

### DIFF
--- a/dashboard/amplify/backend.ts
+++ b/dashboard/amplify/backend.ts
@@ -123,13 +123,11 @@ const taskDispatcherStack = new TaskDispatcherStack(
 );
 
 const resolvedDataApiUrl = (process.env.PLEXUS_API_URL || '').trim();
-const resolvedDataApiKey = (process.env.PLEXUS_API_KEY || '').trim();
 const consoleWorkerImageUri = (process.env.CONSOLE_WORKER_IMAGE_URI || '').trim();
-const consoleWorkerEnvironmentName = ((process.env.AWS_BRANCH || 'staging').trim().toLowerCase().replace(/[^a-z0-9-]/g, '-')) || 'staging';
-const resolvedAnthropicApiKey = (process.env.ANTHROPIC_API_KEY || '').trim();
+const consoleWorkerEnvironmentName = normalizeForResourceName(resolveEnvironmentName());
 
-if (!resolvedDataApiUrl || !resolvedDataApiKey) {
-    throw new Error('PLEXUS_API_URL and PLEXUS_API_KEY must be set for ConsoleRunWorkerStack deployment');
+if (!resolvedDataApiUrl) {
+    throw new Error('PLEXUS_API_URL must be set for ConsoleRunWorkerStack deployment');
 }
 
 if (!consoleWorkerImageUri) {
@@ -142,10 +140,8 @@ const consoleRunWorkerStack = new ConsoleChatResponderStack(
     {
         chatMessageTable,
         plexusApiUrl: resolvedDataApiUrl,
-        plexusApiKey: resolvedDataApiKey,
         workerImageUri: consoleWorkerImageUri,
         environmentName: consoleWorkerEnvironmentName,
-        anthropicApiKey: resolvedAnthropicApiKey,
     }
 );
 

--- a/dashboard/amplify/functions/consoleRunWorker/app.py
+++ b/dashboard/amplify/functions/consoleRunWorker/app.py
@@ -55,7 +55,9 @@ def _resolve_client() -> PlexusDashboardClient:
     api_url = str(os.getenv("PLEXUS_API_URL") or "").strip()
     if not api_url:
         raise RuntimeError("PLEXUS_API_URL is required")
-    os.environ["PLEXUS_GRAPHQL_AUTH_MODE"] = "iam"
+    auth_mode = str(os.getenv("PLEXUS_GRAPHQL_AUTH_MODE") or "").strip().lower()
+    if auth_mode != "iam":
+        raise RuntimeError("PLEXUS_GRAPHQL_AUTH_MODE must be iam")
     return PlexusDashboardClient(api_url=api_url)
 
 

--- a/dashboard/amplify/functions/consoleRunWorker/app.py
+++ b/dashboard/amplify/functions/consoleRunWorker/app.py
@@ -1,7 +1,10 @@
 import logging
+import json
 import os
+from functools import lru_cache
 from typing import Any, Dict
 
+import boto3
 from boto3.dynamodb.types import TypeDeserializer
 
 from plexus.console.chat_runtime import (
@@ -18,16 +21,42 @@ logger.setLevel(logging.INFO)
 deserializer = TypeDeserializer()
 
 
+@lru_cache(maxsize=1)
+def _load_provider_credentials() -> None:
+    secret_name = str(os.getenv("PLEXUS_CONFIG_SECRET_NAME") or "").strip()
+    if not secret_name:
+        raise RuntimeError("PLEXUS_CONFIG_SECRET_NAME is required")
+
+    response = boto3.client("secretsmanager").get_secret_value(SecretId=secret_name)
+    secret_string = response.get("SecretString")
+    if not secret_string:
+        raise RuntimeError("Plexus config secret must contain SecretString")
+
+    try:
+        config = json.loads(secret_string)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Plexus config secret must be valid JSON") from exc
+
+    openai_api_key = str(config.get("openai-api-key") or "").strip()
+    if not openai_api_key:
+        raise RuntimeError("Plexus config secret is missing openai-api-key")
+    os.environ["OPENAI_API_KEY"] = openai_api_key
+
+    anthropic_api_key = str(config.get("anthropic-api-key") or "").strip()
+    if anthropic_api_key:
+        os.environ["ANTHROPIC_API_KEY"] = anthropic_api_key
+
+
 def _deserialize_dynamo_item(raw: Dict[str, Any]) -> Dict[str, Any]:
     return {key: deserializer.deserialize(value) for key, value in raw.items()}
 
 
 def _resolve_client() -> PlexusDashboardClient:
     api_url = str(os.getenv("PLEXUS_API_URL") or "").strip()
-    api_key = str(os.getenv("PLEXUS_API_KEY") or "").strip()
-    if not api_url or not api_key:
-        raise RuntimeError("PLEXUS_API_URL and PLEXUS_API_KEY are required")
-    return PlexusDashboardClient(api_url=api_url, api_key=api_key)
+    if not api_url:
+        raise RuntimeError("PLEXUS_API_URL is required")
+    os.environ["PLEXUS_GRAPHQL_AUTH_MODE"] = "iam"
+    return PlexusDashboardClient(api_url=api_url)
 
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -41,6 +70,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     )
     request_id = getattr(context, "aws_request_id", None)
     owner = build_response_owner(expected_target, request_id=request_id)
+    _load_provider_credentials()
     client = _resolve_client()
 
     failures = []

--- a/dashboard/amplify/functions/consoleRunWorker/app_test.py
+++ b/dashboard/amplify/functions/consoleRunWorker/app_test.py
@@ -165,14 +165,27 @@ def test_resolve_client_uses_iam_auth_without_api_key(monkeypatch):
             created.append(api_url)
 
     monkeypatch.setenv("PLEXUS_API_URL", "https://example.appsync-api.us-west-2.amazonaws.com/graphql")
+    monkeypatch.setenv("PLEXUS_GRAPHQL_AUTH_MODE", "iam")
     monkeypatch.delenv("PLEXUS_API_KEY", raising=False)
-    monkeypatch.delenv("PLEXUS_GRAPHQL_AUTH_MODE", raising=False)
     monkeypatch.setattr(app, "PlexusDashboardClient", FakeClient)
 
     app._resolve_client()
 
     assert created == ["https://example.appsync-api.us-west-2.amazonaws.com/graphql"]
-    assert app.os.environ["PLEXUS_GRAPHQL_AUTH_MODE"] == "iam"
+
+
+def test_resolve_client_requires_iam_auth_mode(monkeypatch):
+    app = _load_app_module()
+
+    monkeypatch.setenv("PLEXUS_API_URL", "https://example.appsync-api.us-west-2.amazonaws.com/graphql")
+    monkeypatch.delenv("PLEXUS_GRAPHQL_AUTH_MODE", raising=False)
+
+    try:
+        app._resolve_client()
+    except RuntimeError as exc:
+        assert "PLEXUS_GRAPHQL_AUTH_MODE must be iam" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
 
 
 def test_load_provider_credentials_sets_openai_and_optional_anthropic(monkeypatch):

--- a/dashboard/amplify/functions/consoleRunWorker/app_test.py
+++ b/dashboard/amplify/functions/consoleRunWorker/app_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -42,6 +43,7 @@ def test_handler_processes_cloud_targeted_insert(monkeypatch):
     calls = []
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "cloud")
+    monkeypatch.setattr(app, "_load_provider_credentials", lambda: None)
     monkeypatch.setattr(app, "_resolve_client", SimpleNamespace)
     monkeypatch.setattr(
         app,
@@ -62,6 +64,7 @@ def test_handler_skips_local_target_when_cloud_worker_does_not_claim(monkeypatch
     app = _load_app_module()
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "cloud")
+    monkeypatch.setattr(app, "_load_provider_credentials", lambda: None)
     monkeypatch.setattr(app, "_resolve_client", SimpleNamespace)
     monkeypatch.setattr(app, "process_console_message", lambda *_args, **_kwargs: False)
 
@@ -79,6 +82,7 @@ def test_handler_ignores_non_insert_records(monkeypatch):
     app = _load_app_module()
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "cloud")
+    monkeypatch.setattr(app, "_load_provider_credentials", lambda: None)
     monkeypatch.setattr(app, "_resolve_client", SimpleNamespace)
 
     result = app.handler(
@@ -94,6 +98,7 @@ def test_handler_reports_partial_batch_failure_when_processing_raises(monkeypatc
     app = _load_app_module()
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "cloud")
+    monkeypatch.setattr(app, "_load_provider_credentials", lambda: None)
     monkeypatch.setattr(app, "_resolve_client", SimpleNamespace)
 
     def fail_processing(*_args, **_kwargs):
@@ -112,6 +117,7 @@ def test_handler_skips_insert_without_new_image(monkeypatch):
     app = _load_app_module()
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "cloud")
+    monkeypatch.setattr(app, "_load_provider_credentials", lambda: None)
     monkeypatch.setattr(app, "_resolve_client", SimpleNamespace)
 
     result = app.handler(
@@ -136,7 +142,8 @@ def test_handler_duplicate_stream_delivery_counts_only_one_processed(monkeypatch
     outcomes = iter([True, False])
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "cloud")
-    monkeypatch.setattr(app, "_resolve_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(app, "_load_provider_credentials", lambda: None)
+    monkeypatch.setattr(app, "_resolve_client", SimpleNamespace)
     monkeypatch.setattr(app, "process_console_message", lambda *_args, **_kwargs: next(outcomes))
 
     result = app.handler(
@@ -147,3 +154,68 @@ def test_handler_duplicate_stream_delivery_counts_only_one_processed(monkeypatch
     assert result["processed"] == 1
     assert result["skipped"] == 1
     assert result["batchItemFailures"] == []
+
+
+def test_resolve_client_uses_iam_auth_without_api_key(monkeypatch):
+    app = _load_app_module()
+    created = []
+
+    class FakeClient:
+        def __init__(self, *, api_url):
+            created.append(api_url)
+
+    monkeypatch.setenv("PLEXUS_API_URL", "https://example.appsync-api.us-west-2.amazonaws.com/graphql")
+    monkeypatch.delenv("PLEXUS_API_KEY", raising=False)
+    monkeypatch.delenv("PLEXUS_GRAPHQL_AUTH_MODE", raising=False)
+    monkeypatch.setattr(app, "PlexusDashboardClient", FakeClient)
+
+    app._resolve_client()
+
+    assert created == ["https://example.appsync-api.us-west-2.amazonaws.com/graphql"]
+    assert app.os.environ["PLEXUS_GRAPHQL_AUTH_MODE"] == "iam"
+
+
+def test_load_provider_credentials_sets_openai_and_optional_anthropic(monkeypatch):
+    app = _load_app_module()
+    app._load_provider_credentials.cache_clear()
+
+    class FakeSecretsManager:
+        def get_secret_value(self, *, SecretId):
+            assert SecretId == "plexus/production/config"
+            return {
+                "SecretString": json.dumps(
+                    {
+                        "openai-api-key": "test-openai-key",
+                        "anthropic-api-key": "test-anthropic-key",
+                    }
+                )
+            }
+
+    monkeypatch.setenv("PLEXUS_CONFIG_SECRET_NAME", "plexus/production/config")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(app.boto3, "client", lambda service_name: FakeSecretsManager())
+
+    app._load_provider_credentials()
+
+    assert app.os.environ["OPENAI_API_KEY"] == "test-openai-key"
+    assert app.os.environ["ANTHROPIC_API_KEY"] == "test-anthropic-key"
+
+
+def test_load_provider_credentials_allows_missing_anthropic(monkeypatch):
+    app = _load_app_module()
+    app._load_provider_credentials.cache_clear()
+
+    class FakeSecretsManager:
+        def get_secret_value(self, *, SecretId):
+            return {"SecretString": json.dumps({"openai-api-key": "test-openai-key"})}
+
+    monkeypatch.setenv("PLEXUS_CONFIG_SECRET_NAME", "plexus/production/config")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(app.boto3, "client", lambda service_name: FakeSecretsManager())
+
+    app._load_provider_credentials()
+
+    assert app.os.environ["OPENAI_API_KEY"] == "test-openai-key"
+    assert "ANTHROPIC_API_KEY" not in app.os.environ

--- a/dashboard/amplify/functions/consoleRunWorker/local_worker_test.py
+++ b/dashboard/amplify/functions/consoleRunWorker/local_worker_test.py
@@ -78,7 +78,7 @@ def test_main_uses_next_public_response_target_from_env(monkeypatch):
     monkeypatch.delenv("CONSOLE_RESPONSE_TARGET", raising=False)
     monkeypatch.setenv("NEXT_PUBLIC_CONSOLE_RESPONSE_TARGET", "local:ryan")
     monkeypatch.setenv("CONSOLE_LOCAL_WORKER_IDLE_POLL_SECONDS", "0")
-    monkeypatch.setattr(worker, "_resolve_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(worker, "_resolve_client", SimpleNamespace)
     monkeypatch.setattr(worker, "_load_local_env", lambda: None)
     monkeypatch.setattr(
         worker,
@@ -105,7 +105,7 @@ def test_main_processes_pending_messages_with_local_owner(monkeypatch):
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "local:ryan")
     monkeypatch.setenv("CONSOLE_LOCAL_WORKER_IDLE_POLL_SECONDS", "0")
-    monkeypatch.setattr(worker, "_resolve_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(worker, "_resolve_client", SimpleNamespace)
     monkeypatch.setattr(
         worker,
         "process_pending_local_messages",
@@ -133,7 +133,7 @@ def test_main_drain_mode_only_sleeps_when_no_work(monkeypatch):
 
     monkeypatch.setenv("CONSOLE_RESPONSE_TARGET", "local:ryan")
     monkeypatch.setenv("CONSOLE_LOCAL_WORKER_IDLE_POLL_SECONDS", "0")
-    monkeypatch.setattr(worker, "_resolve_client", lambda: SimpleNamespace())
+    monkeypatch.setattr(worker, "_resolve_client", SimpleNamespace)
     monkeypatch.setattr(
         worker,
         "process_pending_local_messages",

--- a/dashboard/amplify/functions/consoleRunWorker/resource.ts
+++ b/dashboard/amplify/functions/consoleRunWorker/resource.ts
@@ -5,14 +5,13 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { StartingPosition } from "aws-cdk-lib/aws-lambda";
 import { DynamoEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { ITable } from "aws-cdk-lib/aws-dynamodb";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 
 interface ConsoleChatResponderStackProps extends NestedStackProps {
   chatMessageTable: ITable;
   plexusApiUrl?: string;
-  plexusApiKey?: string;
   workerImageUri?: string;
-  anthropicApiKey?: string;
   environmentName?: string;
 }
 
@@ -67,6 +66,13 @@ export class ConsoleChatResponderStack extends NestedStack {
     const workerImage = parseEcrImageUri(
       props.workerImageUri || process.env.CONSOLE_WORKER_IMAGE_URI || "",
     );
+    const environmentName = props.environmentName || "staging";
+    const configSecretName = `plexus/${environmentName}/config`;
+    const configSecret = secretsmanager.Secret.fromSecretNameV2(
+      this,
+      "PlexusConfigSecret",
+      configSecretName,
+    );
     const workerImageRepository = ecr.Repository.fromRepositoryName(
       this,
       "ConsoleRunWorkerImageRepository",
@@ -80,13 +86,15 @@ export class ConsoleChatResponderStack extends NestedStack {
       memorySize: 2048,
       environment: {
         PLEXUS_API_URL: props.plexusApiUrl || process.env.PLEXUS_API_URL || "",
-        PLEXUS_API_KEY: props.plexusApiKey || process.env.PLEXUS_API_KEY || "",
         PLEXUS_FETCH_SCHEMA_FROM_TRANSPORT: "false",
+        PLEXUS_GRAPHQL_AUTH_MODE: "iam",
+        PLEXUS_CONFIG_SECRET_NAME: configSecretName,
         PYTHONUNBUFFERED: "1",
-        ANTHROPIC_API_KEY: props.anthropicApiKey || process.env.ANTHROPIC_API_KEY || "",
         CONSOLE_RESPONSE_TARGET: "cloud",
       },
     });
+
+    configSecret.grantRead(this.responderFunction);
 
     this.responderFunction.addEventSource(new DynamoEventSource(props.chatMessageTable, {
       startingPosition: StartingPosition.LATEST,

--- a/poetry.lock
+++ b/poetry.lock
@@ -7988,6 +7988,24 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "requests-aws4auth"
+version = "1.3.1"
+description = "AWS4 authentication for Requests"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "requests_aws4auth-1.3.1-py3-none-any.whl", hash = "sha256:2969b5379ae6e60ee666638caf6cb94a32d67033f6bfcf0d50c95cd5474f2419"},
+    {file = "requests_aws4auth-1.3.1.tar.gz", hash = "sha256:b6ad4882310e03ba2538ebf94d1f001ca9feabc5c52618539cf1eb6d5af76791"},
+]
+
+[package.dependencies]
+requests = "*"
+
+[package.extras]
+httpx = ["httpx"]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 description = "A utility belt for advanced users of python-requests"
@@ -10487,4 +10505,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "e9aa6892c711be3ed0d5c506ea82038b370fca4d874b5c20a7c771923f015e79"
+content-hash = "111f62ea3bf8eb8b35f95a913842683c4cfcac9d402e10e803bf0b7daa0f100e"

--- a/project/events/2026-04-28T22:50:21.420Z__a7ffc121-d47a-4fd8-96dd-b5e42d396f72.json
+++ b/project/events/2026-04-28T22:50:21.420Z__a7ffc121-d47a-4fd8-96dd-b5e42d396f72.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "a7ffc121-d47a-4fd8-96dd-b5e42d396f72",
+  "issue_id": "plx-0e38eb7b-5f52-48a9-bf56-f4b152ba840e",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-28T22:50:21.420Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "initiative",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Production credential hygiene"
+  }
+}

--- a/project/events/2026-04-28T22:50:23.557Z__3e679dad-0c2c-4968-8241-4529914688b2.json
+++ b/project/events/2026-04-28T22:50:23.557Z__3e679dad-0c2c-4968-8241-4529914688b2.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "3e679dad-0c2c-4968-8241-4529914688b2",
+  "issue_id": "plx-1d6e6e95-e882-4751-afe3-6f4d37a2a9f3",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-28T22:50:23.557Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": "plx-0e38eb7b-5f52-48a9-bf56-f4b152ba840e",
+    "priority": 1,
+    "status": "open",
+    "title": "Eliminate hardcoded/env credentials in production workers"
+  }
+}

--- a/project/events/2026-04-28T22:50:27.437Z__75163b31-3add-482f-ad22-5d8d3dbfbc78.json
+++ b/project/events/2026-04-28T22:50:27.437Z__75163b31-3add-482f-ad22-5d8d3dbfbc78.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "75163b31-3add-482f-ad22-5d8d3dbfbc78",
+  "issue_id": "plx-c884b56d-210b-4178-aeeb-3aa4a25177bf",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-28T22:50:27.437Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "## Summary\nStop using API-key-based GraphQL auth and remove OpenAI API key from Lambda env vars for `consoleRunWorker`.\n\n## Scope\n- Replace AppSync API key usage with IAM-auth request signing where applicable.\n- Remove OpenAI API key from Lambda environment variables.\n- Read OpenAI key from `plexus/production/config` secret at runtime.\n- Keep one canonical auth/credential path (no fallback credential modes).\n\n## Done\n- No GraphQL API key dependency in `consoleRunWorker` production path.\n- No OpenAI API key in Lambda env configuration for this worker.\n- Runtime retrieves required key from Secrets Manager.\n- Changes merged and deployed to develop.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-1d6e6e95-e882-4751-afe3-6f4d37a2a9f3",
+    "priority": 1,
+    "status": "open",
+    "title": "Migrate consoleRunWorker GraphQL/OpenAI credentials to IAM + Secrets Manager"
+  }
+}

--- a/project/events/2026-04-28T22:50:30.310Z__6e6630cb-1b95-4edd-bed7-3779d91115f7.json
+++ b/project/events/2026-04-28T22:50:30.310Z__6e6630cb-1b95-4edd-bed7-3779d91115f7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6e6630cb-1b95-4edd-bed7-3779d91115f7",
+  "issue_id": "plx-c884b56d-210b-4178-aeeb-3aa4a25177bf",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-28T22:50:30.310Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-28T22:50:30.322Z__91647d9a-f348-4a30-bef5-df06513c3379.json
+++ b/project/events/2026-04-28T22:50:30.322Z__91647d9a-f348-4a30-bef5-df06513c3379.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "91647d9a-f348-4a30-bef5-df06513c3379",
+  "issue_id": "plx-c884b56d-210b-4178-aeeb-3aa4a25177bf",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T22:50:30.322Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "819d4faf-e5a6-4db2-a506-c2926cff64f1"
+  }
+}

--- a/project/events/2026-04-28T23:08:48.517Z__117e9f18-cc0a-4088-9d43-959fa7ace70e.json
+++ b/project/events/2026-04-28T23:08:48.517Z__117e9f18-cc0a-4088-9d43-959fa7ace70e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "117e9f18-cc0a-4088-9d43-959fa7ace70e",
+  "issue_id": "plx-c884b56d-210b-4178-aeeb-3aa4a25177bf",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T23:08:48.517Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "007cadfc-b8c6-4c59-b3e1-21a95d27ad53"
+  }
+}

--- a/project/events/2026-04-28T23:09:29.188Z__657709d3-7858-4e62-8e23-658d69dd4d68.json
+++ b/project/events/2026-04-28T23:09:29.188Z__657709d3-7858-4e62-8e23-658d69dd4d68.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "657709d3-7858-4e62-8e23-658d69dd4d68",
+  "issue_id": "plx-c884b56d-210b-4178-aeeb-3aa4a25177bf",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T23:09:29.188Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "26c70349-af20-483b-a719-24ffcfd502e8"
+  }
+}

--- a/project/events/2026-04-28T23:18:58.418Z__0de76c0c-0705-410e-9ef6-8cd8e41cd5f8.json
+++ b/project/events/2026-04-28T23:18:58.418Z__0de76c0c-0705-410e-9ef6-8cd8e41cd5f8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0de76c0c-0705-410e-9ef6-8cd8e41cd5f8",
+  "issue_id": "plx-c884b56d-210b-4178-aeeb-3aa4a25177bf",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T23:18:58.418Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "3ee01121-7739-4cb4-bab1-90f8854473df"
+  }
+}

--- a/project/issues/plx-0e38eb7b-5f52-48a9-bf56-f4b152ba840e.json
+++ b/project/issues/plx-0e38eb7b-5f52-48a9-bf56-f4b152ba840e.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-0e38eb7b-5f52-48a9-bf56-f4b152ba840e",
+  "title": "Production credential hygiene",
+  "description": "",
+  "type": "initiative",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-28T22:50:21.420718123Z",
+  "updated_at": "2026-04-28T22:50:21.420718123Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-1d6e6e95-e882-4751-afe3-6f4d37a2a9f3.json
+++ b/project/issues/plx-1d6e6e95-e882-4751-afe3-6f4d37a2a9f3.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-1d6e6e95-e882-4751-afe3-6f4d37a2a9f3",
+  "title": "Eliminate hardcoded/env credentials in production workers",
+  "description": "",
+  "type": "epic",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-0e38eb7b-5f52-48a9-bf56-f4b152ba840e",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-28T22:50:23.557512094Z",
+  "updated_at": "2026-04-28T22:50:23.557512094Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-c884b56d-210b-4178-aeeb-3aa4a25177bf.json
+++ b/project/issues/plx-c884b56d-210b-4178-aeeb-3aa4a25177bf.json
@@ -28,10 +28,16 @@
       "author": "derek",
       "text": "Pushed implementation and opened PR:\n- Branch: `feature/plx-c884b5-console-worker-iam-secrets`\n- Commit after rebase: `7a9a7468`\n- PR: https://github.com/AnthusAI/Plexus/pull/241\n\nValidation included in PR body:\n- Console worker Python tests: 15 passed.\n- Dashboard typecheck passed.\n- rcql consoleRunWorker scan passed with no reported findings.\n- poetry check --lock passed with existing deprecation warnings only.\n- git diff --check and py_compile passed.",
       "created_at": "2026-04-28T23:09:29.187441202Z"
+    },
+    {
+      "id": "3ee01121-7739-4cb4-bab1-90f8854473df",
+      "author": "derek",
+      "text": "Follow-up CI fix: changed consoleRunWorker app.py to require PLEXUS_GRAPHQL_AUTH_MODE=iam from the Lambda environment instead of mutating os.environ at runtime. This keeps the production path strict and prevents IAM auth mode from leaking into unrelated Python tests. Validation: targeted consoleRunWorker pytest passed (16 tests), app_test plus dashboard client regression guard passed (11 tests), rcql over consoleRunWorker Python files passed with no findings, git diff --check passed.",
+      "created_at": "2026-04-28T23:18:58.418304897Z"
     }
   ],
   "created_at": "2026-04-28T22:50:27.437588793Z",
-  "updated_at": "2026-04-28T23:09:29.187441202Z",
+  "updated_at": "2026-04-28T23:18:58.418304897Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-c884b56d-210b-4178-aeeb-3aa4a25177bf.json
+++ b/project/issues/plx-c884b56d-210b-4178-aeeb-3aa4a25177bf.json
@@ -22,10 +22,16 @@
       "author": "derek",
       "text": "Implemented consoleRunWorker credential cleanup on `feature/plx-c884b5-console-worker-iam-secrets`.\n\nCode changes:\n- Cloud Lambda `app.py` now uses AppSync IAM auth via `PLEXUS_GRAPHQL_AUTH_MODE=iam` and creates `PlexusDashboardClient` without an API key.\n- Cloud Lambda bootstraps provider credentials from `PLEXUS_CONFIG_SECRET_NAME` using Secrets Manager, setting `OPENAI_API_KEY` in-process from `openai-api-key` and optional `ANTHROPIC_API_KEY` from `anthropic-api-key`.\n- Amplify worker resource no longer injects `PLEXUS_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY` as Lambda environment variables.\n- Worker resource now injects `PLEXUS_CONFIG_SECRET_NAME` and grants read access to that secret.\n- Backend now maps `main` to `production` through existing environment mapping for secret name resolution.\n- Added `requests-aws4auth` to root dependencies so the existing dashboard client IAM auth path is available in the worker image.\n- Cleaned up the reported CodeQL `py/unnecessary-lambda` test findings.\n\nValidation completed:\n- Console worker Python tests: 15 passed.\n- Dashboard typecheck: passed.\n- `rcql --lang python -q -v --files \"dashboard/amplify/functions/consoleRunWorker/*.py\"`: passed with no reported findings.\n- `poetry check --lock`: exit 0 with existing Poetry metadata deprecation warnings only.\n- `git diff --check`: passed.\n- `py_compile` for changed Python files: passed.",
       "created_at": "2026-04-28T23:08:48.517882390Z"
+    },
+    {
+      "id": "26c70349-af20-483b-a719-24ffcfd502e8",
+      "author": "derek",
+      "text": "Pushed implementation and opened PR:\n- Branch: `feature/plx-c884b5-console-worker-iam-secrets`\n- Commit after rebase: `7a9a7468`\n- PR: https://github.com/AnthusAI/Plexus/pull/241\n\nValidation included in PR body:\n- Console worker Python tests: 15 passed.\n- Dashboard typecheck passed.\n- rcql consoleRunWorker scan passed with no reported findings.\n- poetry check --lock passed with existing deprecation warnings only.\n- git diff --check and py_compile passed.",
+      "created_at": "2026-04-28T23:09:29.187441202Z"
     }
   ],
   "created_at": "2026-04-28T22:50:27.437588793Z",
-  "updated_at": "2026-04-28T23:08:48.517882390Z",
+  "updated_at": "2026-04-28T23:09:29.187441202Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-c884b56d-210b-4178-aeeb-3aa4a25177bf.json
+++ b/project/issues/plx-c884b56d-210b-4178-aeeb-3aa4a25177bf.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-c884b56d-210b-4178-aeeb-3aa4a25177bf",
+  "title": "Migrate consoleRunWorker GraphQL/OpenAI credentials to IAM + Secrets Manager",
+  "description": "## Summary\nStop using API-key-based GraphQL auth and remove OpenAI API key from Lambda env vars for `consoleRunWorker`.\n\n## Scope\n- Replace AppSync API key usage with IAM-auth request signing where applicable.\n- Remove OpenAI API key from Lambda environment variables.\n- Read OpenAI key from `plexus/production/config` secret at runtime.\n- Keep one canonical auth/credential path (no fallback credential modes).\n\n## Done\n- No GraphQL API key dependency in `consoleRunWorker` production path.\n- No OpenAI API key in Lambda env configuration for this worker.\n- Runtime retrieves required key from Secrets Manager.\n- Changes merged and deployed to develop.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-1d6e6e95-e882-4751-afe3-6f4d37a2a9f3",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "819d4faf-e5a6-4db2-a506-c2926cff64f1",
+      "author": "derek",
+      "text": "Starting implementation. First step: create feature branch from develop, then inspect consoleRunWorker GraphQL auth + OpenAI credential wiring to remove env/API-key usage in production path.",
+      "created_at": "2026-04-28T22:50:30.322653256Z"
+    },
+    {
+      "id": "007cadfc-b8c6-4c59-b3e1-21a95d27ad53",
+      "author": "derek",
+      "text": "Implemented consoleRunWorker credential cleanup on `feature/plx-c884b5-console-worker-iam-secrets`.\n\nCode changes:\n- Cloud Lambda `app.py` now uses AppSync IAM auth via `PLEXUS_GRAPHQL_AUTH_MODE=iam` and creates `PlexusDashboardClient` without an API key.\n- Cloud Lambda bootstraps provider credentials from `PLEXUS_CONFIG_SECRET_NAME` using Secrets Manager, setting `OPENAI_API_KEY` in-process from `openai-api-key` and optional `ANTHROPIC_API_KEY` from `anthropic-api-key`.\n- Amplify worker resource no longer injects `PLEXUS_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY` as Lambda environment variables.\n- Worker resource now injects `PLEXUS_CONFIG_SECRET_NAME` and grants read access to that secret.\n- Backend now maps `main` to `production` through existing environment mapping for secret name resolution.\n- Added `requests-aws4auth` to root dependencies so the existing dashboard client IAM auth path is available in the worker image.\n- Cleaned up the reported CodeQL `py/unnecessary-lambda` test findings.\n\nValidation completed:\n- Console worker Python tests: 15 passed.\n- Dashboard typecheck: passed.\n- `rcql --lang python -q -v --files \"dashboard/amplify/functions/consoleRunWorker/*.py\"`: passed with no reported findings.\n- `poetry check --lock`: exit 0 with existing Poetry metadata deprecation warnings only.\n- `git diff --check`: passed.\n- `py_compile` for changed Python files: passed.",
+      "created_at": "2026-04-28T23:08:48.517882390Z"
+    }
+  ],
+  "created_at": "2026-04-28T22:50:27.437588793Z",
+  "updated_at": "2026-04-28T23:08:48.517882390Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ hdbscan = "0.8.40"
 sentence-transformers = ">=5.0.0"
 kaleido = ">=0.2.1"
 requests = ">=2.31.0"
+requests-aws4auth = "*"
 
 [tool.poetry.group.dev.dependencies]
 invoke = ">=2.2.0"


### PR DESCRIPTION
## Summary
Move the production ConsoleRunWorker away from plaintext Lambda environment credentials. The cloud worker now uses AppSync IAM auth and reads LLM provider keys from the Plexus environment config secret at runtime.

## Changes
- Create `PlexusDashboardClient` in IAM mode without `PLEXUS_API_KEY` in the cloud Lambda path.
- Load `openai-api-key` and optional `anthropic-api-key` from `plexus/{environment}/config` via Secrets Manager and set provider env vars only in-process.
- Remove `PLEXUS_API_KEY`, `OPENAI_API_KEY`, and `ANTHROPIC_API_KEY` from ConsoleRunWorker Lambda environment configuration.
- Add `PLEXUS_CONFIG_SECRET_NAME` and `PLEXUS_GRAPHQL_AUTH_MODE=iam` to the worker environment.
- Grant the worker read access to the configured Plexus config secret.
- Map `main` to `production` for the worker secret name using existing backend environment resolution.
- Add `requests-aws4auth` to root dependencies so the existing dashboard client IAM auth path is available in the worker image.
- Clean up console worker test lambdas flagged by CodeQL.

## Validation
- `python -m pytest -q dashboard/amplify/functions/consoleRunWorker/app_test.py dashboard/amplify/functions/consoleRunWorker/local_worker_test.py`
- `npm run typecheck -- --pretty false` from `dashboard/`
- `rcql --lang python -q -v --files "dashboard/amplify/functions/consoleRunWorker/*.py"`
- `poetry check --lock`
- `git diff --check`
- `python -m py_compile` for changed console worker Python files

## Kanbus
- `plx-c884b5`