### PR TITLE
Console chat: hidden-until-named sessions + turn-2 title context

### DIFF
--- a/dashboard/components/ui/__tests__/conversation-viewer-session-routing.test.tsx
+++ b/dashboard/components/ui/__tests__/conversation-viewer-session-routing.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 
 import ConversationViewer, { type ChatMessage, type ChatSession } from "../conversation-viewer"
 import { getClient } from "@/utils/data-operations"
@@ -128,6 +128,26 @@ jest.mock("@/components/ai-elements/tool", () => ({
   }) => <div>{errorText || output}</div>,
 }))
 
+jest.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode
+    onSelect?: (event: { preventDefault: () => void }) => void
+  }) => (
+    <button
+      type="button"
+      onClick={() => onSelect?.({ preventDefault: () => undefined })}
+    >
+      {children}
+    </button>
+  ),
+}))
+
 if (typeof window !== "undefined" && !("ResizeObserver" in window)) {
   ;(window as any).ResizeObserver = class {
     observe() {}
@@ -148,6 +168,7 @@ describe("ConversationViewer session-routing states", () => {
       id: "session-1",
       accountId: "acct-1",
       procedureId: "builtin:console/chat",
+      name: "Console Chat",
       category: "Console Chat",
       createdAt: "2026-03-27T00:00:00.000Z",
       updatedAt: "2026-03-27T00:00:00.000Z",
@@ -283,5 +304,139 @@ describe("ConversationViewer session-routing states", () => {
 
     expect(sidebarHeader.className).toContain("h-12")
     expect(mainHeader.className).toContain("h-12")
+  })
+
+  it("does not use category as visible session title fallback", () => {
+    render(
+      <ConversationViewer
+        sessions={[
+          {
+            id: "sess-optimize-1234",
+            accountId: "acct-1",
+            procedureId: "builtin:console/chat",
+            category: "Optimize",
+            createdAt: "2026-03-27T00:00:00.000Z",
+            updatedAt: "2026-03-27T00:00:00.000Z",
+            messageCount: 0,
+          },
+        ]}
+        messages={[]}
+        selectedSessionId="sess-optimize-1234"
+        defaultSidebarCollapsed={false}
+      />
+    )
+
+    expect(screen.queryByText("Optimize")).not.toBeInTheDocument()
+    expect(screen.getAllByText("Session sess-opt")).not.toHaveLength(0)
+  })
+
+  it("hides unnamed sessions that are marked hidden-until-named", () => {
+    render(
+      <ConversationViewer
+        sessions={[
+          {
+            id: "hidden-sess-1",
+            accountId: "acct-1",
+            procedureId: "builtin:console/chat",
+            category: "Optimize",
+            metadata: {
+              console: {
+                hidden_until_named: true,
+              },
+            },
+            createdAt: "2026-03-27T00:00:00.000Z",
+            updatedAt: "2026-03-27T00:00:00.000Z",
+            messageCount: 0,
+          },
+        ]}
+        messages={[]}
+        selectedSessionId="hidden-sess-1"
+        defaultSidebarCollapsed={false}
+      />
+    )
+
+    expect(screen.getByText("Chat Sessions (0)")).toBeInTheDocument()
+    const sidebar = screen.getByTestId("conversation-sidebar-header").parentElement as HTMLElement
+    expect(within(sidebar).queryByText("Session hidden-s")).not.toBeInTheDocument()
+    expect(screen.getByTestId("conversation-main-header")).toHaveTextContent("New Chat")
+  })
+
+  it("keeps unnamed sessions visible when hidden flag is absent", () => {
+    render(
+      <ConversationViewer
+        sessions={[
+          {
+            id: "legacy-unnamed-1",
+            accountId: "acct-1",
+            procedureId: "builtin:console/chat",
+            category: "Optimize",
+            createdAt: "2026-03-27T00:00:00.000Z",
+            updatedAt: "2026-03-27T00:00:00.000Z",
+            messageCount: 0,
+          },
+        ]}
+        messages={[]}
+        selectedSessionId="legacy-unnamed-1"
+        defaultSidebarCollapsed={false}
+      />
+    )
+
+    expect(screen.getByText("Chat Sessions (1)")).toBeInTheDocument()
+    expect(screen.getAllByText("Session legacy-u").length).toBeGreaterThan(0)
+  })
+
+  it("renames a session from the action menu and marks title source manual", async () => {
+    const updateMock = jest.fn().mockResolvedValue({
+      data: {
+        id: "session-1",
+        name: "My Renamed Session",
+      },
+    })
+
+    mockedGetClient.mockReturnValue({
+      models: {
+        ChatSession: {
+          update: updateMock,
+        },
+      },
+    } as any)
+
+    render(
+      <ConversationViewer
+        sessions={sessions}
+        messages={messages}
+        selectedSessionId="session-1"
+        defaultSidebarCollapsed={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "More options" }))
+    fireEvent.click(await screen.findByText("Rename session"))
+
+    const input = await screen.findByPlaceholderText("Session title")
+    fireEvent.change(input, { target: { value: "My Renamed Session" } })
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      const updateArg = updateMock.mock.calls[0]?.[0] || {}
+      const metadataArg = updateArg.metadata
+      const parsedMetadata = typeof metadataArg === "string" ? JSON.parse(metadataArg) : metadataArg
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "session-1",
+          name: "My Renamed Session",
+        })
+      )
+      expect(parsedMetadata).toEqual(
+        expect.objectContaining({
+          title_source: "manual",
+          console: expect.objectContaining({
+            hidden_until_named: false,
+          }),
+        })
+      )
+    })
+
+    expect(screen.getAllByText("My Renamed Session")).not.toHaveLength(0)
   })
 })

--- a/dashboard/components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx
+++ b/dashboard/components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx
@@ -35,9 +35,11 @@ jest.mock("react-virtuoso", () => {
 })
 
 const mockChatSessionList = jest.fn()
+const mockChatSessionGet = jest.fn()
 const mockChatMessageList = jest.fn()
 const mockChatMessageCreate = jest.fn()
 const mockChatSessionOnCreate = jest.fn()
+const mockChatSessionOnUpdate = jest.fn()
 const mockChatMessageOnCreate = jest.fn()
 const mockChatMessageOnUpdate = jest.fn()
 const mockGraphql = jest.fn()
@@ -47,7 +49,9 @@ const mockClient = {
   models: {
     ChatSession: {
       listChatSessionByProcedureIdAndCreatedAt: mockChatSessionList,
+      get: mockChatSessionGet,
       onCreate: mockChatSessionOnCreate,
+      onUpdate: mockChatSessionOnUpdate,
     },
     ChatMessage: {
       listChatMessageByProcedureIdAndCreatedAt: mockChatMessageList,
@@ -209,19 +213,23 @@ if (typeof window !== "undefined" && !("ResizeObserver" in window)) {
 
 describe("ConversationViewer streaming updates", () => {
   const subscriptions = {
+    sessionUpdate: null as null | { next: (payload: any) => void; error?: (error: Error) => void },
     messageCreate: null as null | { next: (payload: any) => void; error?: (error: Error) => void },
     messageUpdate: null as null | { next: (payload: any) => void; error?: (error: Error) => void },
   }
 
   beforeEach(() => {
     mockScrollToIndex.mockReset()
+    subscriptions.sessionUpdate = null
     subscriptions.messageCreate = null
     subscriptions.messageUpdate = null
 
     mockChatSessionList.mockReset()
     mockChatMessageList.mockReset()
     mockChatMessageCreate.mockReset()
+    mockChatSessionGet.mockReset()
     mockChatSessionOnCreate.mockReset()
+    mockChatSessionOnUpdate.mockReset()
     mockChatMessageOnCreate.mockReset()
     mockChatMessageOnUpdate.mockReset()
     mockGraphql.mockReset()
@@ -240,6 +248,7 @@ describe("ConversationViewer streaming updates", () => {
       ],
       nextToken: null,
     })
+    mockChatSessionGet.mockResolvedValue({ data: null })
 
     mockChatMessageList.mockResolvedValue({
       data: [
@@ -268,6 +277,12 @@ describe("ConversationViewer streaming updates", () => {
 
     mockChatSessionOnCreate.mockReturnValue({
       subscribe: () => ({ unsubscribe: jest.fn() }),
+    })
+    mockChatSessionOnUpdate.mockReturnValue({
+      subscribe: (handlers: { next: (payload: any) => void; error?: (error: Error) => void }) => {
+        subscriptions.sessionUpdate = handlers
+        return { unsubscribe: jest.fn() }
+      },
     })
 
     mockChatMessageOnCreate.mockReturnValue({
@@ -526,6 +541,108 @@ describe("ConversationViewer streaming updates", () => {
     const metadata = JSON.parse(createdMessage.metadata)
     expect(metadata.model.id).toBe("gpt-5.3")
     expect(metadata.instrumentation.client_selected_model).toBe("gpt-5.3")
+  })
+
+  it("reveals hidden-until-named sessions after session update notifications", async () => {
+    let currentSessionRows = [
+      {
+        id: "sess-hidden",
+        accountId: "acct-1",
+        procedureId: "proc-1",
+        category: "Optimize",
+        metadata: JSON.stringify({ console: { hidden_until_named: true } }),
+        createdAt: "2026-03-27T00:00:00.000Z",
+        updatedAt: "2026-03-27T00:00:00.000Z",
+      },
+    ]
+    mockChatSessionList.mockImplementation(async () => ({
+      data: currentSessionRows,
+      nextToken: null,
+    }))
+
+    render(
+      <ConversationViewer
+        experimentId="proc-1"
+        defaultSidebarCollapsed={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("Chat Sessions (0)")).toBeInTheDocument()
+    })
+
+    currentSessionRows = [
+      {
+        id: "sess-hidden",
+        accountId: "acct-1",
+        procedureId: "proc-1",
+        name: "Coverage Session",
+        category: "Optimize",
+        metadata: JSON.stringify({ console: { hidden_until_named: false } }),
+        createdAt: "2026-03-27T00:00:00.000Z",
+        updatedAt: "2026-03-27T00:00:30.000Z",
+      },
+    ]
+
+    await act(async () => {
+      subscriptions.sessionUpdate?.next({ data: { id: "sess-hidden" } })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Chat Sessions (1)")).toBeInTheDocument()
+      expect(screen.getAllByText("Coverage Session").length).toBeGreaterThan(0)
+    })
+  })
+
+  it("clears selection instead of auto-selecting a different session when active session disappears", async () => {
+    let currentSessionRows = [
+      {
+        id: "sess-1",
+        accountId: "acct-1",
+        procedureId: "proc-1",
+        name: "Current Session",
+        category: "Optimize",
+        createdAt: "2026-03-27T00:00:00.000Z",
+        updatedAt: "2026-03-27T00:00:00.000Z",
+      },
+    ]
+    mockChatSessionList.mockImplementation(async () => ({
+      data: currentSessionRows,
+      nextToken: null,
+    }))
+
+    render(
+      <ConversationViewer
+        experimentId="proc-1"
+        defaultSidebarCollapsed={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Current Session").length).toBeGreaterThan(0)
+    })
+
+    currentSessionRows = [
+      {
+        id: "sess-2",
+        accountId: "acct-1",
+        procedureId: "proc-1",
+        name: "Different Session",
+        category: "Optimize",
+        createdAt: "2026-03-27T00:01:00.000Z",
+        updatedAt: "2026-03-27T00:01:00.000Z",
+      },
+    ]
+
+    await act(async () => {
+      subscriptions.sessionUpdate?.next({ data: { id: "sess-2" } })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("No session selected")).toBeInTheDocument()
+      expect(screen.getByText("Chat Sessions (1)")).toBeInTheDocument()
+      expect(screen.queryByText("Different Session")).toBeInTheDocument()
+    })
   })
 
   it("renders TOOL_CALL and TOOL_RESPONSE as separate Tool components", async () => {

--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -45,6 +45,7 @@ import {
   PanelLeftClose,
   ChevronDownIcon,
   MoreHorizontal,
+  Pencil,
   Trash2,
   AlertCircle,
   Plus
@@ -61,6 +62,15 @@ import {
   parseMessageMetadata,
 } from "@/lib/procedure-hitl"
 import { cn } from "@/lib/utils"
+import { Input } from "@/components/ui/input"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 
 const EvaluationToolOutput = React.lazy(() => import('./evaluation-tool-output'))
 const STANDARD_SESSION_CATEGORY = 'Optimize'
@@ -114,6 +124,7 @@ export interface ChatSession {
   procedureId?: string
   name?: string
   category?: string
+  metadata?: any
   createdAt: string
   updatedAt?: string
   messageCount?: number
@@ -208,6 +219,72 @@ const parseJsonField = (value: unknown): any => {
   } catch {
     return undefined
   }
+}
+
+const parseSessionMetadata = (value: unknown): Record<string, any> => {
+  const parsed = parseJsonField(value)
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as Record<string, any>
+  }
+  return {}
+}
+
+const serializeSessionMetadata = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    return trimmed || undefined
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
+}
+
+const getSessionDisplayName = (session: Pick<ChatSession, "id" | "name">): string => {
+  const explicitName = String(session.name || "").trim()
+  if (explicitName) {
+    return explicitName
+  }
+  const sessionId = String(session.id || "").trim()
+  if (!sessionId) {
+    return "New Chat"
+  }
+  return `Session ${sessionId.slice(0, 8)}`
+}
+
+const getSessionHeaderTitle = (session: Pick<ChatSession, "id" | "name" | "metadata">): string => {
+  const explicitName = String(session.name || "").trim()
+  if (explicitName) {
+    return explicitName
+  }
+  if (isHiddenUntilNamedSession(session)) {
+    return "New Chat"
+  }
+  const sessionId = String(session.id || "").trim()
+  if (!sessionId) {
+    return "New Chat"
+  }
+  return `Session ${sessionId.slice(0, 8)}`
+}
+
+const isHiddenUntilNamedSession = (session: Pick<ChatSession, "name" | "metadata">): boolean => {
+  const explicitName = String(session.name || "").trim()
+  if (explicitName) {
+    return false
+  }
+  const metadata = parseSessionMetadata(session.metadata)
+  const consoleMetadata = metadata.console
+  if (!consoleMetadata || typeof consoleMetadata !== "object") {
+    return false
+  }
+  return Boolean((consoleMetadata as { hidden_until_named?: boolean }).hidden_until_named)
 }
 
 const getErrorMessage = (error: unknown, fallback: string): string => {
@@ -1260,6 +1337,7 @@ function ConversationViewer({
   
   // Internal state for data loading mode
   const [internalSessions, setInternalSessions] = useState<ChatSession[]>([])
+  const [sessionOverridesById, setSessionOverridesById] = useState<Record<string, Partial<ChatSession>>>({})
   const [internalMessages, setInternalMessages] = useState<ChatMessage[]>([])
   const [internalSelectedSessionId, setInternalSelectedSessionId] = useState<string>()
   const [isLoading, setIsLoading] = useState(false)
@@ -1272,6 +1350,9 @@ function ConversationViewer({
   const [selectedModel, setSelectedModel] = useState(DEFAULT_CONSOLE_CHAT_MODEL)
   const [isPromptSubmitting, setIsPromptSubmitting] = useState(false)
   const [isCreatingSession, setIsCreatingSession] = useState(false)
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false)
+  const [renameSessionValue, setRenameSessionValue] = useState("")
+  const [isRenamingSession, setIsRenamingSession] = useState(false)
   const [pendingAssistantBySession, setPendingAssistantBySession] = useState<Record<string, PendingAssistantState>>({})
   const selectedSessionIdRef = React.useRef<string | undefined>(undefined)
   const promptSubmitLockRef = React.useRef(false)
@@ -1314,7 +1395,14 @@ function ConversationViewer({
   }, [maxSidebarWidth])
 
   // Determine which data source to use
-  const sessions = propSessions || internalSessions
+  const baseSessions = propSessions || internalSessions
+  const sessions = React.useMemo(
+    () => baseSessions.map((session) => ({
+      ...session,
+      ...(sessionOverridesById[session.id] || {}),
+    })),
+    [baseSessions, sessionOverridesById]
+  )
   const messages = propMessages || internalMessages  
   const selectedSessionId = propSelectedSessionId || internalSelectedSessionId
   const isExternallyControlledSession = Boolean(propSelectedSessionId?.trim())
@@ -1647,6 +1735,7 @@ function ConversationViewer({
             procedureId: session.procedureId,
             name: session.name,
             category: session.category,
+            metadata: parseSessionMetadata(session.metadata),
             createdAt: session.createdAt,
             updatedAt: session.updatedAt,
             messageCount: 0 // Will be updated when we load messages
@@ -1773,6 +1862,7 @@ function ConversationViewer({
             procedureId: session.procedureId,
             name: session.name,
             category: session.category,
+            metadata: parseSessionMetadata(session.metadata),
             createdAt: session.createdAt,
             updatedAt: session.updatedAt,
             messageCount: 0 // Will be updated when we load messages
@@ -1805,6 +1895,7 @@ function ConversationViewer({
                   previous.updatedAt !== session.updatedAt
                   || previous.name !== session.name
                   || previous.category !== session.category
+                  || JSON.stringify(previous.metadata || {}) !== JSON.stringify(session.metadata || {})
                 )
               })
 
@@ -1817,9 +1908,15 @@ function ConversationViewer({
               ? mergedSessions.some(session => session.id === currentSelectedSessionId)
               : false
 
-            if (!selectedStillExists && !isExternallyControlledSession && mergedSessions.length > 0) {
-              const newestSessionId = mergedSessions[0].id
-              setInternalSelectedSessionId(newestSessionId)
+            if (!selectedStillExists && !isExternallyControlledSession) {
+              if (currentSelectedSessionId) {
+                // Preserve a neutral sidebar state when the active session is temporarily
+                // unavailable (for example hidden-until-named sessions during refresh lag).
+                setInternalSelectedSessionId(undefined)
+              } else if (mergedSessions.length > 0) {
+                const newestSessionId = mergedSessions[0].id
+                setInternalSelectedSessionId(newestSessionId)
+              }
             }
 
             return mergedSessions
@@ -1838,9 +1935,12 @@ function ConversationViewer({
     const pollTimer = window.setInterval(checkForNewSessions, 15000)
     checkForNewSessions()
 
+    let createSubscription: { unsubscribe: () => void } | null = null
+    let updateSubscription: { unsubscribe: () => void } | null = null
+
     try {
       // @ts-ignore - Amplify Gen2 typing issue with subscriptions
-      const subscription = getClient().models.ChatSession.onCreate().subscribe({
+      createSubscription = getClient().models.ChatSession.onCreate().subscribe({
         next: () => {
           // Don't rely on the subscription data, just use it as a notification
           checkForNewSessions()
@@ -1849,24 +1949,43 @@ function ConversationViewer({
           if (markAuthUnavailable(error, 'session_on_create_subscription')) {
             return
           }
-          console.error('Chat session subscription error:', error)
+          console.error('Chat session create subscription error:', error)
         }
       })
-
-      return () => {
-        window.clearInterval(pollTimer)
-        subscription.unsubscribe()
-      }
     } catch (error) {
-      if (markAuthUnavailable(error, 'session_subscription_setup')) {
+      if (markAuthUnavailable(error, 'session_create_subscription_setup')) {
         return () => {
           window.clearInterval(pollTimer)
         }
       }
-      console.error('Error setting up chat session notification:', error)
+      console.error('Error setting up chat session create notification:', error)
+    }
+
+    try {
+      // @ts-ignore - Amplify Gen2 typing issue with subscriptions
+      updateSubscription = getClient().models.ChatSession.onUpdate().subscribe({
+        next: () => {
+          checkForNewSessions()
+        },
+        error: (error: Error) => {
+          if (markAuthUnavailable(error, 'session_on_update_subscription')) {
+            return
+          }
+          console.error('Chat session update subscription error:', error)
+        }
+      })
+    } catch (error) {
+      if (markAuthUnavailable(error, 'session_update_subscription_setup')) {
+        return () => {
+          window.clearInterval(pollTimer)
+        }
+      }
+      console.error('Error setting up chat session update notification:', error)
     }
     return () => {
       window.clearInterval(pollTimer)
+      createSubscription?.unsubscribe()
+      updateSubscription?.unsubscribe()
     }
   }, [effectiveId, isAuthUnavailable, isExternallyControlledSession, markAuthUnavailable, onSessionSelect])
 
@@ -2072,6 +2191,7 @@ function ConversationViewer({
     const bTime = new Date(b.updatedAt || b.createdAt).getTime()
     return bTime - aTime
   })
+  const visibleSessions = sortedSessions.filter((session) => !isHiddenUntilNamedSession(session))
 
   // Filter messages for selected session
   const filteredMessages = selectedSessionId
@@ -2200,6 +2320,64 @@ function ConversationViewer({
   )
   const canCreateSession = Boolean(fallbackSessionAccountId && fallbackSessionProcedureId)
 
+  const openRenameDialog = React.useCallback(() => {
+    if (!selectedSession) {
+      return
+    }
+    setRenameSessionValue((selectedSession.name || "").trim())
+    setRenameDialogOpen(true)
+  }, [selectedSession])
+
+  const handleRenameSession = React.useCallback(async () => {
+    if (!selectedSession || isRenamingSession) {
+      return
+    }
+    const nextName = renameSessionValue.trim()
+    if (!nextName) {
+      toast.error("Session title cannot be empty")
+      return
+    }
+    setIsRenamingSession(true)
+    try {
+      const client = getClient()
+      const updatedAt = new Date().toISOString()
+      const nextMetadata = {
+        ...parseSessionMetadata(selectedSession.metadata),
+        title_source: "manual",
+        console: {
+          ...(parseSessionMetadata(selectedSession.metadata).console || {}),
+          hidden_until_named: false,
+        },
+      }
+      await (client.models.ChatSession.update as any)({
+        id: selectedSession.id,
+        name: nextName,
+        metadata: serializeSessionMetadata(nextMetadata),
+        updatedAt,
+      })
+      setInternalSessions(prev => prev.map(session => (
+        session.id === selectedSession.id
+          ? { ...session, name: nextName, metadata: nextMetadata, updatedAt }
+          : session
+      )))
+      setSessionOverridesById(prev => ({
+        ...prev,
+        [selectedSession.id]: {
+          name: nextName,
+          metadata: nextMetadata,
+          updatedAt,
+        },
+      }))
+      setRenameDialogOpen(false)
+      toast.success("Session renamed")
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to rename session"
+      toast.error(message)
+    } finally {
+      setIsRenamingSession(false)
+    }
+  }, [isRenamingSession, renameSessionValue, selectedSession])
+
   const handleAtBottomStateChange = React.useCallback((isNowAtBottom: boolean) => {
     setAtBottom(isNowAtBottom)
     if (isNowAtBottom) {
@@ -2256,17 +2434,20 @@ function ConversationViewer({
     }
   }, [selectedSessionId, shouldForceFollow, showThinkingPlaceholder])
 
-  const createNewSession = React.useCallback(async () => {
+  const createNewSession = React.useCallback(async (options?: { hiddenUntilNamed?: boolean }) => {
     if (!fallbackSessionAccountId || !fallbackSessionProcedureId) {
       throw new Error('Missing account or procedure context to create a session')
     }
 
     const client = getClient()
     const createdAt = new Date().toISOString()
+    const hiddenUntilNamed = Boolean(options?.hiddenUntilNamed)
+    const sessionMetadata = hiddenUntilNamed ? { console: { hidden_until_named: true } } : undefined
     const created = await (client.models.ChatSession.create as any)({
       accountId: fallbackSessionAccountId,
       procedureId: fallbackSessionProcedureId,
       category: STANDARD_SESSION_CATEGORY,
+      metadata: serializeSessionMetadata(sessionMetadata),
       createdAt,
       updatedAt: createdAt,
     })
@@ -2282,12 +2463,27 @@ function ConversationViewer({
       procedureId: fallbackSessionProcedureId,
       category: created?.data?.category || STANDARD_SESSION_CATEGORY,
       name: created?.data?.name,
+      metadata: parseSessionMetadata(created?.data?.metadata || sessionMetadata),
       createdAt: created?.data?.createdAt || createdAt,
       updatedAt: created?.data?.updatedAt || createdAt,
       messageCount: 0,
     }
 
     setInternalSessions(prev => [createdSession, ...prev.filter(session => session.id !== sessionId)])
+    if (hiddenUntilNamed) {
+      setSessionOverridesById(prev => ({
+        ...prev,
+        [sessionId]: {
+          metadata: {
+            ...parseSessionMetadata(createdSession.metadata),
+            console: {
+              ...(parseSessionMetadata(createdSession.metadata).console || {}),
+              hidden_until_named: true,
+            },
+          },
+        },
+      }))
+    }
     if (onSessionSelect) {
       onSessionSelect(sessionId)
     } else {
@@ -2311,7 +2507,7 @@ function ConversationViewer({
 
     setIsCreatingSession(true)
     try {
-      await createNewSession()
+      await createNewSession({ hiddenUntilNamed: true })
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to create session'
       console.error('[ConsoleChat] session create failed', {
@@ -2350,7 +2546,7 @@ function ConversationViewer({
 
         if (!targetSessionId) {
           try {
-            const newSession = await createNewSession()
+            const newSession = await createNewSession({ hiddenUntilNamed: true })
             targetSessionId = newSession.id
             targetSessionAccountId = newSession.accountId
             targetSessionProcedureId = newSession.procedureId
@@ -2539,7 +2735,7 @@ function ConversationViewer({
         {/* Sidebar Header */}
         <div data-testid="conversation-sidebar-header" className="h-12 px-3 border-b border-border flex items-center justify-between">
           {!isSidebarCollapsed && (
-            <h3 className="text-sm font-medium">Chat Sessions ({sortedSessions.length})</h3>
+            <h3 className="text-sm font-medium">Chat Sessions ({visibleSessions.length})</h3>
           )}
           <div className="flex items-center gap-1">
             {!isSidebarCollapsed && (
@@ -2572,7 +2768,7 @@ function ConversationViewer({
         {/* Session List */}
         {!isSidebarCollapsed && (
           <div className="flex-1 overflow-y-auto p-2 space-y-1">
-            {sortedSessions.map((session) => (
+            {visibleSessions.map((session) => (
               <Button
                 key={session.id}
                 variant={selectedSessionId === session.id ? "secondary" : "ghost"}
@@ -2584,7 +2780,7 @@ function ConversationViewer({
                   <MessageSquare className="h-4 w-4 flex-shrink-0" />
                   <div className="min-w-0 flex-1">
                     <div className="text-xs font-medium truncate">
-                      {session.name || session.category || `Session ${session.id.slice(0, 8)}`}
+                      {getSessionDisplayName(session)}
                     </div>
                   <div className="text-xs text-muted-foreground">
                       {session.messageCount ? `${session.messageCount} messages` : 'No messages'}
@@ -2599,14 +2795,14 @@ function ConversationViewer({
         {/* Collapsed Sidebar Content */}
         {isSidebarCollapsed && (
           <div className="flex-1 p-2 space-y-2">
-            {sortedSessions.slice(0, 5).map((session) => (
+            {visibleSessions.slice(0, 5).map((session) => (
               <Button
                 key={session.id}
                 variant={selectedSessionId === session.id ? "secondary" : "ghost"}
                 size="sm"
                 onClick={() => handleSessionSelect(session.id)}
                 className="w-full h-8 p-0"
-                title={session.name || session.category || `Session ${session.id.slice(0, 8)}`}
+                title={getSessionDisplayName(session)}
               >
                 <MessageSquare className="h-4 w-4" />
               </Button>
@@ -2634,7 +2830,7 @@ function ConversationViewer({
                 <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div className="min-w-0 flex items-center gap-2">
                   <h3 className="font-medium text-sm truncate">
-                    {selectedSession.name || selectedSession.category || `Session ${selectedSession.id.slice(0, 8)}`}
+                    {getSessionHeaderTitle(selectedSession)}
                   </h3>
                   <span className="text-xs text-muted-foreground truncate">
                     {selectedSession.messageCount ? `${selectedSession.messageCount} messages` : 'No messages'}
@@ -2655,6 +2851,15 @@ function ConversationViewer({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      openRenameDialog()
+                    }}
+                  >
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Rename session
+                  </DropdownMenuItem>
                   <DropdownMenuItem 
                     onSelect={() => {
                       if (onSessionDelete) {
@@ -2670,6 +2875,36 @@ function ConversationViewer({
             </div>
           </div>
         )}
+
+        <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Rename Session</DialogTitle>
+              <DialogDescription>Set a custom title for this chat session.</DialogDescription>
+            </DialogHeader>
+            <Input
+              value={renameSessionValue}
+              onChange={(event) => setRenameSessionValue(event.target.value)}
+              placeholder="Session title"
+              autoFocus
+            />
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setRenameDialogOpen(false)}
+                disabled={isRenamingSession}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleRenameSession}
+                disabled={isRenamingSession || !renameSessionValue.trim()}
+              >
+                Save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
         
         {/* Messages List */}
         <div className="min-h-0 flex-1">

--- a/plexus/console/chat_runtime.py
+++ b/plexus/console/chat_runtime.py
@@ -4,10 +4,13 @@ import asyncio
 import json
 import logging
 import os
+import re
 import socket
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional
+
+from openai import OpenAI
 
 from plexus.cli.procedure.builtin_procedures import CONSOLE_CHAT_BUILTIN_ID
 from plexus.cli.procedure.service import ProcedureService
@@ -22,6 +25,8 @@ COMPLETED = "COMPLETED"
 FAILED = "FAILED"
 HANDLED_HUMAN_INTERACTIONS = {"CHAT"}
 CONSOLE_HISTORY_LIMIT = 16
+DEFAULT_SESSION_TITLE_MODEL = "gpt-5.4-mini"
+SESSION_TITLE_MAX_WORDS = 8
 _PROCEDURE_SERVICE_CACHE: Dict[int, ProcedureService] = {}
 
 
@@ -83,6 +88,310 @@ def _extract_selected_model(raw_metadata: Any) -> Optional[str]:
         return None
     normalized = model_id.strip()
     return normalized or None
+
+
+def _normalize_session_title(raw_title: str) -> Optional[str]:
+    text = str(raw_title or "").strip()
+    if not text:
+        return None
+    text = text.replace("\n", " ").strip()
+    text = re.sub(r"^title\s*:\s*", "", text, flags=re.IGNORECASE)
+    text = text.strip(" \"'`")
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return None
+    words = text.split(" ")
+    if len(words) > SESSION_TITLE_MAX_WORDS:
+        text = " ".join(words[:SESSION_TITLE_MAX_WORDS]).strip()
+    return text or None
+
+
+def _resolve_session_title_model(selected_model: Optional[str]) -> str:
+    normalized_selected = str(selected_model or "").strip()
+    if normalized_selected:
+        return normalized_selected
+    configured_default = str(os.getenv("CONSOLE_SESSION_TITLE_MODEL") or "").strip()
+    if configured_default:
+        return configured_default
+    return DEFAULT_SESSION_TITLE_MODEL
+
+
+def _generate_session_title_with_llm(
+    *,
+    conversation_messages: List[Dict[str, str]],
+    selected_model: Optional[str],
+) -> Optional[str]:
+    prompt_lines = [
+        "Generate a concise chat session title.",
+        "Return only the title text.",
+        "Rules: 3-8 words, plain text, no quotes, no punctuation suffix, no prefixes.",
+    ]
+    for index, message in enumerate(conversation_messages, start=1):
+        role = str(message.get("role") or "USER").strip().upper()
+        content = str(message.get("content") or "").strip()
+        if not content:
+            continue
+        if role == "ASSISTANT":
+            prompt_lines.append(f"Assistant message {index}: {content}")
+        else:
+            prompt_lines.append(f"User message {index}: {content}")
+    prompt = "\n".join(prompt_lines)
+
+    api_key = str(os.getenv("OPENAI_API_KEY") or "").strip()
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is required for session title generation")
+    client = OpenAI(api_key=api_key)
+    response = client.responses.create(
+        model=_resolve_session_title_model(selected_model),
+        input=[{"role": "user", "content": prompt}],
+        max_output_tokens=32,
+    )
+    return _normalize_session_title(response.output_text)
+
+
+def fetch_chat_session(client: PlexusDashboardClient, session_id: str) -> Optional[Dict[str, Any]]:
+    query = """
+    query GetConsoleChatSession($id: ID!) {
+      getChatSession(id: $id) {
+        id
+        name
+        metadata
+      }
+    }
+    """
+    result = client.execute(query, {"id": session_id})
+    payload = _graphql_field(result, "getChatSession")
+    return payload if isinstance(payload, dict) else None
+
+
+def fetch_recent_user_chat_turns(
+    client: PlexusDashboardClient,
+    session_id: str,
+    *,
+    max_turns: int = 3,
+) -> List[Dict[str, str]]:
+    query = """
+    query ListRecentUserChatTurns($sessionId: String!, $limit: Int, $nextToken: String) {
+      listChatMessageBySessionIdAndCreatedAt(
+        sessionId: $sessionId
+        sortDirection: DESC
+        limit: $limit
+        nextToken: $nextToken
+      ) {
+        items {
+          id
+          role
+          humanInteraction
+          messageType
+          content
+          createdAt
+        }
+        nextToken
+      }
+    }
+    """
+    turns: List[Dict[str, str]] = []
+    next_token: Optional[str] = None
+    while len(turns) < max_turns:
+        result = client.execute(
+            query,
+            {"sessionId": session_id, "limit": 100, "nextToken": next_token},
+        )
+        page = _graphql_field(result, "listChatMessageBySessionIdAndCreatedAt")
+        items = page.get("items") if isinstance(page, dict) else []
+        if not isinstance(items, list):
+            break
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            role = str(item.get("role") or "").upper()
+            human_interaction = str(item.get("humanInteraction") or "").upper()
+            message_type = str(item.get("messageType") or "").upper()
+            content = str(item.get("content") or "").strip()
+            if (
+                role == "USER"
+                and human_interaction == "CHAT"
+                and message_type == "MESSAGE"
+                and content
+            ):
+                turns.append(
+                    {
+                        "id": str(item.get("id") or "").strip(),
+                        "content": content,
+                        "createdAt": str(item.get("createdAt") or "").strip(),
+                    }
+                )
+                if len(turns) >= max_turns:
+                    break
+        next_token = page.get("nextToken") if isinstance(page, dict) else None
+        if not next_token:
+            break
+    return turns
+
+
+def fetch_assistant_chat_messages_between(
+    client: PlexusDashboardClient,
+    *,
+    session_id: str,
+    start_created_at: str,
+    end_created_at: str,
+    limit: int = 3,
+) -> List[str]:
+    query = """
+    query ListAssistantMessagesForTitle($sessionId: String!, $limit: Int, $nextToken: String) {
+      listChatMessageBySessionIdAndCreatedAt(
+        sessionId: $sessionId
+        sortDirection: ASC
+        limit: $limit
+        nextToken: $nextToken
+      ) {
+        items {
+          id
+          role
+          humanInteraction
+          messageType
+          content
+          createdAt
+        }
+        nextToken
+      }
+    }
+    """
+    assistant_messages: List[str] = []
+    next_token: Optional[str] = None
+    while len(assistant_messages) < limit:
+        result = client.execute(
+            query,
+            {"sessionId": session_id, "limit": 100, "nextToken": next_token},
+        )
+        page = _graphql_field(result, "listChatMessageBySessionIdAndCreatedAt")
+        items = page.get("items") if isinstance(page, dict) else []
+        if not isinstance(items, list):
+            break
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            role = str(item.get("role") or "").upper()
+            human_interaction = str(item.get("humanInteraction") or "").upper()
+            message_type = str(item.get("messageType") or "").upper()
+            created_at = str(item.get("createdAt") or "").strip()
+            content = str(item.get("content") or "").strip()
+            if not created_at or not content:
+                continue
+            if created_at <= start_created_at or created_at >= end_created_at:
+                continue
+            if (
+                role == "ASSISTANT"
+                and human_interaction in {"CHAT_ASSISTANT", "CHAT"}
+                and message_type == "MESSAGE"
+            ):
+                assistant_messages.append(content)
+                if len(assistant_messages) >= limit:
+                    break
+        next_token = page.get("nextToken") if isinstance(page, dict) else None
+        if not next_token:
+            break
+    return assistant_messages
+
+
+def update_chat_session_title(
+    client: PlexusDashboardClient,
+    *,
+    session_id: str,
+    title: str,
+    turn: int,
+    trigger_message_id: Optional[str],
+    existing_metadata: Optional[Dict[str, Any]],
+) -> None:
+    if not title:
+        return
+    metadata = dict(existing_metadata or {})
+    metadata["title_source"] = "auto"
+    metadata["auto_title_turn"] = turn
+    if trigger_message_id:
+        metadata["auto_title_message_id"] = trigger_message_id
+    console_metadata = metadata.get("console")
+    if not isinstance(console_metadata, dict):
+        console_metadata = {}
+    console_metadata["hidden_until_named"] = False
+    metadata["console"] = console_metadata
+
+    mutation = """
+    mutation UpdateConsoleChatSessionTitle($input: UpdateChatSessionInput!) {
+      updateChatSession(input: $input) {
+        id
+        name
+        updatedAt
+      }
+    }
+    """
+    client.execute(
+        mutation,
+        {
+            "input": {
+                "id": session_id,
+                "name": title,
+                "metadata": json.dumps(metadata),
+                "updatedAt": utc_now(),
+            }
+        },
+    )
+
+
+def maybe_auto_title_session(
+    client: PlexusDashboardClient,
+    *,
+    message: ConsoleMessage,
+) -> None:
+    session = fetch_chat_session(client, message.session_id)
+    if not session:
+        return
+    session_metadata = _parse_metadata_object(session.get("metadata"))
+    if str(session_metadata.get("title_source") or "").strip().lower() == "manual":
+        return
+
+    recent_turns = fetch_recent_user_chat_turns(client, message.session_id, max_turns=3)
+    if not recent_turns:
+        return
+    if len(recent_turns) > 2:
+        return
+
+    chronological_turns = list(reversed(recent_turns))
+    user_messages = [turn["content"] for turn in chronological_turns if turn.get("content")]
+    if not user_messages:
+        return
+
+    conversation_messages: List[Dict[str, str]] = [{"role": "USER", "content": user_messages[0]}]
+    if len(user_messages) == 2:
+        first_created_at = str(chronological_turns[0].get("createdAt") or "")
+        second_created_at = str(chronological_turns[1].get("createdAt") or "")
+        if first_created_at and second_created_at:
+            assistant_messages = fetch_assistant_chat_messages_between(
+                client,
+                session_id=message.session_id,
+                start_created_at=first_created_at,
+                end_created_at=second_created_at,
+                limit=3,
+            )
+            for assistant_content in assistant_messages:
+                conversation_messages.append({"role": "ASSISTANT", "content": assistant_content})
+        conversation_messages.append({"role": "USER", "content": user_messages[1]})
+
+    title = _generate_session_title_with_llm(
+        conversation_messages=conversation_messages,
+        selected_model=message.selected_model,
+    )
+    if not title:
+        return
+
+    update_chat_session_title(
+        client,
+        session_id=message.session_id,
+        title=title,
+        turn=len(chronological_turns),
+        trigger_message_id=message.id,
+        existing_metadata=session_metadata,
+    )
 
 
 def _parse_iso_datetime(value: Optional[str]) -> Optional[datetime]:
@@ -565,6 +874,10 @@ def process_console_message(
         latest_message = fetch_message(client, message.id) or message
         created_at = latest_message.created_at or message.created_at or None
         run_console_chat_response(client, latest_message, owner=owner, latency_trace=latency_trace)
+        try:
+            maybe_auto_title_session(client, message=latest_message)
+        except Exception:
+            logger.exception("Auto-title generation failed for session %s", latest_message.session_id)
         mark_message_completed(client, message.id, created_at=created_at)
         latency_trace["t_completed"] = utc_now()
         logger.info("%s", json.dumps(_build_latency_summary(latency_trace, status="COMPLETED"), sort_keys=True))

--- a/plexus/console/test_chat_runtime.py
+++ b/plexus/console/test_chat_runtime.py
@@ -105,6 +105,82 @@ class FakeHistoryClient(FakeClient):
         return super().execute(query, variables, **_kwargs)
 
 
+class FakeSessionTitleClient(FakeClient):
+    def __init__(self, *, turns=None, session_metadata=None, assistant_messages=None):
+        super().__init__()
+        self.turns = list(turns or [])
+        self.session_metadata = session_metadata
+        self.assistant_messages = list(assistant_messages or [])
+        self.updated_title_payloads = []
+
+    def execute(self, query, variables=None, **_kwargs):
+        if "GetConsoleChatSession" in query:
+            return {
+                "data": {
+                    "getChatSession": {
+                        "id": "sess-1",
+                        "name": None,
+                        "metadata": self.session_metadata,
+                    }
+                }
+            }
+        if "ListRecentUserChatTurns" in query:
+            items = []
+            for index, turn in enumerate(self.turns):
+                items.append(
+                    {
+                        "id": turn.get("id", f"user-{index + 1}"),
+                        "role": "USER",
+                        "humanInteraction": "CHAT",
+                        "messageType": "MESSAGE",
+                        "content": turn["content"],
+                        "createdAt": turn.get("createdAt", f"2026-04-27T00:00:0{index}.000Z"),
+                    }
+                )
+            return {
+                "data": {
+                    "listChatMessageBySessionIdAndCreatedAt": {
+                        "items": items,
+                        "nextToken": None,
+                    }
+                }
+            }
+        if "ListAssistantMessagesForTitle" in query:
+            items = []
+            for index, text in enumerate(self.assistant_messages):
+                items.append(
+                    {
+                        "id": f"assistant-{index + 1}",
+                        "role": "ASSISTANT",
+                        "humanInteraction": "CHAT_ASSISTANT",
+                        "messageType": "MESSAGE",
+                        "content": text,
+                        "createdAt": f"2026-04-27T00:00:0{index + 1}.500Z",
+                    }
+                )
+            return {
+                "data": {
+                    "listChatMessageBySessionIdAndCreatedAt": {
+                        "items": items,
+                        "nextToken": None,
+                    }
+                }
+            }
+        if "UpdateConsoleChatSessionTitle" in query:
+            payload = (variables or {}).get("input", {})
+            self.updated_title_payloads.append(payload)
+            return {
+                "data": {
+                    "updateChatSession": {
+                        "id": payload.get("id"),
+                        "name": payload.get("name"),
+                        "updatedAt": payload.get("updatedAt"),
+                    }
+                }
+            }
+        return super().execute(query, variables, **_kwargs)
+
+
 def test_should_handle_only_matching_pending_user_chat_message():
     message = chat_runtime.parse_chat_message(_raw_message())
 
@@ -238,6 +314,27 @@ def test_process_console_message_runs_harness_and_marks_completed(monkeypatch):
     )
     assert complete_call["input"]["createdAt"] == "2026-04-27T00:00:00.000Z"
     assert complete_call["input"]["responseStatus"] == "COMPLETED"
+
+
+def test_process_console_message_ignores_auto_title_failures(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(
+        chat_runtime,
+        "run_console_chat_response",
+        lambda *_args, **_kwargs: {"success": True},
+    )
+    monkeypatch.setattr(
+        chat_runtime,
+        "maybe_auto_title_session",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("title-fail")),
+    )
+
+    assert chat_runtime.process_console_message(
+        client,
+        _raw_message(),
+        expected_target="cloud",
+        owner="cloud:test",
+    ) is True
 
 
 def test_process_console_message_logs_latency_summary(monkeypatch):
@@ -505,6 +602,109 @@ def test_run_console_chat_response_passes_selected_model_override(monkeypatch):
     assert procedure_id == "builtin:console/chat"
     assert service_client is client
     assert kwargs["context"]["agent_models"] == {"assistant": "gpt-5.3"}
+
+
+def test_maybe_auto_title_session_sets_title_on_first_user_turn(monkeypatch):
+    client = FakeSessionTitleClient(turns=[{"id": "msg-1", "content": "Need help with dosage guidelines"}])
+    message = chat_runtime.parse_chat_message(_raw_message())
+    assert message is not None
+
+    monkeypatch.setattr(
+        chat_runtime,
+        "_generate_session_title_with_llm",
+        lambda **kwargs: "Dosage Guidelines Help",
+    )
+
+    chat_runtime.maybe_auto_title_session(client, message=message)
+
+    assert len(client.updated_title_payloads) == 1
+    payload = client.updated_title_payloads[0]
+    assert payload["name"] == "Dosage Guidelines Help"
+    metadata = json.loads(payload["metadata"])
+    assert metadata["title_source"] == "auto"
+    assert metadata["auto_title_turn"] == 1
+    assert metadata["auto_title_message_id"] == "msg-1"
+    assert metadata["console"]["hidden_until_named"] is False
+
+
+def test_maybe_auto_title_session_replaces_title_on_second_user_turn(monkeypatch):
+    client = FakeSessionTitleClient(
+        turns=[
+            {"id": "msg-2", "content": "Also include prior authorization edge cases", "createdAt": "2026-04-27T00:00:02.000Z"},
+            {"id": "msg-1", "content": "Need help with dosage guidelines", "createdAt": "2026-04-27T00:00:00.000Z"},
+        ],
+        assistant_messages=["Here's a first draft plan you can use."],
+    )
+    message = chat_runtime.parse_chat_message(_raw_message(id="msg-2", metadata='{"model":{"id":"gpt-5.3"}}'))
+    assert message is not None
+
+    calls = []
+
+    def fake_title_generator(**kwargs):
+        calls.append(kwargs)
+        return "Dosage + Prior Authorization"
+
+    monkeypatch.setattr(chat_runtime, "_generate_session_title_with_llm", fake_title_generator)
+
+    chat_runtime.maybe_auto_title_session(client, message=message)
+
+    assert len(client.updated_title_payloads) == 1
+    payload = client.updated_title_payloads[0]
+    metadata = json.loads(payload["metadata"])
+    assert metadata["auto_title_turn"] == 2
+    assert metadata["console"]["hidden_until_named"] is False
+    assert payload["name"] == "Dosage + Prior Authorization"
+    assert calls[0]["selected_model"] == "gpt-5.3"
+    assert calls[0]["conversation_messages"] == [
+        {"role": "USER", "content": "Need help with dosage guidelines"},
+        {"role": "ASSISTANT", "content": "Here's a first draft plan you can use."},
+        {"role": "USER", "content": "Also include prior authorization edge cases"},
+    ]
+
+
+def test_maybe_auto_title_session_skips_third_and_later_turns(monkeypatch):
+    client = FakeSessionTitleClient(
+        turns=[
+            {"id": "msg-3", "content": "third message"},
+            {"id": "msg-2", "content": "second message"},
+            {"id": "msg-1", "content": "first message"},
+        ]
+    )
+    message = chat_runtime.parse_chat_message(_raw_message(id="msg-3"))
+    assert message is not None
+
+    generator_calls = []
+    monkeypatch.setattr(
+        chat_runtime,
+        "_generate_session_title_with_llm",
+        lambda **kwargs: generator_calls.append(kwargs) or "Should Not Be Used",
+    )
+
+    chat_runtime.maybe_auto_title_session(client, message=message)
+
+    assert client.updated_title_payloads == []
+    assert generator_calls == []
+
+
+def test_maybe_auto_title_session_respects_manual_title_lock(monkeypatch):
+    client = FakeSessionTitleClient(
+        turns=[{"id": "msg-1", "content": "first message"}],
+        session_metadata={"title_source": "manual"},
+    )
+    message = chat_runtime.parse_chat_message(_raw_message())
+    assert message is not None
+
+    generator_calls = []
+    monkeypatch.setattr(
+        chat_runtime,
+        "_generate_session_title_with_llm",
+        lambda **kwargs: generator_calls.append(kwargs) or "Should Not Be Used",
+    )
+
+    chat_runtime.maybe_auto_title_session(client, message=message)
+
+    assert client.updated_title_payloads == []
+    assert generator_calls == []
 
 
 def test_fetch_session_history_filters_and_sorts_messages():


### PR DESCRIPTION
## Summary\n\nThis PR tightens Console chat session UX and title generation behavior:\n\n- Enforces strict **hidden-until-named** behavior for newly created sessions\n- Keeps sidebar selection neutral when the active session is hidden/unnamed\n- Uses a neutral header title (**New Chat**) while hidden sessions are unnamed\n- Ensures ChatSession metadata writes are serialized for production AppSync compatibility\n- Improves auto-title context on turn 2 to include:\n  - user message #1\n  - assistant message(s) between user #1 and user #2\n  - user message #2\n\n## Validation\n\n- .......................                                                  [100%]
23 passed in 2.10s\n- 
> aws-amplify-gen2@0.1.0 test
> jest --runTestsByPath components/ui/__tests__/conversation-viewer-session-routing.test.tsx components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx\n\n## Notes\n\nThis change is scoped to the Console chat flow and does not alter non-console task dispatch paths.