### PR TITLE
Console chat: route Plexus tools through single dispatcher

### DIFF
--- a/plexus/cli/procedure/builtin_procedures.py
+++ b/plexus/cli/procedure/builtin_procedures.py
@@ -68,6 +68,10 @@ def _build_console_chat_config(tac_source: str) -> Dict[str, Any]:
                     "You are a practical, accurate engineering copilot.\n"
                     "Respond directly to the user's latest message.\n"
                     "Keep responses concise, specific, and actionable.\n\n"
+                    "When the user explicitly asks to call a Plexus tool (or names one),\n"
+                    "call the `plexus` tool before answering. Pass the exact MCP tool\n"
+                    "name as `tool_name` and pass that tool's JSON inputs as `arguments`.\n"
+                    "Use the tool result directly in your answer.\n\n"
                     "CONTEXT:\n"
                     "- Recent conversation turns are provided as prior context.\n"
                     "- Refer back to earlier turns to preserve continuity.\n"
@@ -75,7 +79,7 @@ def _build_console_chat_config(tac_source: str) -> Dict[str, Any]:
                     "- Avoid filler and never invent data.\n"
                 ),
                 "initial_message": "Ready.",
-                "tools": [],
+                "tools": ["plexus"],
             }
         },
         "stages": ["preparing", "responding", "complete"],

--- a/plexus/cli/procedure/lua_dsl/primitives/agent.py
+++ b/plexus/cli/procedure/lua_dsl/primitives/agent.py
@@ -507,10 +507,19 @@ class AgentPrimitive:
                 success = tool_args.get('success', True)
                 self.stop_primitive.request(reason, success)
 
-            # Add tool result to conversation
+            # Add tool result to conversation. Some model providers omit tool_call_id,
+            # so we still inject a deterministic result message into history.
             if tool_call_id:
-                tool_message = ToolMessage(content=str(tool_result), tool_call_id=tool_call_id)
+                tool_message = ToolMessage(content=str(tool_result), tool_call_id=str(tool_call_id))
                 self._conversation.append(tool_message)
+            else:
+                try:
+                    from langchain_core.messages import HumanMessage
+                except ImportError:  # pragma: no cover - compatibility only
+                    from langchain.schema import HumanMessage
+                self._conversation.append(
+                    HumanMessage(content=f"Tool '{tool_name}' result: {tool_result}")
+                )
 
             # Build executed tool dict for Lua
             executed.append({

--- a/plexus/cli/procedure/lua_dsl/runtime.py
+++ b/plexus/cli/procedure/lua_dsl/runtime.py
@@ -117,6 +117,42 @@ class LuaDSLRuntime:
             raise LuaDSLRuntimeError(f"context.agent_models.{agent_name} must not be blank")
         return model
 
+    @staticmethod
+    def _expand_allowed_tool_names(
+        configured_tool_names: List[str],
+        all_tool_names: List[str],
+    ) -> List[str]:
+        """
+        Expand pseudo toolset aliases into concrete tool names.
+
+        Supported aliases:
+        - 'plexus': include all tools with name prefix 'plexus_' plus
+          core helper tools provided by Plexus MCP registration.
+        """
+        normalized = [str(name).strip() for name in (configured_tool_names or []) if str(name).strip()]
+        if not normalized:
+            return []
+
+        expanded: set[str] = set(normalized)
+        if "plexus" in expanded:
+            for tool_name in all_tool_names:
+                if tool_name.startswith("plexus_"):
+                    expanded.add(tool_name)
+            expanded.update(
+                {
+                    "think",
+                    "get_plexus_documentation",
+                    "score_editor_setup",
+                    "score_editor_get_result",
+                    "score_editor_get_content",
+                    "str_replace_editor",
+                    "submit_score_version",
+                }
+            )
+            expanded.discard("plexus")
+
+        return list(expanded)
+
     async def execute(self, yaml_config: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Execute a Lua-based procedure workflow.
@@ -480,10 +516,17 @@ class LuaDSLRuntime:
                 logger.info(f"Injected output schema guidance into agent '{agent_name}' prompt")
 
             # Filter tools for this agent
-            allowed_tool_names = agent_config.get('tools', [])
-            filtered_tools = [tool for tool in all_mcp_tools if tool.name in allowed_tool_names]
+            configured_tool_names = agent_config.get('tools', [])
+            expanded_tool_names = self._expand_allowed_tool_names(
+                configured_tool_names,
+                [tool.name for tool in all_mcp_tools],
+            )
+            filtered_tools = [tool for tool in all_mcp_tools if tool.name in expanded_tool_names]
 
-            logger.info(f"Agent '{agent_name}' has {len(filtered_tools)} tools: {allowed_tool_names}")
+            logger.info(
+                f"Agent '{agent_name}' has {len(filtered_tools)} tools "
+                f"(configured={configured_tool_names}, expanded={expanded_tool_names})"
+            )
 
             # Convert to LangChain format
             langchain_tools = convert_mcp_tools_to_langchain(filtered_tools)

--- a/plexus/cli/procedure/lua_dsl/test_runtime_basic.py
+++ b/plexus/cli/procedure/lua_dsl/test_runtime_basic.py
@@ -74,6 +74,29 @@ def test_agent_model_override_rejects_non_object_context():
         )
 
 
+def test_expand_allowed_tool_names_for_plexus_alias():
+    """'plexus' alias expands to concrete Plexus tool names."""
+    from plexus.cli.procedure.lua_dsl.runtime import LuaDSLRuntime
+
+    expanded = LuaDSLRuntime._expand_allowed_tool_names(
+        ["plexus"],
+        [
+            "plexus_scorecards_list",
+            "plexus_chat_send",
+            "get_plexus_documentation",
+            "think",
+            "non_plexus_tool",
+        ],
+    )
+
+    assert "plexus_scorecards_list" in expanded
+    assert "plexus_chat_send" in expanded
+    assert "get_plexus_documentation" in expanded
+    assert "think" in expanded
+    assert "non_plexus_tool" not in expanded
+    assert "plexus" not in expanded
+
+
 def test_lua_sandbox():
     """Test Lua sandbox."""
     from plexus.cli.procedure.lua_dsl.lua_sandbox import LuaSandbox

--- a/plexus/cli/procedure/lua_dsl/tests/test_agent_primitives.py
+++ b/plexus/cli/procedure/lua_dsl/tests/test_agent_primitives.py
@@ -198,6 +198,32 @@ class TestAgentTurn:
         assert result['tool_calls'][0]['name'] == 'test_tool'
         assert result['tool_calls'][0]['result'] == 'Tool result'
 
+    def test_turn_appends_tool_result_when_tool_call_has_no_id(
+        self, agent_primitive, mock_llm, mock_tool_primitive
+    ):
+        """Tool results must still enter conversation history even without tool_call_id."""
+        mock_tool = Mock()
+        type(mock_tool).name = 'test_tool'
+        mock_tool.func = Mock(return_value='Tool result')
+        agent_primitive.available_tools = [mock_tool]
+
+        mock_response = Mock()
+        mock_response.content = 'Using tool'
+        tool_call = Mock()
+        tool_call.name = 'test_tool'
+        tool_call.args = {'param': 'value'}
+        tool_call.id = None
+        mock_response.tool_calls = [tool_call]
+        mock_llm.invoke.return_value = mock_response
+
+        agent_primitive.turn()
+
+        mock_tool_primitive.record_call.assert_called_once_with('test_tool', {'param': 'value'}, 'Tool result')
+        # system + initial + ai response + synthetic tool result message
+        assert len(agent_primitive._conversation) == 4
+        synthetic_tool_result = agent_primitive._conversation[-1]
+        assert getattr(synthetic_tool_result, 'content', '') == "Tool 'test_tool' result: Tool result"
+
     def test_turn_handles_multiple_tool_calls(
         self, agent_primitive, mock_llm, mock_tool_primitive
     ):

--- a/plexus/cli/procedure/procedure_executor.py
+++ b/plexus/cli/procedure/procedure_executor.py
@@ -18,6 +18,8 @@ from typing import Dict, Any, Optional, List
 
 logger = logging.getLogger(__name__)
 
+CONSOLE_CHAT_BUILTIN_ID = "builtin:console/chat"
+
 
 def _install_tactus_dspy_context_capture_patch() -> None:
     """Capture Tactus DSPy agent prompt_context before model invocation."""
@@ -129,6 +131,152 @@ def _cost_event_signature(entry: Dict[str, Any]) -> str:
             "timestamp",
         )
     )
+
+
+def _mcp_tool_value(tool: Any, key: str, default: Any = None) -> Any:
+    if isinstance(tool, dict):
+        return tool.get(key, default)
+    return getattr(tool, key, default)
+
+
+def _mcp_tool_result_to_text(result: Any) -> str:
+    def _content_to_text(content: Any) -> str:
+        if not isinstance(content, list):
+            return str(content)
+
+        text_parts: List[str] = []
+        for item in content:
+            if isinstance(item, dict) and "text" in item:
+                text_parts.append(str(item["text"]))
+            elif hasattr(item, "text"):
+                text_parts.append(str(getattr(item, "text")))
+            else:
+                text_parts.append(str(item))
+        return "\n".join(text_parts)
+
+    if isinstance(result, dict):
+        content = result.get("content")
+        if content is not None:
+            return _content_to_text(content)
+        if "text" in result:
+            return str(result["text"])
+        return json.dumps(result, indent=2, default=str)
+
+    if isinstance(result, list):
+        return _content_to_text(result)
+
+    return str(result)
+
+
+async def _create_console_plexus_dispatch_tool(mcp_client: Any) -> Optional[Any]:
+    """Create the single Console-facing Plexus MCP dispatcher tool."""
+    list_tools = getattr(mcp_client, "list_tools", None)
+    call_tool = getattr(mcp_client, "call_tool", None)
+    if not callable(list_tools) or not callable(call_tool):
+        return None
+
+    mcp_tools = await list_tools()
+    tool_catalog = []
+    for tool in mcp_tools or []:
+        name = _mcp_tool_value(tool, "name")
+        if not name:
+            continue
+        description = " ".join(str(_mcp_tool_value(tool, "description", "") or "").split())
+        if len(description) > 180:
+            description = f"{description[:177]}..."
+        tool_catalog.append((str(name), description))
+
+    if not tool_catalog:
+        return None
+
+    tool_catalog.sort(key=lambda item: item[0])
+    allowed_tool_names = [name for name, _description in tool_catalog]
+    allowed_tool_set = set(allowed_tool_names)
+    catalog_text = "\n".join(
+        f"- {name}: {description}" if description else f"- {name}"
+        for name, description in tool_catalog
+    )
+
+    description = (
+        "Call exactly one Plexus MCP tool by name. Use `tool_name` for the exact "
+        "underlying MCP tool name and `arguments` for that tool's JSON arguments. "
+        "Available Plexus MCP tools:\n"
+        f"{catalog_text}"
+    )
+
+    async def plexus(tool_name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
+        if tool_name not in allowed_tool_set:
+            raise ValueError(
+                f"Unknown Plexus MCP tool '{tool_name}'. Available tools: "
+                f"{', '.join(allowed_tool_names)}"
+            )
+        if arguments is None:
+            arguments = {}
+        elif isinstance(arguments, str):
+            try:
+                parsed_arguments = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                raise TypeError("`arguments` must be a JSON object") from exc
+            arguments = parsed_arguments
+        if not isinstance(arguments, dict):
+            raise TypeError("`arguments` must be a JSON object")
+
+        result = await call_tool(tool_name, arguments)
+        return _mcp_tool_result_to_text(result)
+
+    from pydantic_ai import Tool
+
+    async def _prepare(_ctx: Any, tool_def: Any) -> Any:
+        from pydantic_ai.tools import ToolDefinition
+
+        return ToolDefinition(
+            name=tool_def.name,
+            description=tool_def.description or "",
+            parameters_json_schema={
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "tool_name": {
+                        "type": "string",
+                        "enum": allowed_tool_names,
+                        "description": "Exact Plexus MCP tool name to call.",
+                    },
+                    "arguments": {
+                        "type": "object",
+                        "description": "JSON arguments for the selected MCP tool.",
+                        "additionalProperties": True,
+                        "default": {},
+                    },
+                },
+                "required": ["tool_name"],
+            },
+        )
+
+    tool = Tool(
+        plexus,
+        name="plexus",
+        description=description,
+        prepare=_prepare,
+    )
+    tool._mcp_input_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "tool_name": {
+                "type": "string",
+                "enum": allowed_tool_names,
+                "description": "Exact Plexus MCP tool name to call.",
+            },
+            "arguments": {
+                "type": "object",
+                "description": "JSON arguments for the selected MCP tool.",
+                "additionalProperties": True,
+                "default": {},
+            },
+        },
+        "required": ["tool_name"],
+    }
+    return tool
 
 
 def _persist_inference_costs_to_state(storage: Any, procedure_id: str, cost_events: List[Any]) -> None:
@@ -1103,27 +1251,40 @@ async def _execute_tactus(
 
         if mcp_client_for_bridge:
             try:
-                from tactus.adapters.mcp import PydanticAIMCPAdapter
                 from pydantic_ai.toolsets import FunctionToolset
 
-                mcp_adapter = PydanticAIMCPAdapter(
-                    mcp_client_for_bridge,
-                    runtime=runtime,
-                )
-                mcp_tools = await mcp_adapter.load_tools()
-                if mcp_tools and "plexus" not in runtime.toolset_registry:
-                    runtime.toolset_registry["plexus"] = FunctionToolset(tools=mcp_tools)
-                    logger.info(
-                        "Registered bridged MCP toolset 'plexus' with %d tool(s)",
-                        len(mcp_tools),
+                if procedure_id == CONSOLE_CHAT_BUILTIN_ID:
+                    plexus_dispatch_tool = await _create_console_plexus_dispatch_tool(
+                        mcp_client_for_bridge
                     )
-                    # Also register each tool individually so agent configs can reference
-                    # specific tool names (e.g., tools: [plexus_scorecard_info]) instead of
-                    # only the whole toolset name "plexus".
-                    for tool in mcp_tools:
-                        tool_name = getattr(tool, "name", None)
-                        if tool_name and tool_name not in runtime.toolset_registry:
-                            runtime.toolset_registry[tool_name] = FunctionToolset(tools=[tool])
+                    if plexus_dispatch_tool and "plexus" not in runtime.toolset_registry:
+                        runtime.toolset_registry["plexus"] = FunctionToolset(
+                            tools=[plexus_dispatch_tool]
+                        )
+                        logger.info(
+                            "Registered Console MCP dispatcher toolset 'plexus' with one dispatch tool"
+                        )
+                else:
+                    from tactus.adapters.mcp import PydanticAIMCPAdapter
+
+                    mcp_adapter = PydanticAIMCPAdapter(
+                        mcp_client_for_bridge,
+                        runtime=runtime,
+                    )
+                    mcp_tools = await mcp_adapter.load_tools()
+                    if mcp_tools and "plexus" not in runtime.toolset_registry:
+                        runtime.toolset_registry["plexus"] = FunctionToolset(tools=mcp_tools)
+                        logger.info(
+                            "Registered bridged MCP toolset 'plexus' with %d tool(s)",
+                            len(mcp_tools),
+                        )
+                        # Also register each tool individually so agent configs can reference
+                        # specific tool names (e.g., tools: [plexus_scorecard_info]) instead of
+                        # only the whole toolset name "plexus".
+                        for tool in mcp_tools:
+                            tool_name = getattr(tool, "name", None)
+                            if tool_name and tool_name not in runtime.toolset_registry:
+                                runtime.toolset_registry[tool_name] = FunctionToolset(tools=[tool])
             except Exception as exc:
                 logger.warning("Could not bridge MCP tools into Tactus toolset registry: %s", exc)
 

--- a/plexus/cli/procedure/test_builtin_procedures.py
+++ b/plexus/cli/procedure/test_builtin_procedures.py
@@ -24,6 +24,7 @@ def test_builtin_console_procedure_yaml_contains_tactus_source():
     assert parsed["agents"]["assistant"]["verbosity"] == "low"
     assert parsed["agents"]["assistant"]["max_tokens"] == 220
     assert parsed["agents"]["assistant"]["stream"] is True
+    assert parsed["agents"]["assistant"]["tools"] == ["plexus"]
     assert isinstance(parsed.get("code"), str)
     assert "State.set(\"stage\", \"preparing\")" in parsed["code"]
     assert "Previous user message before latest (if any):" in parsed["code"]

--- a/plexus/cli/procedure/test_procedure_executor_compat.py
+++ b/plexus/cli/procedure/test_procedure_executor_compat.py
@@ -9,11 +9,13 @@ from plexus.cli.procedure.procedure_executor import _PlexusTraceLogBridge, _exec
 
 class _FakeRuntime:
     last_context = None
+    last_instance = None
 
     def __init__(self, **_kwargs):
         self.toolset_registry = {}
         self.tool_primitive = None
         self.log_handler = None
+        _FakeRuntime.last_instance = self
 
     async def execute(self, _source, _context, format="yaml"):
         assert format == "yaml"
@@ -275,6 +277,47 @@ class _CollectingTraceSink:
         return None
 
 
+class _FakeMCPClient:
+    def __init__(self):
+        self.calls = []
+
+    async def list_tools(self):
+        return [
+            {
+                "name": "plexus_scorecards_list",
+                "description": "List scorecards from Plexus.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {"type": "string"},
+                    },
+                },
+            },
+            {
+                "name": "plexus_scorecard_info",
+                "description": "Get scorecard details.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "scorecard_identifier": {"type": "string"},
+                    },
+                    "required": ["scorecard_identifier"],
+                },
+            },
+        ]
+
+    async def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"called {name} with {arguments}",
+                }
+            ]
+        }
+
+
 @pytest.mark.asyncio
 async def test_trace_bridge_forwards_cost_events_to_trace_sink():
     from tactus.protocols.models import CostEvent
@@ -348,6 +391,58 @@ async def test_execute_tactus_initializes_embedded_mcp_transport(monkeypatch):
 
     assert result["success"] is True
     assert mcp_server.transport.connected is True
+
+
+@pytest.mark.asyncio
+async def test_console_tactus_registers_one_plexus_dispatch_tool(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    monkeypatch.setattr("tactus.core.TactusRuntime", _FakeRuntime)
+    monkeypatch.setattr(
+        "plexus.cli.procedure.tactus_adapters.PlexusStorageAdapter",
+        lambda *_a, **_k: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        "plexus.cli.procedure.tactus_adapters.PlexusHITLAdapter",
+        lambda *_a, **_k: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        "plexus.cli.procedure.tactus_adapters.PlexusTraceSink",
+        lambda *_a, **_k: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        "plexus.cli.procedure.chat_recorder.ProcedureChatRecorder",
+        lambda *_a, **_k: SimpleNamespace(),
+    )
+
+    mcp_client = _FakeMCPClient()
+    result = await _execute_tactus(
+        procedure_id="builtin:console/chat",
+        procedure_source=(
+            "name: Console\n"
+            "class: Tactus\n"
+            "code: |\n"
+            "  local function run(input)\n"
+            "    return { success = true }\n"
+            "  end\n"
+            "  return run(input)\n"
+        ),
+        client=SimpleNamespace(),
+        mcp_server=mcp_client,
+        context={},
+    )
+
+    assert result["success"] is True
+    toolset = _FakeRuntime.last_instance.toolset_registry["plexus"]
+    assert list(toolset.tools.keys()) == ["plexus"]
+
+    plexus_tool = toolset.tools["plexus"]
+    output = await plexus_tool.function(
+        tool_name="plexus_scorecards_list",
+        arguments='{"limit": "1"}',
+    )
+    assert output == "called plexus_scorecards_list with {'limit': '1'}"
+    assert mcp_client.calls == [("plexus_scorecards_list", {"limit": "1"})]
 
 
 @pytest.mark.asyncio

--- a/plexus/console/chat_runtime.py
+++ b/plexus/console/chat_runtime.py
@@ -824,7 +824,7 @@ async def run_console_chat_response_async(
         account_id=message.account_id,
         console_user_message=message.content,
         console_session_history=history,
-        enable_mcp=False,
+        enable_mcp=True,
         context=context,
     )
     if latency_trace is not None:

--- a/plexus/console/test_chat_runtime.py
+++ b/plexus/console/test_chat_runtime.py
@@ -564,7 +564,7 @@ def test_run_console_chat_response_passes_console_context_to_builtin(monkeypatch
         "role": "USER",
         "content": "Multiply 6 by 7",
     }
-    assert kwargs["enable_mcp"] is False
+    assert kwargs["enable_mcp"] is True
     assert kwargs["context"] == {
         "account_id": "acct-1",
         "chat_session_id": "sess-1",

--- a/plexus/procedures/console/chat_agent.tac
+++ b/plexus/procedures/console/chat_agent.tac
@@ -211,15 +211,6 @@ local assistant_prompt = "You are the Plexus Console assistant in an ongoing eng
                          "Recent conversation context (oldest to newest):\n" .. history_context .. "\n\n" ..
                          "Respond to the latest user message now."
 
-local assistant_result = nil
-if deterministic_response ~= nil and deterministic_response ~= "" then
-  assistant_result = { response = deterministic_response }
-else
-  assistant_result = assistant({ message = assistant_prompt })
-end
-
-local final_response = ""
-
 local function extract_text(value)
   if type(value) == "string" and value ~= "" then
     return value
@@ -252,6 +243,15 @@ local function extract_text(value)
   end
   return ""
 end
+
+local assistant_result = nil
+if deterministic_response ~= nil and deterministic_response ~= "" then
+  assistant_result = { response = deterministic_response }
+else
+  assistant_result = assistant({ message = assistant_prompt })
+end
+
+local final_response = ""
 
 final_response = extract_text(assistant_result)
 

--- a/plexus/procedures/console_chat_agent.yaml
+++ b/plexus/procedures/console_chat_agent.yaml
@@ -44,12 +44,19 @@ agents:
       Respond directly to the user's latest message in the active chat session.
       Keep responses concise, specific, and actionable.
 
+      When the user explicitly asks you to call a Plexus tool (or names a tool),
+      you must call the `plexus` tool before answering. Pass the exact MCP tool
+      name as `tool_name` and pass that tool's JSON inputs as `arguments`. Use
+      the tool result directly in your answer. Do not ask a clarifying question
+      when the tool request is specific and executable.
+
       If user intent is unclear, ask one clarifying question.
       Avoid filler and avoid inventing data.
 
     initial_message: Ready.
 
-    tools: []
+    tools:
+      - plexus
 
 stages:
   - preparing

--- a/project/events/2026-04-27T12:42:41.687Z__5a24018f-4794-48b1-884f-b63678e7090b.json
+++ b/project/events/2026-04-27T12:42:41.687Z__5a24018f-4794-48b1-884f-b63678e7090b.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "5a24018f-4794-48b1-884f-b63678e7090b",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-27T12:42:41.687Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-b7030f92-0508-4982-a1f3-3c67781a8a72",
+    "priority": 2,
+    "status": "open",
+    "title": "Local development worker for console chat via dev SQS queue"
+  }
+}

--- a/project/events/2026-04-27T12:42:48.669Z__efda609c-2e27-4853-88db-a99ef5d67be1.json
+++ b/project/events/2026-04-27T12:42:48.669Z__efda609c-2e27-4853-88db-a99ef5d67be1.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "efda609c-2e27-4853-88db-a99ef5d67be1",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "field_updated",
+  "occurred_at": "2026-04-27T12:42:48.669Z",
+  "actor_id": "ryan",
+  "payload": {
+    "changes": {
+      "priority": {
+        "from": 2,
+        "to": 1
+      }
+    }
+  }
+}

--- a/project/events/2026-04-27T12:42:48.685Z__70877308-ab36-4d42-9531-e3a9571b3f79.json
+++ b/project/events/2026-04-27T12:42:48.685Z__70877308-ab36-4d42-9531-e3a9571b3f79.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "70877308-ab36-4d42-9531-e3a9571b3f79",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T12:42:48.685Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "916d6611-ab21-44fc-a2a3-cf8b338f2b2a"
+  }
+}

--- a/project/events/2026-04-27T12:42:53.440Z__05f8b70f-f17f-414a-9523-ee09b3318ca6.json
+++ b/project/events/2026-04-27T12:42:53.440Z__05f8b70f-f17f-414a-9523-ee09b3318ca6.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "05f8b70f-f17f-414a-9523-ee09b3318ca6",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-27T12:42:53.440Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-27T20:39:01.719Z__bd428b0a-ccda-4a47-8f8b-f6e6b11df2cc.json
+++ b/project/events/2026-04-27T20:39:01.719Z__bd428b0a-ccda-4a47-8f8b-f6e6b11df2cc.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bd428b0a-ccda-4a47-8f8b-f6e6b11df2cc",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T20:39:01.719Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "77c8fdb5-e0a6-4945-8048-1da063a25eeb"
+  }
+}

--- a/project/events/2026-04-27T21:03:43.703Z__4d52abf7-9fe6-4979-9031-1b47753fba43.json
+++ b/project/events/2026-04-27T21:03:43.703Z__4d52abf7-9fe6-4979-9031-1b47753fba43.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4d52abf7-9fe6-4979-9031-1b47753fba43",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:03:43.703Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "319d570d-fa32-4331-970b-d447d2a612ef"
+  }
+}

--- a/project/events/2026-04-27T21:25:24.974Z__dafa69bc-2e6c-478c-b650-6dff697b532a.json
+++ b/project/events/2026-04-27T21:25:24.974Z__dafa69bc-2e6c-478c-b650-6dff697b532a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "dafa69bc-2e6c-478c-b650-6dff697b532a",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T21:25:24.974Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "caee288e-e264-49cc-93a6-104adf72b583"
+  }
+}

--- a/project/events/2026-04-27T22:34:46.460Z__401e2aca-4a37-429f-94d0-765a5418fe5d.json
+++ b/project/events/2026-04-27T22:34:46.460Z__401e2aca-4a37-429f-94d0-765a5418fe5d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "401e2aca-4a37-429f-94d0-765a5418fe5d",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:34:46.460Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "f5556fe1-cef6-48c5-b6f6-e1a6942ebb46"
+  }
+}

--- a/project/events/2026-04-27T22:41:20.900Z__ad75213e-3b11-4713-b1a9-4ed08578a7cc.json
+++ b/project/events/2026-04-27T22:41:20.900Z__ad75213e-3b11-4713-b1a9-4ed08578a7cc.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ad75213e-3b11-4713-b1a9-4ed08578a7cc",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T22:41:20.900Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "8aed0b08-4ea2-464a-865d-f99078fa8a36"
+  }
+}

--- a/project/events/2026-04-27T23:45:54.979Z__269d6429-9819-476c-937b-9721005ca7ec.json
+++ b/project/events/2026-04-27T23:45:54.979Z__269d6429-9819-476c-937b-9721005ca7ec.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "269d6429-9819-476c-937b-9721005ca7ec",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-27T23:45:54.979Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "94d074fd-292d-4f94-a7ed-1213d6f5175a"
+  }
+}

--- a/project/events/2026-04-27T23:46:06.943Z__861631b3-2efe-4226-adac-f408722eca7e.json
+++ b/project/events/2026-04-27T23:46:06.943Z__861631b3-2efe-4226-adac-f408722eca7e.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "event_id": "861631b3-2efe-4226-adac-f408722eca7e",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_updated",
+  "occurred_at": "2026-04-27T23:46:06.943Z",
+  "actor_id": "ryan",
+  "payload": {
+    "changed_fields": [
+      "text"
+    ],
+    "comment_author": "ryan",
+    "comment_id": "94d074fd-292d-4f94-a7ed-1213d6f5175a"
+  }
+}

--- a/project/events/2026-04-28T01:18:42.417Z__e0555b8f-c5e7-4768-b5b4-1f96d5e0dd74.json
+++ b/project/events/2026-04-28T01:18:42.417Z__e0555b8f-c5e7-4768-b5b4-1f96d5e0dd74.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e0555b8f-c5e7-4768-b5b4-1f96d5e0dd74",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T01:18:42.417Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "0eb800ad-1b03-4f51-9621-006cf763d04f"
+  }
+}

--- a/project/events/2026-04-28T04:00:03.753Z__5e32f2b8-b87b-4537-b114-1edc7f84c5b2.json
+++ b/project/events/2026-04-28T04:00:03.753Z__5e32f2b8-b87b-4537-b114-1edc7f84c5b2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5e32f2b8-b87b-4537-b114-1edc7f84c5b2",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:00:03.753Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "7530b5a4-4e57-4cc8-bec6-b5a8a51fde54"
+  }
+}

--- a/project/events/2026-04-28T04:00:31.408Z__ae6bb890-0ab8-436c-891a-a8baf19b5960.json
+++ b/project/events/2026-04-28T04:00:31.408Z__ae6bb890-0ab8-436c-891a-a8baf19b5960.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ae6bb890-0ab8-436c-891a-a8baf19b5960",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:00:31.408Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "5bbe81bb-02ed-492a-aa74-f8b794e39480"
+  }
+}

--- a/project/events/2026-04-28T04:02:03.137Z__22aa2651-e274-413e-b490-b17ed727b352.json
+++ b/project/events/2026-04-28T04:02:03.137Z__22aa2651-e274-413e-b490-b17ed727b352.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "22aa2651-e274-413e-b490-b17ed727b352",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:02:03.137Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "ca440085-74d4-43f5-bfe3-418854bcb3d0"
+  }
+}

--- a/project/events/2026-04-28T04:02:19.120Z__d80cc0b4-ec83-4a76-9a1c-26b8d568bc72.json
+++ b/project/events/2026-04-28T04:02:19.120Z__d80cc0b4-ec83-4a76-9a1c-26b8d568bc72.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d80cc0b4-ec83-4a76-9a1c-26b8d568bc72",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:02:19.120Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "22853caf-bd01-4525-b73e-ae1b5e44f3d6"
+  }
+}

--- a/project/events/2026-04-28T04:02:56.456Z__e5b419e4-35a8-4506-8606-45b011b20fca.json
+++ b/project/events/2026-04-28T04:02:56.456Z__e5b419e4-35a8-4506-8606-45b011b20fca.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e5b419e4-35a8-4506-8606-45b011b20fca",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:02:56.456Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "72495d86-1ff1-4655-be3f-fd33a4ea6984"
+  }
+}

--- a/project/events/2026-04-28T04:03:39.236Z__896e8fba-6fbe-4c85-9b78-c827172ad1e8.json
+++ b/project/events/2026-04-28T04:03:39.236Z__896e8fba-6fbe-4c85-9b78-c827172ad1e8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "896e8fba-6fbe-4c85-9b78-c827172ad1e8",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:03:39.236Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "7fad0e54-b72c-419f-8f33-c5fe487aa77d"
+  }
+}

--- a/project/events/2026-04-28T04:05:18.994Z__aaac66a3-1f65-4cee-a8ca-4692f8924a22.json
+++ b/project/events/2026-04-28T04:05:18.994Z__aaac66a3-1f65-4cee-a8ca-4692f8924a22.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "aaac66a3-1f65-4cee-a8ca-4692f8924a22",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:05:18.994Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "773646c3-6b58-46e9-9ff0-b8721763ef72"
+  }
+}

--- a/project/events/2026-04-28T04:08:12.684Z__d38edca2-a71a-4d2d-b6bf-90bed1deb9cd.json
+++ b/project/events/2026-04-28T04:08:12.684Z__d38edca2-a71a-4d2d-b6bf-90bed1deb9cd.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d38edca2-a71a-4d2d-b6bf-90bed1deb9cd",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:08:12.684Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "5928c911-5d38-4f7d-84f3-3dbea7e9dc14"
+  }
+}

--- a/project/events/2026-04-28T04:10:17.142Z__7454eeea-84d4-4f7d-ac3c-cee3ad902e80.json
+++ b/project/events/2026-04-28T04:10:17.142Z__7454eeea-84d4-4f7d-ac3c-cee3ad902e80.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7454eeea-84d4-4f7d-ac3c-cee3ad902e80",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:10:17.142Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "80c67b0e-2ca1-421d-9748-903c1ccad79a"
+  }
+}

--- a/project/events/2026-04-28T04:10:33.027Z__f16932cf-fac5-4c2b-b256-65fe9ccd0dbf.json
+++ b/project/events/2026-04-28T04:10:33.027Z__f16932cf-fac5-4c2b-b256-65fe9ccd0dbf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f16932cf-fac5-4c2b-b256-65fe9ccd0dbf",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:10:33.027Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "057c6930-746d-412e-b835-9f05cd161ea9"
+  }
+}

--- a/project/events/2026-04-28T04:17:43.502Z__9dddfc97-c0ef-4327-b45f-b57fe827b049.json
+++ b/project/events/2026-04-28T04:17:43.502Z__9dddfc97-c0ef-4327-b45f-b57fe827b049.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9dddfc97-c0ef-4327-b45f-b57fe827b049",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:17:43.502Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "54bea0ad-ad66-4b25-b180-7dcdafae46a6"
+  }
+}

--- a/project/events/2026-04-28T04:26:58.630Z__e96f0a15-f422-4aa0-b5d8-65133cd0db83.json
+++ b/project/events/2026-04-28T04:26:58.630Z__e96f0a15-f422-4aa0-b5d8-65133cd0db83.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e96f0a15-f422-4aa0-b5d8-65133cd0db83",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T04:26:58.630Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "c8dbb773-5efe-413c-9bd7-0208da085d27"
+  }
+}

--- a/project/events/2026-04-28T05:05:47.160Z__da54972f-a9ee-4065-8b05-680c81450003.json
+++ b/project/events/2026-04-28T05:05:47.160Z__da54972f-a9ee-4065-8b05-680c81450003.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "da54972f-a9ee-4065-8b05-680c81450003",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T05:05:47.160Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e6d1a971-7fac-427a-aac5-36d8267e79a2"
+  }
+}

--- a/project/events/2026-04-28T11:55:28.332Z__1004f14b-f6ee-440b-8f14-e276f3fe8b41.json
+++ b/project/events/2026-04-28T11:55:28.332Z__1004f14b-f6ee-440b-8f14-e276f3fe8b41.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1004f14b-f6ee-440b-8f14-e276f3fe8b41",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T11:55:28.332Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "8742f643-e4fb-4d2c-be23-f75c0ac8d239"
+  }
+}

--- a/project/events/2026-04-28T12:00:27.098Z__4b6b0d55-601c-475d-bb0a-7c038da4829e.json
+++ b/project/events/2026-04-28T12:00:27.098Z__4b6b0d55-601c-475d-bb0a-7c038da4829e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4b6b0d55-601c-475d-bb0a-7c038da4829e",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T12:00:27.098Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "3c7b9522-5914-4ec7-ad20-9c3097ec8bb0"
+  }
+}

--- a/project/events/2026-04-28T12:39:38.246Z__7bbfa05e-c23d-48c9-a971-4a1114c14cf6.json
+++ b/project/events/2026-04-28T12:39:38.246Z__7bbfa05e-c23d-48c9-a971-4a1114c14cf6.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7bbfa05e-c23d-48c9-a971-4a1114c14cf6",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T12:39:38.246Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "0579d905-deae-48a7-8e2a-40e9b1039e83"
+  }
+}

--- a/project/events/2026-04-28T13:01:51.879Z__94c1153f-eb76-4143-9607-358135f5f574.json
+++ b/project/events/2026-04-28T13:01:51.879Z__94c1153f-eb76-4143-9607-358135f5f574.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "94c1153f-eb76-4143-9607-358135f5f574",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T13:01:51.879Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "c1db64a8-4d64-4184-8531-af7da2dbd4f7"
+  }
+}

--- a/project/events/2026-04-28T18:15:24.637Z__7f217cf7-2b9e-498e-bb73-f896b56f57a1.json
+++ b/project/events/2026-04-28T18:15:24.637Z__7f217cf7-2b9e-498e-bb73-f896b56f57a1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7f217cf7-2b9e-498e-bb73-f896b56f57a1",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T18:15:24.637Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "6c8b2279-eec0-4d6f-a5dc-efe397456334"
+  }
+}

--- a/project/events/2026-04-28T18:19:28.373Z__d81cf1ae-236e-4112-90a4-15ccf13096e0.json
+++ b/project/events/2026-04-28T18:19:28.373Z__d81cf1ae-236e-4112-90a4-15ccf13096e0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d81cf1ae-236e-4112-90a4-15ccf13096e0",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T18:19:28.373Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "cd58b0e7-86c2-4b12-b1a3-819d16a66f2f"
+  }
+}

--- a/project/events/2026-04-28T22:38:07.522Z__1829e98b-47ab-4ff2-8373-ba1d11418107.json
+++ b/project/events/2026-04-28T22:38:07.522Z__1829e98b-47ab-4ff2-8373-ba1d11418107.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "1829e98b-47ab-4ff2-8373-ba1d11418107",
+  "issue_id": "plx-47024c1c-0bff-4943-b73c-5f7602bd1a72",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-28T22:38:07.522Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-b7030f92-0508-4982-a1f3-3c67781a8a72",
+    "priority": 2,
+    "status": "open",
+    "title": "Console session titles: auto-title turns 1/2 + manual rename"
+  }
+}

--- a/project/events/2026-04-28T22:38:12.577Z__8bad0c30-4ebe-4082-af05-c92ae4bd4157.json
+++ b/project/events/2026-04-28T22:38:12.577Z__8bad0c30-4ebe-4082-af05-c92ae4bd4157.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8bad0c30-4ebe-4082-af05-c92ae4bd4157",
+  "issue_id": "plx-47024c1c-0bff-4943-b73c-5f7602bd1a72",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-28T22:38:12.577Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-28T22:38:12.579Z__616b681a-76ba-421c-9549-d16c65bf1df9.json
+++ b/project/events/2026-04-28T22:38:12.579Z__616b681a-76ba-421c-9549-d16c65bf1df9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "616b681a-76ba-421c-9549-d16c65bf1df9",
+  "issue_id": "plx-47024c1c-0bff-4943-b73c-5f7602bd1a72",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T22:38:12.579Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "c8213902-527c-4d7e-b51c-0aee8672e1bf"
+  }
+}

--- a/project/events/2026-04-28T22:41:52.076Z__5e6e5d83-65a8-4403-8e20-54ea015702ee.json
+++ b/project/events/2026-04-28T22:41:52.076Z__5e6e5d83-65a8-4403-8e20-54ea015702ee.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5e6e5d83-65a8-4403-8e20-54ea015702ee",
+  "issue_id": "plx-47024c1c-0bff-4943-b73c-5f7602bd1a72",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T22:41:52.076Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "16d27767-545d-4956-9708-941a81136e47"
+  }
+}

--- a/project/events/2026-04-28T23:40:32.382Z__594049e6-0d3c-404d-bb93-9de6ceefa59c.json
+++ b/project/events/2026-04-28T23:40:32.382Z__594049e6-0d3c-404d-bb93-9de6ceefa59c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "594049e6-0d3c-404d-bb93-9de6ceefa59c",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T23:40:32.382Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "add170de-ed66-4e2f-9ea5-8cdd4c315948"
+  }
+}

--- a/project/events/2026-04-28T23:42:05.108Z__f0f287c8-06de-4173-b0d9-3da55731737a.json
+++ b/project/events/2026-04-28T23:42:05.108Z__f0f287c8-06de-4173-b0d9-3da55731737a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f0f287c8-06de-4173-b0d9-3da55731737a",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T23:42:05.108Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "239f0d56-f66f-4554-b49f-641ad6b53229"
+  }
+}

--- a/project/events/2026-04-28T23:51:05.278Z__188a2ad1-df4d-417c-b706-2c21d6f6d649.json
+++ b/project/events/2026-04-28T23:51:05.278Z__188a2ad1-df4d-417c-b706-2c21d6f6d649.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "188a2ad1-df4d-417c-b706-2c21d6f6d649",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T23:51:05.278Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "4fd4fdf6-c1d9-436e-8f4a-781a22b6f682"
+  }
+}

--- a/project/events/2026-04-28T23:55:08.481Z__44748a71-b231-4d34-9eb4-c296324d336b.json
+++ b/project/events/2026-04-28T23:55:08.481Z__44748a71-b231-4d34-9eb4-c296324d336b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "44748a71-b231-4d34-9eb4-c296324d336b",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-28T23:55:08.481Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e021729b-7cbd-42a5-85c8-10d2729741e8"
+  }
+}

--- a/project/events/2026-04-29T00:01:46.403Z__ac285ee5-936e-400e-815f-633ec20038c8.json
+++ b/project/events/2026-04-29T00:01:46.403Z__ac285ee5-936e-400e-815f-633ec20038c8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ac285ee5-936e-400e-815f-633ec20038c8",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T00:01:46.403Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "5647ae08-8d30-4d82-9a07-3691df46e9d1"
+  }
+}

--- a/project/events/2026-04-29T00:32:04.420Z__ea99b811-5ac4-4115-b8d4-c26f959fa2a5.json
+++ b/project/events/2026-04-29T00:32:04.420Z__ea99b811-5ac4-4115-b8d4-c26f959fa2a5.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ea99b811-5ac4-4115-b8d4-c26f959fa2a5",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T00:32:04.420Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "2a1c44da-94a3-4d03-8f1d-957917974c42"
+  }
+}

--- a/project/events/2026-04-29T01:09:33.807Z__8edd90c5-991d-42f2-bfb5-a6d490864baf.json
+++ b/project/events/2026-04-29T01:09:33.807Z__8edd90c5-991d-42f2-bfb5-a6d490864baf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8edd90c5-991d-42f2-bfb5-a6d490864baf",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T01:09:33.807Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "5d76de1a-0a6f-4748-bc02-3ef409979068"
+  }
+}

--- a/project/events/2026-04-29T01:24:25.740Z__700477d1-80e9-4556-a1ef-5036f287ef36.json
+++ b/project/events/2026-04-29T01:24:25.740Z__700477d1-80e9-4556-a1ef-5036f287ef36.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "700477d1-80e9-4556-a1ef-5036f287ef36",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T01:24:25.740Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "aa218b0f-8d3e-4619-bb91-fe0c55e6c48b"
+  }
+}

--- a/project/events/2026-04-29T02:29:20.735Z__b0d6a682-f51d-46be-830f-60016f7338e0.json
+++ b/project/events/2026-04-29T02:29:20.735Z__b0d6a682-f51d-46be-830f-60016f7338e0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b0d6a682-f51d-46be-830f-60016f7338e0",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T02:29:20.735Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "1488296f-4640-49d6-8536-1557852afddc"
+  }
+}

--- a/project/events/2026-04-29T03:30:46.282Z__feb7c54e-161b-40ba-815c-5148e7921822.json
+++ b/project/events/2026-04-29T03:30:46.282Z__feb7c54e-161b-40ba-815c-5148e7921822.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "feb7c54e-161b-40ba-815c-5148e7921822",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T03:30:46.282Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "edf44c9b-fca8-485a-9be0-09867df691da"
+  }
+}

--- a/project/events/2026-04-29T03:39:44.210Z__90b246ca-3ae1-476d-9b29-cc630aa7b9ac.json
+++ b/project/events/2026-04-29T03:39:44.210Z__90b246ca-3ae1-476d-9b29-cc630aa7b9ac.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "90b246ca-3ae1-476d-9b29-cc630aa7b9ac",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T03:39:44.210Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "3fb97c6b-1e85-4e35-964a-6097453ba19e"
+  }
+}

--- a/project/events/2026-04-29T17:45:02.638Z__0e90e0f0-88f9-42b6-bdbd-d83467ebc3e2.json
+++ b/project/events/2026-04-29T17:45:02.638Z__0e90e0f0-88f9-42b6-bdbd-d83467ebc3e2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0e90e0f0-88f9-42b6-bdbd-d83467ebc3e2",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T17:45:02.638Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "f72709fd-92c7-4d0a-9bc3-0cc70b1f7fa1"
+  }
+}

--- a/project/issues/plx-47024c1c-0bff-4943-b73c-5f7602bd1a72.json
+++ b/project/issues/plx-47024c1c-0bff-4943-b73c-5f7602bd1a72.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-47024c1c-0bff-4943-b73c-5f7602bd1a72",
+  "title": "Console session titles: auto-title turns 1/2 + manual rename",
+  "description": "",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b7030f92-0508-4982-a1f3-3c67781a8a72",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "c8213902-527c-4d7e-b51c-0aee8672e1bf",
+      "author": "ryan",
+      "text": "Implementing: (1) remove category fallback title in console UI, (2) auto-title sessions on user turn 1 and 2 in shared chat runtime with manual-title lock in metadata, (3) add manual rename action in session header menu, (4) add focused Python/Jest coverage.",
+      "created_at": "2026-04-28T22:38:12.579340Z"
+    },
+    {
+      "id": "16d27767-545d-4956-9708-941a81136e47",
+      "author": "ryan",
+      "text": "Implemented session titling + manual rename:\n\n- Added auto-title generation in shared console runtime for user turn 1 and 2 only.\n- Auto-title reads `metadata.model.id` from trigger message, writes `ChatSession.name`, and records metadata (`title_source=auto`, `auto_title_turn`, `auto_title_message_id`).\n- Added manual-title lock check (`title_source=manual`) to skip auto updates.\n- Auto-title failures are now non-fatal to chat response processing.\n- Added session rename UI action in conversation header menu with dialog + save flow; updates session metadata with `title_source=manual`.\n- Removed category fallback from visible session title rendering; now uses explicit name or neutral `Session <id>`.\n\nVerification:\n- `pytest -q plexus/console/test_chat_runtime.py` (23 passed)\n- `cd dashboard && npm test -- --runInBand components/ui/__tests__/conversation-viewer-session-routing.test.tsx components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx` (pass)",
+      "created_at": "2026-04-28T22:41:52.075981Z"
+    }
+  ],
+  "created_at": "2026-04-28T22:38:07.522093Z",
+  "updated_at": "2026-04-28T22:41:52.075981Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
+++ b/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
@@ -40,10 +40,232 @@
       "author": "ryan",
       "text": "Expanded programmatic verification before manual npm-run-dev testing. Added tests for local poller index query/pagination, harness failure marking, stream Lambda partial batch failure, missing stream NewImage, explicit Console session reuse, and built-in Tactus context handoff. Also tightened local worker polling to use the responseStatusCreatedAt sort-key condition instead of a post-query filter. Verification: focused Python suite 53 passed; dashboard Jest streaming suite 6 passed; dashboard typecheck passed; py_compile passed for app.py/local_worker.py/chat_runtime.py.",
       "created_at": "2026-04-27T14:02:15.243723Z"
+    },
+    {
+      "id": "77c8fdb5-e0a6-4945-8048-1da063a25eeb",
+      "author": "ryan",
+      "text": "Deployment progress (2026-04-27): PR #215 merged into develop (4d1b66e). Staging merge was blocked by conflicts on #217; resolved via release branch chore/release-develop-into-staging and merged as PR #218 (1ea6c4f). Staging CI/CD run is active: https://github.com/AnthusAI/Plexus/actions/runs/25018032021. Infra deltas in this release: ChatMessage response routing/status fields + responseTarget/responseStatus/createdAt index, removal of startConsoleRun resolver from data API, ConsoleChatResponder Docker Lambda subscribed directly to ChatMessage DynamoDB stream, and required env vars PLEXUS_API_URL, PLEXUS_API_KEY, CONSOLE_WORKER_IMAGE_URI, optional ANTHROPIC_API_KEY.",
+      "created_at": "2026-04-27T20:39:01.714567Z"
+    },
+    {
+      "id": "319d570d-fa32-4331-970b-d447d2a612ef",
+      "author": "ryan",
+      "text": "Now resolving develop->main promotion conflicts on PR #219 so release can proceed.",
+      "created_at": "2026-04-27T21:03:43.702576Z"
+    },
+    {
+      "id": "caee288e-e264-49cc-93a6-104adf72b583",
+      "author": "ryan",
+      "text": "Applied github-code-quality suggestions on PR #219: replaced five unnecessary lambda wrappers with SimpleNamespace in dashboard/amplify/functions/consoleRunWorker/app_test.py. Pushed to develop at a4ed815f; PR checks rerunning.",
+      "created_at": "2026-04-27T21:25:24.974170Z"
+    },
+    {
+      "id": "f5556fe1-cef6-48c5-b6f6-e1a6942ebb46",
+      "author": "ryan",
+      "text": "Post-deploy validation: running focused architecture smoke tests (stream handler, chat runtime harness, and local worker) before manual UI testing.",
+      "created_at": "2026-04-27T22:34:46.458661Z"
+    },
+    {
+      "id": "8aed0b08-4ea2-464a-865d-f99078fa8a36",
+      "author": "ryan",
+      "text": "Post-deploy smoke results: PR #219 merged to main at cb5267a. Focused architecture tests passed locally: PYTHONPATH=. pytest dashboard/amplify/functions/consoleRunWorker/app_test.py -q (5 passed), pytest plexus/console/test_chat_runtime.py -q (11 passed), pytest plexus/cli/procedure/test_trace_sink.py -q (15 passed), and dashboard Jest conversation streaming suite (6 passed). Ready for live end-to-end cloud/local routing verification from UI.",
+      "created_at": "2026-04-27T22:41:20.899743Z"
+    },
+    {
+      "id": "94d074fd-292d-4f94-a7ed-1213d6f5175a",
+      "author": "ryan",
+      "text": "Deep post-deploy testing found a production blocker. Programmatic suites are green (stream handler/chat runtime/trace sink/frontend streaming tests), but live cloud path fails at runtime: ConsoleChatResponder Lambda invokes from ChatMessage stream and then errors on GraphQL auth (UnauthorizedException: You are not authorized to make this call) during claim_message in process_console_message. Evidence from CloudWatch log group /aws/lambda/amplify-d1cegb1ft4iove-ma-ConsoleChatResponderFunc-QGryg0iEuCI9 around 2026-04-27T23:43Z for stream record 1205984500002426694388310189. Trigger message id 78984680-2258-4751-9941-5cb2493c58b7 remained responseStatus=PENDING with no assistant message. Local worker similarly fails with same auth error when pointed at deployed API. This indicates PLEXUS_API_KEY/authorization wiring is invalid for runtime client in deployed env.",
+      "created_at": "2026-04-27T23:45:54.979177Z"
+    },
+    {
+      "id": "0eb800ad-1b03-4f51-9621-006cf763d04f",
+      "author": "ryan",
+      "text": "Additional local hardening tests completed (2026-04-28): added coverage for createdAt fallback during completion updates when fetched message lacks createdAt; added duplicate stream-delivery handler behavior (process once, skip once); added local_worker tests for NEXT_PUBLIC env fallback, cloud-target rejection, and poll-loop processing owner/target wiring; added fetch_session_history filtering/sort test for USER+ASSISTANT chat messages only. Verification: PYTHONPATH=. pytest plexus/console/test_chat_runtime.py dashboard/amplify/functions/consoleRunWorker/app_test.py dashboard/amplify/functions/consoleRunWorker/local_worker_test.py -q (22 passed); pytest plexus/cli/procedure/test_trace_sink.py plexus/cli/procedure/test_chat_recorder_account_resolution.py plexus/cli/procedure/test_procedure_executor_compat.py -k 'stream or trace or legacy_chat_runtime' -q (22 passed); dashboard Jest console/conversation streaming suite (14 passed); dashboard typecheck passed.",
+      "created_at": "2026-04-28T01:18:42.416706Z"
+    },
+    {
+      "id": "7530b5a4-4e57-4cc8-bec6-b5a8a51fde54",
+      "author": "ryan",
+      "text": "UI follow-up: increasing Console chat message font size in conversation-viewer/message components because message text is currently too small for readability in /lab/console.",
+      "created_at": "2026-04-28T04:00:03.752597Z"
+    },
+    {
+      "id": "5bbe81bb-02ed-492a-aa74-f8b794e39480",
+      "author": "ryan",
+      "text": "Implemented UI readability tweak: increased Console chat message text from text-sm to text-base in message rendering components and thinking placeholder. Verified with focused Jest suites for conversation-viewer streaming and session routing (both passing).",
+      "created_at": "2026-04-28T04:00:31.408421Z"
+    },
+    {
+      "id": "ca440085-74d4-43f5-bfe3-418854bcb3d0",
+      "author": "ryan",
+      "text": "UI tweak requested: make the per-message Spent/Reused cost indicator width independent from message bubble width and uniform across instances.",
+      "created_at": "2026-04-28T04:02:03.137658Z"
+    },
+    {
+      "id": "22853caf-bd01-4525-b73e-ae1b5e44f3d6",
+      "author": "ryan",
+      "text": "Applied cost indicator sizing tweak in conversation-viewer: cost details blocks now use inline-block fixed width (w-64, max-w-full), so they no longer inherit chat bubble width. Focused streaming UI test still passes.",
+      "created_at": "2026-04-28T04:02:19.119905Z"
+    },
+    {
+      "id": "72495d86-1ff1-4655-be3f-fd33a4ea6984",
+      "author": "ryan",
+      "text": "Config tweak requested: console chat currently reports GPT-4o; switching console chat harness default model to gpt-5.4-mini and validating with focused tests.",
+      "created_at": "2026-04-28T04:02:56.456344Z"
+    },
+    {
+      "id": "7fad0e54-b72c-419f-8f33-c5fe487aa77d",
+      "author": "ryan",
+      "text": "Set built-in Console chat assistant model explicitly to gpt-5.4-mini in builtin procedure YAML generation to prevent fallback/default model drift (e.g., gpt-4o). Added test assertion in test_builtin_procedures. Validation: pytest test_builtin_procedures + test_chat_runtime passed.",
+      "created_at": "2026-04-28T04:03:39.235946Z"
+    },
+    {
+      "id": "773646c3-6b58-46e9-9ff0-b8721763ef72",
+      "author": "ryan",
+      "text": "Implementing Console prompt model selector UI in PromptInput and wiring selected model into outgoing chat message metadata (default gpt-5.4-mini).",
+      "created_at": "2026-04-28T04:05:18.994020Z"
+    },
+    {
+      "id": "5928c911-5d38-4f7d-84f3-3dbea7e9dc14",
+      "author": "ryan",
+      "text": "Added Console PromptInput model selector (GPT 5.4 mini / 5.4 / 5.2), defaulting to gpt-5.4-mini. Wired selected model into outgoing USER ChatMessage metadata under metadata.model.id and metadata.instrumentation.client_selected_model. Updated conversation-viewer Jest mocks for PromptInputSelect primitives and added assertion for default selected model in streaming-updates test. Focused suites passing.",
+      "created_at": "2026-04-28T04:08:12.683905Z"
+    },
+    {
+      "id": "80c67b0e-2ca1-421d-9748-903c1ccad79a",
+      "author": "ryan",
+      "text": "Updating Console model selector options to requested list: GPT-5.4, 5.3, 5.2, 5.1, 5.4 mini, 5 mini, 5.4 nano, 5 nano (default remains gpt-5.4-mini).",
+      "created_at": "2026-04-28T04:10:17.142631Z"
+    },
+    {
+      "id": "057c6930-746d-412e-b835-9f05cd161ea9",
+      "author": "ryan",
+      "text": "Updated model selector list to requested set: GPT-5.4, 5.3, 5.2, 5.1, 5.4 mini, 5 mini, 5.4 nano, 5 nano. Default unchanged: gpt-5.4-mini. Re-ran focused conversation-viewer test suites; passing.",
+      "created_at": "2026-04-28T04:10:33.027794Z"
+    },
+    {
+      "id": "54bea0ad-ad66-4b25-b180-7dcdafae46a6",
+      "author": "ryan",
+      "text": "Implemented model propagation end-to-end. Backend: chat_runtime now parses metadata.model.id from ChatMessage (string/dict metadata), stores selected_model on ConsoleMessage, includes metadata in fetch/list queries, and injects context.agent_models={assistant:<model>} into run_experiment for per-turn override (trust pass-through). Tests added/updated: chat_runtime metadata extraction + model-override context; existing no-override context test still enforces absence when not selected. Frontend tests: added selector-change test asserting gpt-5.3 is written into metadata.model.id and instrumentation.client_selected_model. Validation passed: pytest chat_runtime + builtin_procedures, and Jest streaming/session-routing suites.",
+      "created_at": "2026-04-28T04:17:43.501733Z"
+    },
+    {
+      "id": "c8dbb773-5efe-413c-9bd7-0208da085d27",
+      "author": "ryan",
+      "text": "Continuing implementation/verification of latency loop: instrumentation + benchmark harness + worker drain mode + startup cache reuse. Running targeted test suite and local benchmark run next.",
+      "created_at": "2026-04-28T04:26:58.629920Z"
+    },
+    {
+      "id": "e6d1a971-7fac-427a-aac5-36d8267e79a2",
+      "author": "ryan",
+      "text": "Latency loop update (local worker path): Added structured per-message latency logs (claim/history/start/first-token/total), deterministic benchmark script (JSON/CSV artifacts), worker drain mode, ProcedureService reuse, and model pass-through instrumentation. Root cause for extreme latency was redundant chat-recorder console lookups inside _execute_tactus even when console_user_message/history were already present in context; fixed by skipping those lookups when context provides values and disabling trace dispatch-metadata lookup for stream-dispatch runs. Benchmarks: baseline /tmp/console_latency_run_20260428.json first_chunk p95 ~93.7s, total p95 ~94.8s. After fixes with isolated target local:codexbench /tmp/console_latency_codexbench_20260428.json first_chunk p50 1.75s p95 3.73s; total p50 24.8s p95 28.8s. Remaining work: reduce total completion latency (currently ~25-29s) by shrinking post-first-chunk tail and runtime startup overhead.",
+      "created_at": "2026-04-28T05:05:47.159996Z"
+    },
+    {
+      "id": "8742f643-e4fb-4d2c-be23-f75c0ac8d239",
+      "author": "ryan",
+      "text": "UI follow-up (in progress): investigate console conversation auto-follow + bottom jump button behavior for streaming replies. Goal: keep latest assistant chunks visible without manual scrolling and verify whether components are literal Vercel AI Elements package vs local wrappers.",
+      "created_at": "2026-04-28T11:55:28.331870Z"
+    },
+    {
+      "id": "3c7b9522-5914-4ec7-ad20-9c3097ec8bb0",
+      "author": "ryan",
+      "text": "UI scroll follow-up implemented for /lab/console conversation view. Findings: we are not importing the literal Vercel package component for Conversation; we use local wrappers at dashboard/components/ai-elements/*. Added auto-follow controller in conversation-viewer.tsx so stream updates keep viewport pinned, plus a transition snap on Thinking -> first assistant chunk. Added guard so transient atBottom=false during active response does not disable follow mode. Verification: npm --prefix dashboard test -- --runTestsByPath components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx components/ui/__tests__/conversation-viewer-session-routing.test.tsx (12 passed); npm --prefix dashboard run typecheck (pass).",
+      "created_at": "2026-04-28T12:00:27.097798Z"
+    },
+    {
+      "id": "0579d905-deae-48a7-8e2a-40e9b1039e83",
+      "author": "ryan",
+      "text": "Starting implementation of first-class chat session CLI + MCP tools (all sessions). Scope: shared chat ops module + new plexus chat commands (last/messages/send) + MCP chat tools (plexus_chat_last/messages/send) + focused tests.",
+      "created_at": "2026-04-28T12:39:38.245570Z"
+    },
+    {
+      "id": "c1db64a8-4d64-4184-8531-af7da2dbd4f7",
+      "author": "ryan",
+      "text": "Implemented first-class chat session tooling: new shared module plexus/chat/session_ops.py (latest session lookup, message listing with pagination/offset/internal filtering, USER CHAT send, USER RESPONSE send with parent-derived control metadata), new CLI group plexus chat (last/messages/send), and new MCP chat tools (plexus_chat_last/messages/send). Registered chat tools in MCP fast server and legacy server, and registered chat CLI in CommandLineInterface. Verification: pytest -q plexus/chat/session_ops_test.py plexus/cli/chat/chats_test.py MCP/tools/chat/chats_test.py (13 passed); python -m py_compile plexus/chat/session_ops.py plexus/cli/chat/chats.py MCP/tools/chat/chats.py; python -m plexus.cli --help confirms new chat command is present.",
+      "created_at": "2026-04-28T13:01:51.879433Z"
+    },
+    {
+      "id": "6c8b2279-eec0-4d6f-a5dc-efe397456334",
+      "author": "ryan",
+      "text": "Prepared merge to develop: added first-class chat CLI/MCP tools, account resolution hardening, and IAM GraphQL auth mode for CLI/MCP smoke tests. Verified production smoke path and fixed Lambda OPENAI_API_KEY env on main responder.",
+      "created_at": "2026-04-28T18:15:24.636399Z"
+    },
+    {
+      "id": "cd58b0e7-86c2-4b12-b1a3-819d16a66f2f",
+      "author": "ryan",
+      "text": "Opened PR #238 into develop with chat CLI/MCP tools, model-routing/runtime hardening, and dashboard conversation fixes. Rebased branch on origin/develop to resolve conflicts and force-pushed; checks are running. PR: https://github.com/AnthusAI/Plexus/pull/238",
+      "created_at": "2026-04-28T18:19:28.373263Z"
+    },
+    {
+      "id": "add170de-ed66-4e2f-9ea5-8cdd4c315948",
+      "author": "ryan",
+      "text": "Starting implementation for 'hidden-until-named' session visibility: finish ChatSession.onUpdate list reveal, enforce sidebar filtering for metadata.console.hidden_until_named, wire create-first-message sessions with hidden flag, and fix/update Jest + Python tests to validate strict behavior.",
+      "created_at": "2026-04-28T23:40:32.381284Z"
+    },
+    {
+      "id": "239f0d56-f66f-4554-b49f-641ad6b53229",
+      "author": "ryan",
+      "text": "Implemented hidden-until-named session visibility flow: (1) first-prompt-created sessions are created with metadata.console.hidden_until_named=true, (2) auto-title path now clears hidden flag on successful title update and preserves strict hidden behavior on title failure, (3) manual rename sets title_source=manual and clears hidden flag, (4) sidebar filters hidden unnamed sessions, (5) session onUpdate subscription triggers fast list reveal. Validation: pytest -q plexus/console/test_chat_runtime.py (23 passed) and dashboard Jest session-routing + streaming suites (17 passed).",
+      "created_at": "2026-04-28T23:42:05.108484Z"
+    },
+    {
+      "id": "4fd4fdf6-c1d9-436e-8f4a-781a22b6f682",
+      "author": "ryan",
+      "text": "UI selection tweak implemented: when the currently selected session disappears during refresh (common with hidden-until-named + eventual consistency), we now clear selection instead of auto-selecting a different visible session. Added regression test in conversation-viewer-streaming-updates to assert 'No session selected' state after session replacement refresh. Re-ran dashboard Jest suites: 18 passed.",
+      "created_at": "2026-04-28T23:51:05.278209Z"
+    },
+    {
+      "id": "e021729b-7cbd-42a5-85c8-10d2729741e8",
+      "author": "ryan",
+      "text": "Applied stricter hidden-until-named UX: all new-session creation paths (including + New session) now set hidden_until_named=true; selected hidden session remains out of sidebar list; main header for hidden unnamed sessions now shows neutral 'New Chat' instead of Session <id>; no auto-highlight of a different session while hidden current session is active. Re-ran targeted dashboard Jest suites: 18/18 passing.",
+      "created_at": "2026-04-28T23:55:08.480419Z"
+    },
+    {
+      "id": "5647ae08-8d30-4d82-9a07-3691df46e9d1",
+      "author": "ryan",
+      "text": "Updated auto-title context for turn 2 to include prior assistant output between user turns. Session title prompt context is now: user#1, assistant message(s) between user#1 and user#2, user#2. It no longer uses only user messages for second-title generation. Added/updated runtime tests in plexus/console/test_chat_runtime.py; pytest suite remains green (23 passed).",
+      "created_at": "2026-04-29T00:01:46.403631Z"
+    },
+    {
+      "id": "2a1c44da-94a3-4d03-8f1d-957917974c42",
+      "author": "ryan",
+      "text": "Updated console built-in agent tool access: plexus/procedures/console_chat_agent.yaml now grants assistant tools: [plexus], enabling full Plexus MCP toolset for Console chat turns. Regression check: pytest -q plexus/console/test_chat_runtime.py (23 passed).",
+      "created_at": "2026-04-29T00:32:04.419728Z"
+    },
+    {
+      "id": "5d76de1a-0a6f-4748-bc02-3ef409979068",
+      "author": "ryan",
+      "text": "Investigating tool-call failure in local console responder. Verified shared runtime had enable_mcp disabled; switched to enable_mcp=True and updated tests. Next: run live smoke with local worker and inspect logs for actual tool invocation; if still failing, patch toolset resolution and re-test end-to-end.",
+      "created_at": "2026-04-29T01:09:33.806278Z"
+    },
+    {
+      "id": "aa218b0f-8d3e-4619-bb91-fe0c55e6c48b",
+      "author": "ryan",
+      "text": "Tool-use root cause identified and fixed. The built-in console procedure source is generated in plexus/cli/procedure/builtin_procedures.py, and it was hard-coded with assistant tools: [] (ignoring edits to plexus/procedures/console_chat_agent.yaml). Updated built-in config to tools: [plexus] and added explicit system prompt instruction to call tools when requested. Verified with runtime debug: agent raw tools config now ['plexus'], toolset resolves successfully, and workflow reports 1 tool call. Live local-worker smoke (IAM auth mode: PLEXUS_GRAPHQL_AUTH_MODE=iam + AWS_PROFILE=capacity_anthus) now persists ASSISTANT TOOL_CALL messages (e.g., 'Tool call: plexus_scorecards_list').",
+      "created_at": "2026-04-29T01:24:25.740364Z"
+    },
+    {
+      "id": "1488296f-4640-49d6-8536-1557852afddc",
+      "author": "ryan",
+      "text": "Starting first-party Tactus fix for tool-result propagation (no Plexus monkey patch). Confirmed editable Tactus source at /Users/ryan/Projects/Tactus/tactus/dspy/agent.py and that current non-streaming path is single-pass after tool execution. Implementing multi-round tool-call loop + force-synthesis-on-no-final-output in Tactus, then removing local post-tool patch in plexus/cli/procedure/procedure_executor.py and revalidating console smoke.",
+      "created_at": "2026-04-29T02:29:20.734591Z"
+    },
+    {
+      "id": "edf44c9b-fca8-485a-9be0-09867df691da",
+      "author": "ryan",
+      "text": "Returning focus from Tactus merge/deploy to the Console agent tool-surface cleanup: implement a single model-facing Plexus MCP dispatcher tool for the built-in Console agent, backed by the existing MCP registry, then validate via focused tests and local responder smoke.",
+      "created_at": "2026-04-29T03:30:46.281863Z"
+    },
+    {
+      "id": "3fb97c6b-1e85-4e35-964a-6097453ba19e",
+      "author": "ryan",
+      "text": "Implemented and verified Console's single model-facing Plexus MCP dispatcher tool. For builtin:console/chat, tools: [plexus] now exposes one Tactus tool named plexus; its tool_name argument dispatches to the selected underlying MCP tool and arguments are passed as JSON. Kept non-Console Tactus MCP bridging unchanged. Live IAM/local-worker smoke against session 64d67ced-c0d9-4cb8-b62a-e288abde2195 succeeded: internal TOOL_CALL is now 'Tool call: plexus' and assistant answered from plexus_scorecards_list results. Focused tests passed: PYTHONPATH=. pytest -q plexus/cli/procedure/test_procedure_executor_compat.py plexus/cli/procedure/test_builtin_procedures.py plexus/console/test_chat_runtime.py -q (51 passed).",
+      "created_at": "2026-04-29T03:39:44.209922Z"
     }
   ],
   "created_at": "2026-04-27T12:42:41.687340Z",
-  "updated_at": "2026-04-27T14:02:15.243723Z",
+  "updated_at": "2026-04-29T03:39:44.209922Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
+++ b/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
@@ -262,10 +262,19 @@
       "author": "ryan",
       "text": "Implemented and verified Console's single model-facing Plexus MCP dispatcher tool. For builtin:console/chat, tools: [plexus] now exposes one Tactus tool named plexus; its tool_name argument dispatches to the selected underlying MCP tool and arguments are passed as JSON. Kept non-Console Tactus MCP bridging unchanged. Live IAM/local-worker smoke against session 64d67ced-c0d9-4cb8-b62a-e288abde2195 succeeded: internal TOOL_CALL is now 'Tool call: plexus' and assistant answered from plexus_scorecards_list results. Focused tests passed: PYTHONPATH=. pytest -q plexus/cli/procedure/test_procedure_executor_compat.py plexus/cli/procedure/test_builtin_procedures.py plexus/console/test_chat_runtime.py -q (51 passed).",
       "created_at": "2026-04-29T03:39:44.209922Z"
+    },
+    {
+      "id": "f72709fd-92c7-4d0a-9bc3-0cc70b1f7fa1",
+      "author": "ryan",
+      "text": "Prepared Console Plexus tool dispatcher for fresh develop PR. Tactus import resolves to 0.46.3 from /Users/ryan/Projects/Tactus. Focused verification passed: python -m pytest -q plexus/cli/procedure/test_procedure_executor_compat.py plexus/cli/procedure/test_builtin_procedures.py plexus/console/test_chat_runtime.py plexus/cli/procedure/lua_dsl/test_runtime_basic.py plexus/cli/procedure/lua_dsl/tests/test_agent_primitives.py (84 passed).",
+      "created_at": "2026-04-29T17:45:02.636604Z"
     }
   ],
   "created_at": "2026-04-27T12:42:41.687340Z",
-  "updated_at": "2026-04-29T03:39:44.209922Z",
+  "updated_at": "2026-04-29T17:45:02.636604Z",
   "closed_at": null,
-  "custom": {}
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
 }


### PR DESCRIPTION
## Summary
- enables MCP for the shared Console chat responder path
- exposes one model-facing `plexus` dispatcher tool for Console chat
- dispatches underlying Plexus MCP tools by `tool_name` plus JSON `arguments`
- updates built-in Console agent instructions/config so tool requests use the dispatcher

## Verification
- Confirmed Tactus import resolves to `0.46.3`
- `python -m pytest -q plexus/cli/procedure/test_procedure_executor_compat.py plexus/cli/procedure/test_builtin_procedures.py plexus/console/test_chat_runtime.py plexus/cli/procedure/lua_dsl/test_runtime_basic.py plexus/cli/procedure/lua_dsl/tests/test_agent_primitives.py` -> 84 passed

## Notes
- Leaves unrelated local diagram/doc edits out of this PR
- Tactus owns multi-tool/final-answer behavior; Plexus only bridges/configures the Console tool surface