### PR TITLE
fix(deps): bump tactus to v0.46.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -9072,14 +9072,14 @@ py-cpuinfo = "*"
 
 [[package]]
 name = "tactus"
-version = "0.46.3"
+version = "0.46.4"
 description = "Tactus: Lua-based DSL for agentic workflows"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "tactus-0.46.3-py3-none-any.whl", hash = "sha256:40c6541e13cc8a284acc56e9fe240b7c95e5623484c8a1c2273bf9b152ad4e17"},
-    {file = "tactus-0.46.3.tar.gz", hash = "sha256:6977dc63d2484cdd329a565c5b43bb0147db2daba47d2dc3cf1afe160419e7ca"},
+    {file = "tactus-0.46.4-py3-none-any.whl", hash = "sha256:5dd87121818839bcd4f9ef9a2177f2c759d9259cccc7ea951fda7d7d0404ad2d"},
+    {file = "tactus-0.46.4.tar.gz", hash = "sha256:a6dd8b6c00fc2587fdcffda3c4ac677721ab7370230c63e36259d253b853969e"},
 ]
 
 [package.dependencies]
@@ -10505,4 +10505,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "111f62ea3bf8eb8b35f95a913842683c4cfcac9d402e10e803bf0b7daa0f100e"
+content-hash = "770926014e7305d4db7179aa11124a32fe316e3cab59daba294791750ad3c862"

--- a/project/events/2026-04-29T17:18:57.671Z__bb5498fd-9892-4375-9147-da4de2c95708.json
+++ b/project/events/2026-04-29T17:18:57.671Z__bb5498fd-9892-4375-9147-da4de2c95708.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "bb5498fd-9892-4375-9147-da4de2c95708",
+  "issue_id": "plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T17:18:57.671Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-1f6b32f8-0d5c-4792-be56-a5caa89242a7",
+    "priority": 1,
+    "status": "open",
+    "title": "Bump tactus to v0.46.4 in pyproject and lambda requirements, regenerate lock, run lambda smoke tests"
+  }
+}

--- a/project/events/2026-04-29T17:19:01.012Z__706288b7-5ba9-4864-aaed-913382414c3e.json
+++ b/project/events/2026-04-29T17:19:01.012Z__706288b7-5ba9-4864-aaed-913382414c3e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "706288b7-5ba9-4864-aaed-913382414c3e",
+  "issue_id": "plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T17:19:01.012Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "36e7e308-1b94-4827-a31c-61ac908eff26"
+  }
+}

--- a/project/events/2026-04-29T17:19:01.013Z__201a1cf9-1381-48c0-971b-a2829bba016c.json
+++ b/project/events/2026-04-29T17:19:01.013Z__201a1cf9-1381-48c0-971b-a2829bba016c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "201a1cf9-1381-48c0-971b-a2829bba016c",
+  "issue_id": "plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T17:19:01.013Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-29T17:23:50.519Z__a09d034e-b1e3-4bb0-b4d3-26dccb0452af.json
+++ b/project/events/2026-04-29T17:23:50.519Z__a09d034e-b1e3-4bb0-b4d3-26dccb0452af.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a09d034e-b1e3-4bb0-b4d3-26dccb0452af",
+  "issue_id": "plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T17:23:50.519Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "0429db07-4e14-42c1-a763-bf8385539e8c"
+  }
+}

--- a/project/events/2026-04-29T17:37:04.478Z__0aa80562-b04d-4f8d-b3fb-ef4ef21b6460.json
+++ b/project/events/2026-04-29T17:37:04.478Z__0aa80562-b04d-4f8d-b3fb-ef4ef21b6460.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0aa80562-b04d-4f8d-b3fb-ef4ef21b6460",
+  "issue_id": "plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T17:37:04.478Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "24aa436f-22d2-426f-8401-88bc12c0637d"
+  }
+}

--- a/project/issues/plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd.json
+++ b/project/issues/plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd",
+  "title": "Bump tactus to v0.46.4 in pyproject and lambda requirements, regenerate lock, run lambda smoke tests",
+  "description": "",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-1f6b32f8-0d5c-4792-be56-a5caa89242a7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "0429db07-4e14-42c1-a763-bf8385539e8c",
+      "author": "derek",
+      "text": "Updated dependency pins: pyproject.toml tactus ^0.46.4 and score-processor-lambda/requirements.txt tactus==0.46.4. Regenerated poetry.lock (tactus now locked to 0.46.4). Ran lambda container smoke test via make test-smoke in score-processor-lambda: PASS (10 passed, 0 failed).",
+      "created_at": "2026-04-29T17:23:50.519482993Z"
+    }
+  ],
+  "created_at": "2026-04-29T17:18:57.671235867Z",
+  "updated_at": "2026-04-29T17:23:50.519482993Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd.json
+++ b/project/issues/plx-3bb359fb-02c3-4e45-a2ae-47343f279ecd.json
@@ -16,10 +16,16 @@
       "author": "derek",
       "text": "Updated dependency pins: pyproject.toml tactus ^0.46.4 and score-processor-lambda/requirements.txt tactus==0.46.4. Regenerated poetry.lock (tactus now locked to 0.46.4). Ran lambda container smoke test via make test-smoke in score-processor-lambda: PASS (10 passed, 0 failed).",
       "created_at": "2026-04-29T17:23:50.519482993Z"
+    },
+    {
+      "id": "24aa436f-22d2-426f-8401-88bc12c0637d",
+      "author": "derek",
+      "text": "Opened PR to develop: https://github.com/AnthusAI/Plexus/pull/246 (branch feature/plx-3bb359-tactus-0.46.4). GitHub CI/CD Pipeline run 25123671777 passed.",
+      "created_at": "2026-04-29T17:37:04.478102877Z"
     }
   ],
   "created_at": "2026-04-29T17:18:57.671235867Z",
-  "updated_at": "2026-04-29T17:23:50.519482993Z",
+  "updated_at": "2026-04-29T17:37:04.478102877Z",
   "closed_at": null,
   "custom": {}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ langgraph = "0.6.7"
 "langgraph-checkpoint-postgres" = "2.0.9"
 psycopg = { version = ">=3.2.0,<4.0.0", extras = ["binary"] }
 lupa = "2.7"
-tactus = "^0.46.3"
+tactus = "^0.46.4"
 openpyxl = "3.1.5"
 rapidfuzz = "3.9.4"
 datasets = "*"

--- a/score-processor-lambda/requirements.txt
+++ b/score-processor-lambda/requirements.txt
@@ -12,7 +12,7 @@ langchain-aws==0.2.35
 langgraph-checkpoint-postgres==2.0.9
 
 # Tactus
-tactus==0.46.1
+tactus==0.46.4
 
 # AWS & Azure
 boto3


### PR DESCRIPTION
**Summary**
- Bumped `tactus` to `^0.46.4` in `pyproject.toml`.
- Bumped `tactus` to `0.46.4` in `score-processor-lambda/requirements.txt`.
- Regenerated `poetry.lock` so the resolved package set now includes `tactus 0.46.4`.
- Included required Kanbus artifact updates under `project/issues` and `project/events` for task `plx-3bb359`.

**Why**
- Aligns the core project and lambda runtime dependency versions on the requested `tactus` release.
- Ensures lockfile reproducibility and avoids dependency drift between local/dev and lambda container builds.

**Validation**
- `poetry lock` (successful; lockfile rewritten)
- `cd score-processor-lambda && make test-smoke` (pass: `10 passed, 0 failed`, verifies `tactus: 0.46.4` in-container)
- GitHub Actions `CI/CD Pipeline` run `25123671777` on `feature/plx-3bb359-tactus-0.46.4` (completed `success`)

**Expected Outcome**
- Local Poetry environment and score-processor lambda image both resolve and run with `tactus 0.46.4`.
- Dependency baseline is updated without behavioral regressions in the lambda smoke path.

**Kanbus / Task Tracking**
- `plx-3bb359`
