### PR TITLE
Restore FeedbackItem metrics aggregation

### DIFF
--- a/infrastructure/deploy_metrics_only.py
+++ b/infrastructure/deploy_metrics_only.py
@@ -30,8 +30,8 @@ print()
 app = cdk.App()
 
 account = os.environ.get('CDK_DEFAULT_ACCOUNT')
-# Use AWS_REGION from .env, fallback to CDK_DEFAULT_REGION, then us-west-2
-region = os.environ.get('AWS_REGION') or os.environ.get('CDK_DEFAULT_REGION', 'us-west-2')
+# Metrics aggregation production resources are deployed with the Amplify data plane in us-west-2.
+region = os.environ.get('AWS_REGION') or 'us-west-2'
 env = cdk.Environment(account=account, region=region)
 
 print(f"Deploying to region: {region}")

--- a/infrastructure/deploy_metrics_only.py
+++ b/infrastructure/deploy_metrics_only.py
@@ -30,8 +30,8 @@ print()
 app = cdk.App()
 
 account = os.environ.get('CDK_DEFAULT_ACCOUNT')
-# Metrics aggregation production resources are deployed with the Amplify data plane in us-west-2.
-region = os.environ.get('AWS_REGION') or 'us-west-2'
+# Use AWS_REGION from .env, fallback to CDK_DEFAULT_REGION, then us-west-2
+region = os.environ.get('AWS_REGION') or os.environ.get('CDK_DEFAULT_REGION', 'us-west-2')
 env = cdk.Environment(account=account, region=region)
 
 print(f"Deploying to region: {region}")

--- a/infrastructure/lambda_functions/metrics_aggregator/bucket_counter.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/bucket_counter.py
@@ -6,8 +6,15 @@ by iterating through the data once and assigning each record to all relevant buc
 """
 
 from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Tuple, Set
+from typing import Dict, List, Tuple, Optional
 from collections import defaultdict
+
+
+FEEDBACK_RECORD_TYPES = [
+    'feedbackItems',
+    'feedbackItemsByScorecard',
+    'feedbackItemsByScore',
+]
 
 
 class BucketCounter:
@@ -98,6 +105,14 @@ class BucketCounter:
         return epoch + timedelta(minutes=bucket_start_minutes)
 
 
+def align_to_bucket(timestamp: datetime, bucket_minutes: int) -> datetime:
+    """Align a timestamp to a bucket boundary without instantiating a counter."""
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    minutes_since_epoch = int((timestamp - epoch).total_seconds() / 60)
+    bucket_start_minutes = (minutes_since_epoch // bucket_minutes) * bucket_minutes
+    return epoch + timedelta(minutes=bucket_start_minutes)
+
+
 def get_time_window() -> Tuple[datetime, datetime]:
     """
     Get the time window to query (current hour + previous hour).
@@ -184,6 +199,145 @@ def count_records_efficiently(records: List[Dict[str, any]],
         size_total = sum(b['count'] for b in size_buckets)
         print(f"    {size:2d}min: {len(size_buckets):3d} buckets, {size_total:5d} total records")
     
+    return bucket_counts
+
+
+def get_feedback_record_timestamp(record: Dict[str, any]) -> Optional[datetime]:
+    """Resolve the effective feedback timestamp used for bucketing."""
+    timestamp_str = record.get('editedAt') or record.get('updatedAt') or record.get('createdAt')
+    if not timestamp_str:
+        return None
+    return parse_iso_datetime(timestamp_str)
+
+
+def classify_feedback_record(record: Dict[str, any]) -> str:
+    """Classify a feedback record using dashboard/report semantics."""
+    is_invalid = record.get('isInvalid')
+    if isinstance(is_invalid, str):
+        is_invalid = is_invalid.strip().lower() in ('1', 'true', 'yes', 'y', 'on')
+    elif isinstance(is_invalid, (int, float)):
+        is_invalid = is_invalid != 0
+    else:
+        is_invalid = bool(is_invalid)
+
+    initial_value = record.get('initialAnswerValue')
+    final_value = record.get('finalAnswerValue')
+
+    if is_invalid or initial_value is None or final_value is None:
+        return 'invalid'
+    if str(initial_value) != str(final_value):
+        return 'changed'
+    return 'unchanged'
+
+
+def dedupe_feedback_records(records: List[Dict[str, any]]) -> List[Dict[str, any]]:
+    """Deduplicate feedback items by id using the newest effective timestamp."""
+    deduped: Dict[str, Dict[str, any]] = {}
+    for record in records:
+        record_id = record.get('id')
+        if not record_id:
+            continue
+        timestamp = get_feedback_record_timestamp(record)
+        if not timestamp:
+            continue
+        existing = deduped.get(record_id)
+        if not existing:
+            deduped[record_id] = record
+            continue
+        existing_timestamp = get_feedback_record_timestamp(existing)
+        if not existing_timestamp or timestamp >= existing_timestamp:
+            deduped[record_id] = record
+    return list(deduped.values())
+
+
+def count_feedback_records_efficiently(
+    records: List[Dict[str, any]],
+    account_id: str,
+) -> List[Dict[str, any]]:
+    """Count FeedbackItems into account, scorecard, and score scoped buckets."""
+    counters: Dict[Tuple[str, Optional[str], Optional[str]], Dict[Tuple[datetime, int], Dict[str, int]]] = {}
+    processed = 0
+    skipped = 0
+
+    def get_counter(
+        record_type: str,
+        scorecard_id: Optional[str] = None,
+        score_id: Optional[str] = None,
+    ) -> Dict[Tuple[datetime, int], Dict[str, int]]:
+        key = (record_type, scorecard_id, score_id)
+        if key not in counters:
+            counters[key] = defaultdict(lambda: {
+                'count': 0,
+                'changed_count': 0,
+                'unchanged_count': 0,
+                'invalid_count': 0,
+            })
+        return counters[key]
+
+    for record in dedupe_feedback_records(records):
+        timestamp = get_feedback_record_timestamp(record)
+        if not timestamp:
+            skipped += 1
+            continue
+
+        scorecard_id = record.get('scorecardId')
+        score_id = record.get('scoreId')
+        classification = classify_feedback_record(record)
+
+        scopes = [('feedbackItems', None, None)]
+        if scorecard_id:
+            scopes.append(('feedbackItemsByScorecard', scorecard_id, None))
+        if scorecard_id and score_id:
+            scopes.append(('feedbackItemsByScore', scorecard_id, score_id))
+
+        for record_type, scoped_scorecard_id, scoped_score_id in scopes:
+            counter = get_counter(record_type, scoped_scorecard_id, scoped_score_id)
+            for bucket_minutes in BucketCounter.BUCKET_SIZES:
+                bucket_start = align_to_bucket(timestamp, bucket_minutes)
+                bucket_key = (bucket_start, bucket_minutes)
+                bucket = counter[bucket_key]
+                bucket['count'] += 1
+                if classification == 'changed':
+                    bucket['changed_count'] += 1
+                elif classification == 'unchanged':
+                    bucket['unchanged_count'] += 1
+                else:
+                    bucket['invalid_count'] += 1
+
+        processed += 1
+
+    now = datetime.now(timezone.utc)
+    bucket_counts: List[Dict[str, any]] = []
+    for (record_type, scorecard_id, score_id), scoped_buckets in counters.items():
+        for (bucket_start, bucket_minutes), bucket in scoped_buckets.items():
+            bucket_end = bucket_start + timedelta(minutes=bucket_minutes)
+            bucket_counts.append({
+                'account_id': account_id,
+                'record_type': record_type,
+                'scorecard_id': scorecard_id,
+                'score_id': score_id,
+                'time_range_start': bucket_start.isoformat().replace('+00:00', 'Z'),
+                'time_range_end': bucket_end.isoformat().replace('+00:00', 'Z'),
+                'number_of_minutes': bucket_minutes,
+                'count': bucket['count'],
+                'complete': bucket_end <= now,
+                'metadata': {
+                    'changedCount': bucket['changed_count'],
+                    'unchangedCount': bucket['unchanged_count'],
+                    'invalidCount': bucket['invalid_count'],
+                },
+            })
+
+    print(f"  Processed: {processed} feedback items ({skipped} skipped - no effective timestamp)")
+    for record_type in FEEDBACK_RECORD_TYPES:
+        type_buckets = [bucket for bucket in bucket_counts if bucket['record_type'] == record_type]
+        one_min_total = sum(
+            bucket['count']
+            for bucket in type_buckets
+            if bucket['number_of_minutes'] == 1
+        )
+        print(f"    {record_type}: {len(type_buckets)} buckets, {one_min_total} total feedback items in 1-min buckets")
+
     return bucket_counts
 
 

--- a/infrastructure/lambda_functions/metrics_aggregator/graphql_client.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/graphql_client.py
@@ -94,7 +94,9 @@ class GraphQLClient:
     def generate_composite_key(self,
                                record_type: str,
                                time_range_start: str,
-                               number_of_minutes: int) -> str:
+                               number_of_minutes: int,
+                               scorecard_id: Optional[str] = None,
+                               score_id: Optional[str] = None) -> str:
         """
         Generate composite key for AggregatedMetrics.
         
@@ -106,6 +108,10 @@ class GraphQLClient:
         Returns:
             Composite key string
         """
+        if score_id:
+            return f"{record_type}#{score_id}#{time_range_start}#{number_of_minutes}"
+        if scorecard_id:
+            return f"{record_type}#{scorecard_id}#{time_range_start}#{number_of_minutes}"
         return f"{record_type}#{time_range_start}#{number_of_minutes}"
     
     def create_aggregated_metrics(self,
@@ -117,7 +123,8 @@ class GraphQLClient:
                                   count: int,
                                   complete: bool = False,
                                   scorecard_id: Optional[str] = None,
-                                  score_id: Optional[str] = None) -> Dict[str, Any]:
+                                  score_id: Optional[str] = None,
+                                  metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Create a new AggregatedMetrics record with composite key.
         
@@ -146,12 +153,19 @@ class GraphQLClient:
                 numberOfMinutes
                 count
                 complete
+                metadata
             }
         }
         """
         
         now = datetime.utcnow().isoformat() + 'Z'
-        composite_key = self.generate_composite_key(record_type, time_range_start, number_of_minutes)
+        composite_key = self.generate_composite_key(
+            record_type,
+            time_range_start,
+            number_of_minutes,
+            scorecard_id=scorecard_id,
+            score_id=score_id
+        )
         
         input_data = {
             'accountId': account_id,
@@ -170,6 +184,8 @@ class GraphQLClient:
             input_data['scorecardId'] = scorecard_id
         if score_id:
             input_data['scoreId'] = score_id
+        if metadata is not None:
+            input_data['metadata'] = metadata
         
         variables = {'input': input_data}
         
@@ -186,7 +202,8 @@ class GraphQLClient:
                                   count: int,
                                   complete: bool = False,
                                   scorecard_id: Optional[str] = None,
-                                  score_id: Optional[str] = None) -> Dict[str, Any]:
+                                  score_id: Optional[str] = None,
+                                  metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Update an existing AggregatedMetrics record using composite key.
         
@@ -212,6 +229,7 @@ class GraphQLClient:
                 compositeKey
                 count
                 complete
+                metadata
                 updatedAt
             }
         }
@@ -238,6 +256,8 @@ class GraphQLClient:
             variables['input']['scorecardId'] = scorecard_id
         if score_id:
             variables['input']['scoreId'] = score_id
+        if metadata is not None:
+            variables['input']['metadata'] = metadata
         
         data = self.execute_query(mutation, variables)
         return data.get('updateAggregatedMetrics', {})
@@ -251,7 +271,8 @@ class GraphQLClient:
                                   count: int,
                                   complete: bool = False,
                                   scorecard_id: Optional[str] = None,
-                                  score_id: Optional[str] = None) -> Dict[str, Any]:
+                                  score_id: Optional[str] = None,
+                                  metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
         Create or update an AggregatedMetrics record using composite key.
         With composite keys, we can directly create - DynamoDB will handle upsert.
@@ -272,7 +293,13 @@ class GraphQLClient:
         """
         # With composite primary key, we can just create/update directly
         # Try update first (more common case), fall back to create
-        composite_key = self.generate_composite_key(record_type, time_range_start, number_of_minutes)
+        composite_key = self.generate_composite_key(
+            record_type,
+            time_range_start,
+            number_of_minutes,
+            scorecard_id=scorecard_id,
+            score_id=score_id
+        )
         
         try:
             # Try update first
@@ -286,7 +313,8 @@ class GraphQLClient:
                 count=count,
                 complete=complete,
                 scorecard_id=scorecard_id,
-                score_id=score_id
+                score_id=score_id,
+                metadata=metadata
             )
         except Exception as e:
             # If update fails, fall back to create
@@ -304,7 +332,8 @@ class GraphQLClient:
                     count=count,
                     complete=complete,
                     scorecard_id=scorecard_id,
-                    score_id=score_id
+                    score_id=score_id,
+                    metadata=metadata
                 )
             else:
                 raise

--- a/infrastructure/lambda_functions/metrics_aggregator/graphql_queries.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/graphql_queries.py
@@ -8,6 +8,8 @@ to get all records in a time window for counting.
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 
+from bucket_counter import dedupe_feedback_records
+
 
 def query_items_in_window(graphql_client, 
                           account_id: str, 
@@ -218,9 +220,39 @@ def query_feedback_items_in_window(graphql_client,
                                    account_id: str,
                                    start_time: datetime,
                                    end_time: datetime) -> List[Dict[str, Any]]:
-    """Query all FeedbackItems in a time window with pagination."""
-    query = """
-    query ListFeedbackItemsByTime(
+    """Query FeedbackItems in a time window via editedAt and updatedAt, then dedupe."""
+    edited_query = """
+    query ListFeedbackItemsByEditedTime(
+        $accountId: String!,
+        $startTime: String!,
+        $endTime: String!,
+        $nextToken: String
+    ) {
+        listFeedbackItemByAccountIdAndEditedAt(
+            accountId: $accountId,
+            editedAt: { between: [$startTime, $endTime] },
+            limit: 1000,
+            nextToken: $nextToken
+        ) {
+            items {
+                id
+                scorecardId
+                scoreId
+                itemId
+                initialAnswerValue
+                finalAnswerValue
+                isInvalid
+                editedAt
+                updatedAt
+                createdAt
+            }
+            nextToken
+        }
+    }
+    """
+
+    updated_query = """
+    query ListFeedbackItemsByUpdatedTime(
         $accountId: String!,
         $startTime: String!,
         $endTime: String!,
@@ -234,23 +266,45 @@ def query_feedback_items_in_window(graphql_client,
         ) {
             items {
                 id
+                scorecardId
+                scoreId
+                itemId
+                initialAnswerValue
+                finalAnswerValue
+                isInvalid
+                editedAt
                 updatedAt
+                createdAt
             }
             nextToken
         }
     }
     """
     
-    return _paginated_query(
+    variables = {
+        'accountId': account_id,
+        'startTime': start_time.isoformat().replace('+00:00', 'Z'),
+        'endTime': end_time.isoformat().replace('+00:00', 'Z')
+    }
+
+    edited_items = _paginated_query(
         graphql_client,
-        query,
-        {
-            'accountId': account_id,
-            'startTime': start_time.isoformat().replace('+00:00', 'Z'),
-            'endTime': end_time.isoformat().replace('+00:00', 'Z')
-        },
+        edited_query,
+        dict(variables),
+        'listFeedbackItemByAccountIdAndEditedAt'
+    )
+    updated_items = _paginated_query(
+        graphql_client,
+        updated_query,
+        dict(variables),
         'listFeedbackItemByAccountIdAndUpdatedAt'
     )
+    deduped_items = dedupe_feedback_records(edited_items + updated_items)
+    print(
+        f"  Deduped feedback items: {len(deduped_items)} unique "
+        f"from {len(edited_items)} editedAt + {len(updated_items)} updatedAt records"
+    )
+    return deduped_items
 
 
 def query_procedures_in_window(graphql_client,

--- a/infrastructure/lambda_functions/metrics_aggregator/handler.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/handler.py
@@ -15,7 +15,7 @@ from typing import Dict, Any, Set
 
 from graphql_client import get_client_from_env
 from graphql_queries import query_records_for_counting
-from bucket_counter import count_records_efficiently, get_time_window
+from bucket_counter import count_records_efficiently, count_feedback_records_efficiently, get_time_window
 
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -134,6 +134,10 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     
                     # Combine all bucket counts
                     all_bucket_counts = bucket_counts + prediction_bucket_counts + evaluation_bucket_counts
+                elif record_type == 'feedbackItems':
+                    print(f"[2/3] Counting feedbackItems into scoped buckets...")
+                    all_bucket_counts = count_feedback_records_efficiently(records, account_id)
+                    print(f"[2/3] Generated {len(all_bucket_counts)} bucket updates")
                 else:
                     # Count records into all buckets efficiently (O(n))
                     print(f"[2/3] Counting into buckets...")
@@ -274,7 +278,10 @@ def update_buckets(graphql_client, bucket_counts: list) -> tuple:
                 time_range_end=bucket['time_range_end'],
                 number_of_minutes=bucket['number_of_minutes'],
                 count=bucket['count'],
-                complete=bucket['complete']
+                complete=bucket['complete'],
+                scorecard_id=bucket.get('scorecard_id'),
+                score_id=bucket.get('score_id'),
+                metadata=bucket.get('metadata')
             )
             updates += 1
             
@@ -284,4 +291,3 @@ def update_buckets(graphql_client, bucket_counts: list) -> tuple:
                   f"({bucket['number_of_minutes']}min): {e}")
     
     return updates, errors
-

--- a/infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py
@@ -1,0 +1,240 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+METRICS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(METRICS_DIR))
+
+from bucket_counter import (  # noqa: E402
+    count_feedback_records_efficiently,
+    dedupe_feedback_records,
+)
+from graphql_client import GraphQLClient  # noqa: E402
+from graphql_queries import query_feedback_items_in_window  # noqa: E402
+from handler import update_buckets  # noqa: E402
+
+
+def test_dedupe_feedback_records_prefers_latest_effective_timestamp():
+    records = [
+        {
+            "id": "feedback-1",
+            "scorecardId": "scorecard-1",
+            "scoreId": "score-1",
+            "initialAnswerValue": "yes",
+            "finalAnswerValue": "yes",
+            "updatedAt": "2026-04-24T00:00:00Z",
+        },
+        {
+            "id": "feedback-1",
+            "scorecardId": "scorecard-1",
+            "scoreId": "score-1",
+            "initialAnswerValue": "yes",
+            "finalAnswerValue": "no",
+            "editedAt": "2026-04-24T01:00:00Z",
+            "updatedAt": "2026-04-24T01:00:00Z",
+        },
+    ]
+
+    deduped = dedupe_feedback_records(records)
+
+    assert len(deduped) == 1
+    assert deduped[0]["finalAnswerValue"] == "no"
+
+
+def test_count_feedback_records_efficiently_writes_scoped_buckets_and_metadata():
+    records = [
+        {
+            "id": "feedback-1",
+            "scorecardId": "scorecard-1",
+            "scoreId": "score-1",
+            "initialAnswerValue": "yes",
+            "finalAnswerValue": "no",
+            "editedAt": "2026-04-24T12:00:00Z",
+        },
+        {
+            "id": "feedback-2",
+            "scorecardId": "scorecard-1",
+            "scoreId": "score-1",
+            "initialAnswerValue": "yes",
+            "finalAnswerValue": "yes",
+            "updatedAt": "2026-04-24T12:01:00Z",
+        },
+        {
+            "id": "feedback-3",
+            "scorecardId": "scorecard-1",
+            "scoreId": "score-2",
+            "initialAnswerValue": "yes",
+            "finalAnswerValue": None,
+            "updatedAt": "2026-04-24T12:02:00Z",
+        },
+    ]
+
+    counts = count_feedback_records_efficiently(records, "account-1")
+
+    account_one_min = [
+        bucket
+        for bucket in counts
+        if bucket["record_type"] == "feedbackItems"
+        and bucket["number_of_minutes"] == 1
+    ]
+    scorecard_one_min = [
+        bucket
+        for bucket in counts
+        if bucket["record_type"] == "feedbackItemsByScorecard"
+        and bucket["number_of_minutes"] == 1
+    ]
+    score_one_min = [
+        bucket
+        for bucket in counts
+        if bucket["record_type"] == "feedbackItemsByScore"
+        and bucket["number_of_minutes"] == 1
+    ]
+
+    assert len(account_one_min) == 3
+    assert sum(bucket["count"] for bucket in account_one_min) == 3
+    assert sum(bucket["metadata"]["changedCount"] for bucket in account_one_min) == 1
+    assert sum(bucket["metadata"]["unchangedCount"] for bucket in account_one_min) == 1
+    assert sum(bucket["metadata"]["invalidCount"] for bucket in account_one_min) == 1
+
+    assert len(scorecard_one_min) == 3
+    assert {bucket["scorecard_id"] for bucket in scorecard_one_min} == {"scorecard-1"}
+
+    assert len(score_one_min) == 3
+    assert sorted(bucket["score_id"] for bucket in score_one_min) == [
+        "score-1",
+        "score-1",
+        "score-2",
+    ]
+
+
+def test_graphql_client_generates_scoped_composite_keys():
+    client = GraphQLClient.__new__(GraphQLClient)
+
+    assert client.generate_composite_key(
+        "feedbackItems",
+        "2026-04-24T12:00:00Z",
+        1,
+    ) == "feedbackItems#2026-04-24T12:00:00Z#1"
+    assert client.generate_composite_key(
+        "feedbackItemsByScorecard",
+        "2026-04-24T12:00:00Z",
+        1,
+        scorecard_id="scorecard-1",
+    ) == "feedbackItemsByScorecard#scorecard-1#2026-04-24T12:00:00Z#1"
+    assert client.generate_composite_key(
+        "feedbackItemsByScore",
+        "2026-04-24T12:00:00Z",
+        1,
+        scorecard_id="scorecard-1",
+        score_id="score-1",
+    ) == "feedbackItemsByScore#score-1#2026-04-24T12:00:00Z#1"
+
+
+def test_update_buckets_passes_scope_and_metadata_to_graphql_client():
+    class FakeGraphQLClient:
+        def __init__(self):
+            self.calls = []
+
+        def upsert_aggregated_metrics(self, **kwargs):
+            self.calls.append(kwargs)
+
+    graphql_client = FakeGraphQLClient()
+    buckets = [
+        {
+            "account_id": "account-1",
+            "record_type": "feedbackItemsByScore",
+            "scorecard_id": "scorecard-1",
+            "score_id": "score-1",
+            "time_range_start": "2026-04-24T12:00:00Z",
+            "time_range_end": "2026-04-24T12:01:00Z",
+            "number_of_minutes": 1,
+            "count": 1,
+            "complete": True,
+            "metadata": {
+                "changedCount": 1,
+                "unchangedCount": 0,
+                "invalidCount": 0,
+            },
+        }
+    ]
+
+    updates, errors = update_buckets(graphql_client, buckets)
+
+    assert updates == 1
+    assert errors == 0
+    assert graphql_client.calls == [
+        {
+            "account_id": "account-1",
+            "record_type": "feedbackItemsByScore",
+            "time_range_start": "2026-04-24T12:00:00Z",
+            "time_range_end": "2026-04-24T12:01:00Z",
+            "number_of_minutes": 1,
+            "count": 1,
+            "complete": True,
+            "scorecard_id": "scorecard-1",
+            "score_id": "score-1",
+            "metadata": {
+                "changedCount": 1,
+                "unchangedCount": 0,
+                "invalidCount": 0,
+            },
+        }
+    ]
+
+
+def test_query_feedback_items_uses_edited_and_updated_indexes_then_dedupes():
+    class FakeGraphQLClient:
+        def __init__(self):
+            self.queries = []
+
+        def execute_query(self, query, variables):
+            self.queries.append(query)
+            if "listFeedbackItemByAccountIdAndEditedAt" in query:
+                return {
+                    "listFeedbackItemByAccountIdAndEditedAt": {
+                        "items": [
+                            {
+                                "id": "feedback-1",
+                                "scorecardId": "scorecard-1",
+                                "scoreId": "score-1",
+                                "initialAnswerValue": "yes",
+                                "finalAnswerValue": "no",
+                                "editedAt": "2026-04-24T12:00:00Z",
+                                "updatedAt": "2026-04-24T12:00:00Z",
+                                "createdAt": "2026-04-24T11:59:00Z",
+                            }
+                        ],
+                        "nextToken": None,
+                    }
+                }
+            return {
+                "listFeedbackItemByAccountIdAndUpdatedAt": {
+                    "items": [
+                        {
+                            "id": "feedback-1",
+                            "scorecardId": "scorecard-1",
+                            "scoreId": "score-1",
+                            "initialAnswerValue": "yes",
+                            "finalAnswerValue": "yes",
+                            "updatedAt": "2026-04-24T11:59:00Z",
+                            "createdAt": "2026-04-24T11:59:00Z",
+                        }
+                    ],
+                    "nextToken": None,
+                }
+            }
+
+    client = FakeGraphQLClient()
+    records = query_feedback_items_in_window(
+        client,
+        "account-1",
+        datetime.fromisoformat("2026-04-24T00:00:00+00:00"),
+        datetime.fromisoformat("2026-04-25T00:00:00+00:00"),
+    )
+
+    assert len(client.queries) == 2
+    assert any("listFeedbackItemByAccountIdAndEditedAt" in query for query in client.queries)
+    assert any("listFeedbackItemByAccountIdAndUpdatedAt" in query for query in client.queries)
+    assert len(records) == 1
+    assert records[0]["finalAnswerValue"] == "no"

--- a/infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py
@@ -46,3 +46,18 @@ def test_metrics_stack_subscribes_to_procedure_table_stream():
 
 def test_amplify_discovery_includes_procedure_table():
     assert METRICS_TABLE_PATTERNS["procedure"] == "Procedure"
+
+
+def test_feedback_item_streams_are_classified_as_feedback_items():
+    arn = "arn:aws:dynamodb:us-west-2:123456789012:table/FeedbackItem-abc123/stream/2026-04-29T00:00:00.000"
+
+    assert determine_record_type(arn) == "feedbackItems"
+
+
+def test_metrics_stack_subscribes_to_feedback_item_table_stream():
+    assert "feedbackitem" in METRICS_TABLE_TYPES
+    assert METRICS_STREAM_CONFIGS["feedbackitem"] == {"batch_size": 10, "batch_window": 15}
+
+
+def test_amplify_discovery_includes_feedback_item_table():
+    assert METRICS_TABLE_PATTERNS["feedbackitem"] == "FeedbackItem"

--- a/infrastructure/scripts/create-secrets-production.sh
+++ b/infrastructure/scripts/create-secrets-production.sh
@@ -6,19 +6,27 @@ set -e
 
 ENVIRONMENT="production"
 SECRET_NAME="plexus/$ENVIRONMENT/config"
+AWS_REGION="${AWS_REGION:-${CDK_DEFAULT_REGION:-us-west-2}}"
 
 # Load environment variables from root .env file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$SCRIPT_DIR/../../.env"
+INFRA_ENV_FILE="$SCRIPT_DIR/../.env"
 
 if [ ! -f "$ENV_FILE" ]; then
     echo "❌ Error: .env file not found at $ENV_FILE"
+    exit 1
+fi
+if [ ! -f "$INFRA_ENV_FILE" ]; then
+    echo "❌ Error: infrastructure .env file not found at $INFRA_ENV_FILE"
+    echo "Run infrastructure/discover_and_save_tables.py before refreshing secrets."
     exit 1
 fi
 
 echo "📄 Loading configuration from $ENV_FILE"
 set -a  # Automatically export all variables
 source "$ENV_FILE"
+source "$INFRA_ENV_FILE"
 set +a
 
 echo ""
@@ -51,13 +59,17 @@ SECRET_VALUE=$(cat <<EOF
   "table-evaluation-stream-arn": "${TABLE_EVALUATION_STREAM_ARN:-}",
   "table-procedure-name": "${TABLE_PROCEDURE_NAME:-}",
   "table-procedure-arn": "${TABLE_PROCEDURE_ARN:-}",
-  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}"
+  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}",
+  "table-feedbackitem-name": "${TABLE_FEEDBACKITEM_NAME:-}",
+  "table-feedbackitem-arn": "${TABLE_FEEDBACKITEM_ARN:-}",
+  "table-feedbackitem-stream-arn": "${TABLE_FEEDBACKITEM_STREAM_ARN:-}"
 }
 EOF
 )
 
 # Try to create the secret (will fail if it already exists)
 if aws secretsmanager create-secret \
+    --region "$AWS_REGION" \
     --name "$SECRET_NAME" \
     --description "Plexus configuration for $ENVIRONMENT environment" \
     --secret-string "$SECRET_VALUE" \
@@ -67,6 +79,7 @@ else
     # If creation failed, update the existing secret
     echo "Secret already exists, updating..."
     aws secretsmanager update-secret \
+        --region "$AWS_REGION" \
         --secret-id "$SECRET_NAME" \
         --secret-string "$SECRET_VALUE"
     echo "✅ Secret updated successfully: $SECRET_NAME"
@@ -75,6 +88,7 @@ fi
 echo ""
 echo "📋 Secret details:"
 echo "  Name: $SECRET_NAME"
+echo "  Region: $AWS_REGION"
 echo "  Keys:"
 echo "$SECRET_VALUE" | jq -r 'keys[]' | sed 's/^/    - /'
 echo ""

--- a/infrastructure/scripts/create-secrets-production.sh
+++ b/infrastructure/scripts/create-secrets-production.sh
@@ -6,27 +6,19 @@ set -e
 
 ENVIRONMENT="production"
 SECRET_NAME="plexus/$ENVIRONMENT/config"
-AWS_REGION="${AWS_REGION:-${CDK_DEFAULT_REGION:-us-west-2}}"
 
 # Load environment variables from root .env file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$SCRIPT_DIR/../../.env"
-INFRA_ENV_FILE="$SCRIPT_DIR/../.env"
 
 if [ ! -f "$ENV_FILE" ]; then
     echo "❌ Error: .env file not found at $ENV_FILE"
-    exit 1
-fi
-if [ ! -f "$INFRA_ENV_FILE" ]; then
-    echo "❌ Error: infrastructure .env file not found at $INFRA_ENV_FILE"
-    echo "Run infrastructure/discover_and_save_tables.py before refreshing secrets."
     exit 1
 fi
 
 echo "📄 Loading configuration from $ENV_FILE"
 set -a  # Automatically export all variables
 source "$ENV_FILE"
-source "$INFRA_ENV_FILE"
 set +a
 
 echo ""
@@ -59,17 +51,13 @@ SECRET_VALUE=$(cat <<EOF
   "table-evaluation-stream-arn": "${TABLE_EVALUATION_STREAM_ARN:-}",
   "table-procedure-name": "${TABLE_PROCEDURE_NAME:-}",
   "table-procedure-arn": "${TABLE_PROCEDURE_ARN:-}",
-  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}",
-  "table-feedbackitem-name": "${TABLE_FEEDBACKITEM_NAME:-}",
-  "table-feedbackitem-arn": "${TABLE_FEEDBACKITEM_ARN:-}",
-  "table-feedbackitem-stream-arn": "${TABLE_FEEDBACKITEM_STREAM_ARN:-}"
+  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}"
 }
 EOF
 )
 
 # Try to create the secret (will fail if it already exists)
 if aws secretsmanager create-secret \
-    --region "$AWS_REGION" \
     --name "$SECRET_NAME" \
     --description "Plexus configuration for $ENVIRONMENT environment" \
     --secret-string "$SECRET_VALUE" \
@@ -79,7 +67,6 @@ else
     # If creation failed, update the existing secret
     echo "Secret already exists, updating..."
     aws secretsmanager update-secret \
-        --region "$AWS_REGION" \
         --secret-id "$SECRET_NAME" \
         --secret-string "$SECRET_VALUE"
     echo "✅ Secret updated successfully: $SECRET_NAME"
@@ -88,7 +75,6 @@ fi
 echo ""
 echo "📋 Secret details:"
 echo "  Name: $SECRET_NAME"
-echo "  Region: $AWS_REGION"
 echo "  Keys:"
 echo "$SECRET_VALUE" | jq -r 'keys[]' | sed 's/^/    - /'
 echo ""

--- a/infrastructure/scripts/create-secrets-staging.sh
+++ b/infrastructure/scripts/create-secrets-staging.sh
@@ -6,19 +6,27 @@ set -e
 
 ENVIRONMENT="staging"
 SECRET_NAME="plexus/$ENVIRONMENT/config"
+AWS_REGION="${AWS_REGION:-${CDK_DEFAULT_REGION:-us-west-2}}"
 
 # Load environment variables from root .env file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$SCRIPT_DIR/../../.env"
+INFRA_ENV_FILE="$SCRIPT_DIR/../.env"
 
 if [ ! -f "$ENV_FILE" ]; then
     echo "❌ Error: .env file not found at $ENV_FILE"
+    exit 1
+fi
+if [ ! -f "$INFRA_ENV_FILE" ]; then
+    echo "❌ Error: infrastructure .env file not found at $INFRA_ENV_FILE"
+    echo "Run infrastructure/discover_and_save_tables.py before refreshing secrets."
     exit 1
 fi
 
 echo "📄 Loading configuration from $ENV_FILE"
 set -a  # Automatically export all variables
 source "$ENV_FILE"
+source "$INFRA_ENV_FILE"
 set +a
 
 echo ""
@@ -51,13 +59,17 @@ SECRET_VALUE=$(cat <<EOF
   "table-evaluation-stream-arn": "${TABLE_EVALUATION_STREAM_ARN:-}",
   "table-procedure-name": "${TABLE_PROCEDURE_NAME:-}",
   "table-procedure-arn": "${TABLE_PROCEDURE_ARN:-}",
-  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}"
+  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}",
+  "table-feedbackitem-name": "${TABLE_FEEDBACKITEM_NAME:-}",
+  "table-feedbackitem-arn": "${TABLE_FEEDBACKITEM_ARN:-}",
+  "table-feedbackitem-stream-arn": "${TABLE_FEEDBACKITEM_STREAM_ARN:-}"
 }
 EOF
 )
 
 # Try to create the secret (will fail if it already exists)
 if aws secretsmanager create-secret \
+    --region "$AWS_REGION" \
     --name "$SECRET_NAME" \
     --description "Plexus configuration for $ENVIRONMENT environment" \
     --secret-string "$SECRET_VALUE" \
@@ -67,6 +79,7 @@ else
     # If creation failed, update the existing secret
     echo "Secret already exists, updating..."
     aws secretsmanager update-secret \
+        --region "$AWS_REGION" \
         --secret-id "$SECRET_NAME" \
         --secret-string "$SECRET_VALUE"
     echo "✅ Secret updated successfully: $SECRET_NAME"
@@ -75,6 +88,7 @@ fi
 echo ""
 echo "📋 Secret details:"
 echo "  Name: $SECRET_NAME"
+echo "  Region: $AWS_REGION"
 echo "  Keys:"
 echo "$SECRET_VALUE" | jq -r 'keys[]' | sed 's/^/    - /'
 echo ""

--- a/infrastructure/scripts/create-secrets-staging.sh
+++ b/infrastructure/scripts/create-secrets-staging.sh
@@ -6,27 +6,19 @@ set -e
 
 ENVIRONMENT="staging"
 SECRET_NAME="plexus/$ENVIRONMENT/config"
-AWS_REGION="${AWS_REGION:-${CDK_DEFAULT_REGION:-us-west-2}}"
 
 # Load environment variables from root .env file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$SCRIPT_DIR/../../.env"
-INFRA_ENV_FILE="$SCRIPT_DIR/../.env"
 
 if [ ! -f "$ENV_FILE" ]; then
     echo "❌ Error: .env file not found at $ENV_FILE"
-    exit 1
-fi
-if [ ! -f "$INFRA_ENV_FILE" ]; then
-    echo "❌ Error: infrastructure .env file not found at $INFRA_ENV_FILE"
-    echo "Run infrastructure/discover_and_save_tables.py before refreshing secrets."
     exit 1
 fi
 
 echo "📄 Loading configuration from $ENV_FILE"
 set -a  # Automatically export all variables
 source "$ENV_FILE"
-source "$INFRA_ENV_FILE"
 set +a
 
 echo ""
@@ -59,17 +51,13 @@ SECRET_VALUE=$(cat <<EOF
   "table-evaluation-stream-arn": "${TABLE_EVALUATION_STREAM_ARN:-}",
   "table-procedure-name": "${TABLE_PROCEDURE_NAME:-}",
   "table-procedure-arn": "${TABLE_PROCEDURE_ARN:-}",
-  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}",
-  "table-feedbackitem-name": "${TABLE_FEEDBACKITEM_NAME:-}",
-  "table-feedbackitem-arn": "${TABLE_FEEDBACKITEM_ARN:-}",
-  "table-feedbackitem-stream-arn": "${TABLE_FEEDBACKITEM_STREAM_ARN:-}"
+  "table-procedure-stream-arn": "${TABLE_PROCEDURE_STREAM_ARN:-}"
 }
 EOF
 )
 
 # Try to create the secret (will fail if it already exists)
 if aws secretsmanager create-secret \
-    --region "$AWS_REGION" \
     --name "$SECRET_NAME" \
     --description "Plexus configuration for $ENVIRONMENT environment" \
     --secret-string "$SECRET_VALUE" \
@@ -79,7 +67,6 @@ else
     # If creation failed, update the existing secret
     echo "Secret already exists, updating..."
     aws secretsmanager update-secret \
-        --region "$AWS_REGION" \
         --secret-id "$SECRET_NAME" \
         --secret-string "$SECRET_VALUE"
     echo "✅ Secret updated successfully: $SECRET_NAME"
@@ -88,7 +75,6 @@ fi
 echo ""
 echo "📋 Secret details:"
 echo "  Name: $SECRET_NAME"
-echo "  Region: $AWS_REGION"
 echo "  Keys:"
 echo "$SECRET_VALUE" | jq -r 'keys[]' | sed 's/^/    - /'
 echo ""

--- a/infrastructure/stacks/metrics_aggregation_config.py
+++ b/infrastructure/stacks/metrics_aggregation_config.py
@@ -1,4 +1,4 @@
-METRICS_TABLE_TYPES = ['item', 'scoreresult', 'task', 'evaluation', 'procedure']
+METRICS_TABLE_TYPES = ['item', 'scoreresult', 'task', 'evaluation', 'procedure', 'feedbackitem']
 
 METRICS_STREAM_CONFIGS = {
     'item': {'batch_size': 10, 'batch_window': 15},
@@ -6,4 +6,5 @@ METRICS_STREAM_CONFIGS = {
     'task': {'batch_size': 1, 'batch_window': 15},
     'evaluation': {'batch_size': 1, 'batch_window': 15},
     'procedure': {'batch_size': 1, 'batch_window': 15},
+    'feedbackitem': {'batch_size': 10, 'batch_window': 15},
 }

--- a/infrastructure/stacks/shared/amplify_discovery.py
+++ b/infrastructure/stacks/shared/amplify_discovery.py
@@ -15,7 +15,8 @@ METRICS_TABLE_PATTERNS = {
     'scoreResult': 'ScoreResult',
     'task': 'Task',
     'evaluation': 'Evaluation',
-    'procedure': 'Procedure'
+    'procedure': 'Procedure',
+    'feedbackitem': 'FeedbackItem'
 }
 
 

--- a/project/events/2026-04-29T17:43:04.370Z__1f2f4834-1779-41dc-abeb-48c3f9c54cdd.json
+++ b/project/events/2026-04-29T17:43:04.370Z__1f2f4834-1779-41dc-abeb-48c3f9c54cdd.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "1f2f4834-1779-41dc-abeb-48c3f9c54cdd",
+  "issue_id": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T17:43:04.370Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Restore ongoing FeedbackItem aggregation and backfill missing AggregatedMetrics from 2026-04-24T00:00:00Z so dashboard and drawer feedback volume surfaces are current and consistent.\n\nDefinition of Done:\n- FeedbackItem table streams are wired into the metrics aggregation Lambda.\n- Lambda writes account, scorecard, and score scoped feedback metrics with classification metadata.\n- Backfill from 2026-04-24T00:00:00Z through deployment time is complete and verified.\n- Tests, deployment, push, and GitHub Actions CI pass.",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Restore FeedbackItem metrics aggregation"
+  }
+}

--- a/project/events/2026-04-29T17:43:08.454Z__0606ddeb-9140-412c-96c1-fb20572f7159.json
+++ b/project/events/2026-04-29T17:43:08.454Z__0606ddeb-9140-412c-96c1-fb20572f7159.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "0606ddeb-9140-412c-96c1-fb20572f7159",
+  "issue_id": "plx-b6c2c019-b5cb-4a39-8d10-a22e1e397d5d",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T17:43:08.454Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "As a dashboard user, I want newly created or edited FeedbackItems to update aggregated feedback metrics automatically, so that the feedback dashboard, drawer gauge, and drawer histogram reflect current activity.\n\nFeature: FeedbackItem stream aggregation\n\nScenario: A FeedbackItem stream event is processed\nGiven a FeedbackItem is inserted or updated for an account\nWhen the metrics aggregation Lambda processes the affected time window\nThen AggregatedMetrics contains feedbackItems, feedbackItemsByScorecard, and feedbackItemsByScore buckets for the effective feedback timestamp\nAnd the buckets include changedCount, unchangedCount, and invalidCount metadata.",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+    "priority": 1,
+    "status": "open",
+    "title": "FeedbackItem stream updates keep dashboard metrics current"
+  }
+}

--- a/project/events/2026-04-29T17:43:15.020Z__6915f345-feed-4d32-be80-19cb6233df72.json
+++ b/project/events/2026-04-29T17:43:15.020Z__6915f345-feed-4d32-be80-19cb6233df72.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "6915f345-feed-4d32-be80-19cb6233df72",
+  "issue_id": "plx-b2616d02-cd71-4b68-a2a4-15165d87522d",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T17:43:15.020Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "As an operator, I want to recompute FeedbackItem metrics from 2026-04-24T00:00:00Z, so that missing dashboard data is restored after the aggregation outage.\n\nFeature: FeedbackItem metrics backfill\n\nScenario: Feedback metrics are backfilled after an outage\nGiven FeedbackItems exist from 2026-04-24T00:00:00Z onward\nWhen the operator runs metrics update for feedbackItems, feedbackItemsByScorecard, and feedbackItemsByScore\nThen AggregatedMetrics matches recomputed FeedbackItem counts for each scope\nAnd metrics verify reports no differences for the backfill window.",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+    "priority": 1,
+    "status": "open",
+    "title": "FeedbackItem metrics can be backfilled from April 24"
+  }
+}

--- a/project/events/2026-04-29T17:43:20.176Z__da740fba-938e-4670-b5c0-04bf44ff6397.json
+++ b/project/events/2026-04-29T17:43:20.176Z__da740fba-938e-4670-b5c0-04bf44ff6397.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "da740fba-938e-4670-b5c0-04bf44ff6397",
+  "issue_id": "plx-dc88bc00-53bf-4ff0-a9ca-5366b4e5a1a4",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T17:43:20.176Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Add FeedbackItem table discovery, secret config, and stream subscription configuration for the metrics aggregation stack.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+    "priority": 1,
+    "status": "open",
+    "title": "Wire FeedbackItem streams into metrics stack"
+  }
+}

--- a/project/events/2026-04-29T17:43:20.205Z__6196cc18-1efe-4673-a4d2-44d908e4ffe5.json
+++ b/project/events/2026-04-29T17:43:20.205Z__6196cc18-1efe-4673-a4d2-44d908e4ffe5.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "6196cc18-1efe-4673-a4d2-44d908e4ffe5",
+  "issue_id": "plx-fa344e6d-b3dd-4641-b4a5-8cafe5f6730a",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T17:43:20.205Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Update the metrics aggregation Lambda to query, dedupe, classify, and write account/scorecard/score scoped FeedbackItem buckets.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+    "priority": 1,
+    "status": "open",
+    "title": "Implement scoped FeedbackItem Lambda aggregation"
+  }
+}

--- a/project/events/2026-04-29T17:43:20.233Z__b147c99b-0a1e-4a38-94aa-15ccce03ec8a.json
+++ b/project/events/2026-04-29T17:43:20.233Z__b147c99b-0a1e-4a38-94aa-15ccce03ec8a.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "b147c99b-0a1e-4a38-94aa-15ccce03ec8a",
+  "issue_id": "plx-a6a16040-8e45-478b-ad6b-8a0313600e28",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T17:43:20.233Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Add unit tests for FeedbackItem stream config, record classification, query fields, scoped counting, composite keys, and metadata payloads.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+    "priority": 1,
+    "status": "open",
+    "title": "Test FeedbackItem metrics aggregation"
+  }
+}

--- a/project/events/2026-04-29T17:43:20.260Z__a0a0a324-0715-454a-8342-b146fac57b99.json
+++ b/project/events/2026-04-29T17:43:20.260Z__a0a0a324-0715-454a-8342-b146fac57b99.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "a0a0a324-0715-454a-8342-b146fac57b99",
+  "issue_id": "plx-fa71d513-c72a-452a-a124-dcea961fce53",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T17:43:20.260Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Deploy the production metrics stack, backfill FeedbackItem metrics from 2026-04-24T00:00:00Z, verify counts, push, and confirm CI.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+    "priority": 1,
+    "status": "open",
+    "title": "Deploy and backfill FeedbackItem metrics"
+  }
+}

--- a/project/events/2026-04-29T17:43:23.826Z__36d5dfa4-5561-43e5-9860-dca38bba5248.json
+++ b/project/events/2026-04-29T17:43:23.826Z__36d5dfa4-5561-43e5-9860-dca38bba5248.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "36d5dfa4-5561-43e5-9860-dca38bba5248",
+  "issue_id": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T17:43:23.826Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-29T17:43:23.852Z__4111592a-fc54-4bc5-8169-67aa20c8173c.json
+++ b/project/events/2026-04-29T17:43:23.852Z__4111592a-fc54-4bc5-8169-67aa20c8173c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4111592a-fc54-4bc5-8169-67aa20c8173c",
+  "issue_id": "plx-dc88bc00-53bf-4ff0-a9ca-5366b4e5a1a4",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T17:43:23.852Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-29T17:43:23.876Z__66de7531-b9d1-44c5-b3a3-e184e3cb350a.json
+++ b/project/events/2026-04-29T17:43:23.876Z__66de7531-b9d1-44c5-b3a3-e184e3cb350a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "66de7531-b9d1-44c5-b3a3-e184e3cb350a",
+  "issue_id": "plx-fa344e6d-b3dd-4641-b4a5-8cafe5f6730a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T17:43:23.876Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-29T17:43:23.899Z__6445f555-b4b0-4d29-92bc-890bd183e381.json
+++ b/project/events/2026-04-29T17:43:23.899Z__6445f555-b4b0-4d29-92bc-890bd183e381.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6445f555-b4b0-4d29-92bc-890bd183e381",
+  "issue_id": "plx-a6a16040-8e45-478b-ad6b-8a0313600e28",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T17:43:23.899Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-29T17:45:36.278Z__8e372cd7-3b66-442a-92ab-8521c4d5f225.json
+++ b/project/events/2026-04-29T17:45:36.278Z__8e372cd7-3b66-442a-92ab-8521c4d5f225.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8e372cd7-3b66-442a-92ab-8521c4d5f225",
+  "issue_id": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T17:45:36.278Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "50938fa1-27bc-4414-b028-ec9e2f4a786d"
+  }
+}

--- a/project/events/2026-04-29T17:56:42.522Z__60702b78-b6da-4b45-a2f2-2051e4ba9df2.json
+++ b/project/events/2026-04-29T17:56:42.522Z__60702b78-b6da-4b45-a2f2-2051e4ba9df2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "60702b78-b6da-4b45-a2f2-2051e4ba9df2",
+  "issue_id": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T17:56:42.522Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "b64f8261-5564-4c38-a290-863ea101f548"
+  }
+}

--- a/project/events/2026-04-29T17:57:52.027Z__f72d6511-d210-4706-a279-50fd8a23c150.json
+++ b/project/events/2026-04-29T17:57:52.027Z__f72d6511-d210-4706-a279-50fd8a23c150.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f72d6511-d210-4706-a279-50fd8a23c150",
+  "issue_id": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T17:57:52.027Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "24eb7e38-4100-4a77-8455-93a9c64a4665"
+  }
+}

--- a/project/events/2026-04-29T18:15:00.393Z__0e44faad-d52c-456f-ab6a-44a3a489472d.json
+++ b/project/events/2026-04-29T18:15:00.393Z__0e44faad-d52c-456f-ab6a-44a3a489472d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0e44faad-d52c-456f-ab6a-44a3a489472d",
+  "issue_id": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T18:15:00.393Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "90fb86ae-3978-4fc7-a906-8f0d35b9c587"
+  }
+}

--- a/project/issues/plx-9f0720f4-4a36-41fb-9c8b-044316722e95.json
+++ b/project/issues/plx-9f0720f4-4a36-41fb-9c8b-044316722e95.json
@@ -28,10 +28,16 @@
       "author": "ryan",
       "text": "Branch status:\n- Committed fix as efe40d303 on bugfix/feedbackitem-metrics-aggregation.\n- Pushed branch to origin.\n- Local targeted tests passed after rollback: python -m pytest plexus/cli/metrics/aggregation_test.py infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py.\n- gh run list found no GitHub Actions runs for the branch push. A PR into develop is needed to run the normal CI/CD path; PR was not opened because repo policy requires explicit confirmation.",
       "created_at": "2026-04-29T17:57:52.027223Z"
+    },
+    {
+      "id": "90fb86ae-3978-4fc7-a906-8f0d35b9c587",
+      "author": "ryan",
+      "text": "Normal deployment path restored:\n- Opened PR #248 into develop: https://github.com/AnthusAI/Plexus/pull/248\n- CI/CD Pipeline run 25126019100 is queued on PR checks.\n- No direct deploy or backfill will be run outside the normal Amplify Gen2 CI/CD process.",
+      "created_at": "2026-04-29T18:15:00.393010Z"
     }
   ],
   "created_at": "2026-04-29T17:43:04.369433Z",
-  "updated_at": "2026-04-29T17:57:52.027223Z",
+  "updated_at": "2026-04-29T18:15:00.393010Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-9f0720f4-4a36-41fb-9c8b-044316722e95.json
+++ b/project/issues/plx-9f0720f4-4a36-41fb-9c8b-044316722e95.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "title": "Restore FeedbackItem metrics aggregation",
+  "description": "Restore ongoing FeedbackItem aggregation and backfill missing AggregatedMetrics from 2026-04-24T00:00:00Z so dashboard and drawer feedback volume surfaces are current and consistent.\n\nDefinition of Done:\n- FeedbackItem table streams are wired into the metrics aggregation Lambda.\n- Lambda writes account, scorecard, and score scoped feedback metrics with classification metadata.\n- Backfill from 2026-04-24T00:00:00Z through deployment time is complete and verified.\n- Tests, deployment, push, and GitHub Actions CI pass.",
+  "type": "epic",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "50938fa1-27bc-4414-b028-ec9e2f4a786d",
+      "author": "ryan",
+      "text": "Implementation progress:\n- Created required Kanbus epic, stories, and tasks.\n- Created branch bugfix/feedbackitem-metrics-aggregation from updated develop.\n- Implemented FeedbackItem stream wiring, Lambda scoped counting, editedAt/updatedAt query dedupe, scoped composite keys, and metadata mutation payloads.\n- Added tests for stream config, classification, query dedupe, scoped buckets, composite keys, and mutation payloads.\n- Targeted tests passed: python -m pytest plexus/cli/metrics/aggregation_test.py infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py.",
+      "created_at": "2026-04-29T17:45:36.277568Z"
+    },
+    {
+      "id": "b64f8261-5564-4c38-a290-863ea101f548",
+      "author": "ryan",
+      "text": "Correction after deployment-model reminder:\n- A direct CDK deploy was started from the original implementation plan, but this project deploys Amplify Gen2 changes through CI/CD.\n- The local cdk deploy process was terminated.\n- CloudFormation cancel-update-stack was issued for plexus-metrics-aggregation-production in us-west-2.\n- Stack reached UPDATE_ROLLBACK_COMPLETE.\n- Remaining work will stay on the branch as source/test changes for CI/CD; no direct backfill/deploy will be run from this session.",
+      "created_at": "2026-04-29T17:56:42.522241Z"
+    }
+  ],
+  "created_at": "2026-04-29T17:43:04.369433Z",
+  "updated_at": "2026-04-29T17:56:42.522241Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-9f0720f4-4a36-41fb-9c8b-044316722e95.json
+++ b/project/issues/plx-9f0720f4-4a36-41fb-9c8b-044316722e95.json
@@ -22,10 +22,16 @@
       "author": "ryan",
       "text": "Correction after deployment-model reminder:\n- A direct CDK deploy was started from the original implementation plan, but this project deploys Amplify Gen2 changes through CI/CD.\n- The local cdk deploy process was terminated.\n- CloudFormation cancel-update-stack was issued for plexus-metrics-aggregation-production in us-west-2.\n- Stack reached UPDATE_ROLLBACK_COMPLETE.\n- Remaining work will stay on the branch as source/test changes for CI/CD; no direct backfill/deploy will be run from this session.",
       "created_at": "2026-04-29T17:56:42.522241Z"
+    },
+    {
+      "id": "24eb7e38-4100-4a77-8455-93a9c64a4665",
+      "author": "ryan",
+      "text": "Branch status:\n- Committed fix as efe40d303 on bugfix/feedbackitem-metrics-aggregation.\n- Pushed branch to origin.\n- Local targeted tests passed after rollback: python -m pytest plexus/cli/metrics/aggregation_test.py infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py.\n- gh run list found no GitHub Actions runs for the branch push. A PR into develop is needed to run the normal CI/CD path; PR was not opened because repo policy requires explicit confirmation.",
+      "created_at": "2026-04-29T17:57:52.027223Z"
     }
   ],
   "created_at": "2026-04-29T17:43:04.369433Z",
-  "updated_at": "2026-04-29T17:56:42.522241Z",
+  "updated_at": "2026-04-29T17:57:52.027223Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-a6a16040-8e45-478b-ad6b-8a0313600e28.json
+++ b/project/issues/plx-a6a16040-8e45-478b-ad6b-8a0313600e28.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-a6a16040-8e45-478b-ad6b-8a0313600e28",
+  "title": "Test FeedbackItem metrics aggregation",
+  "description": "Add unit tests for FeedbackItem stream config, record classification, query fields, scoped counting, composite keys, and metadata payloads.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-29T17:43:20.232889Z",
+  "updated_at": "2026-04-29T17:43:23.899685Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-b2616d02-cd71-4b68-a2a4-15165d87522d.json
+++ b/project/issues/plx-b2616d02-cd71-4b68-a2a4-15165d87522d.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-b2616d02-cd71-4b68-a2a4-15165d87522d",
+  "title": "FeedbackItem metrics can be backfilled from April 24",
+  "description": "As an operator, I want to recompute FeedbackItem metrics from 2026-04-24T00:00:00Z, so that missing dashboard data is restored after the aggregation outage.\n\nFeature: FeedbackItem metrics backfill\n\nScenario: Feedback metrics are backfilled after an outage\nGiven FeedbackItems exist from 2026-04-24T00:00:00Z onward\nWhen the operator runs metrics update for feedbackItems, feedbackItemsByScorecard, and feedbackItemsByScore\nThen AggregatedMetrics matches recomputed FeedbackItem counts for each scope\nAnd metrics verify reports no differences for the backfill window.",
+  "type": "story",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-29T17:43:15.020044Z",
+  "updated_at": "2026-04-29T17:43:15.020044Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-b6c2c019-b5cb-4a39-8d10-a22e1e397d5d.json
+++ b/project/issues/plx-b6c2c019-b5cb-4a39-8d10-a22e1e397d5d.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-b6c2c019-b5cb-4a39-8d10-a22e1e397d5d",
+  "title": "FeedbackItem stream updates keep dashboard metrics current",
+  "description": "As a dashboard user, I want newly created or edited FeedbackItems to update aggregated feedback metrics automatically, so that the feedback dashboard, drawer gauge, and drawer histogram reflect current activity.\n\nFeature: FeedbackItem stream aggregation\n\nScenario: A FeedbackItem stream event is processed\nGiven a FeedbackItem is inserted or updated for an account\nWhen the metrics aggregation Lambda processes the affected time window\nThen AggregatedMetrics contains feedbackItems, feedbackItemsByScorecard, and feedbackItemsByScore buckets for the effective feedback timestamp\nAnd the buckets include changedCount, unchangedCount, and invalidCount metadata.",
+  "type": "story",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-29T17:43:08.454276Z",
+  "updated_at": "2026-04-29T17:43:08.454276Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-dc88bc00-53bf-4ff0-a9ca-5366b4e5a1a4.json
+++ b/project/issues/plx-dc88bc00-53bf-4ff0-a9ca-5366b4e5a1a4.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-dc88bc00-53bf-4ff0-a9ca-5366b4e5a1a4",
+  "title": "Wire FeedbackItem streams into metrics stack",
+  "description": "Add FeedbackItem table discovery, secret config, and stream subscription configuration for the metrics aggregation stack.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-29T17:43:20.175277Z",
+  "updated_at": "2026-04-29T17:43:23.852560Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-fa344e6d-b3dd-4641-b4a5-8cafe5f6730a.json
+++ b/project/issues/plx-fa344e6d-b3dd-4641-b4a5-8cafe5f6730a.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-fa344e6d-b3dd-4641-b4a5-8cafe5f6730a",
+  "title": "Implement scoped FeedbackItem Lambda aggregation",
+  "description": "Update the metrics aggregation Lambda to query, dedupe, classify, and write account/scorecard/score scoped FeedbackItem buckets.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-29T17:43:20.205015Z",
+  "updated_at": "2026-04-29T17:43:23.875933Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-fa71d513-c72a-452a-a124-dcea961fce53.json
+++ b/project/issues/plx-fa71d513-c72a-452a-a124-dcea961fce53.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-fa71d513-c72a-452a-a124-dcea961fce53",
+  "title": "Deploy and backfill FeedbackItem metrics",
+  "description": "Deploy the production metrics stack, backfill FeedbackItem metrics from 2026-04-24T00:00:00Z, verify counts, push, and confirm CI.",
+  "type": "task",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-9f0720f4-4a36-41fb-9c8b-044316722e95",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-04-29T17:43:20.259910Z",
+  "updated_at": "2026-04-29T17:43:20.259910Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Wire FeedbackItem streams into the metrics aggregation stack configuration and table discovery.
- Update the metrics aggregator Lambda to query FeedbackItems by editedAt and updatedAt, dedupe by id, and write account, scorecard, and score scoped buckets.
- Preserve classification metadata in AggregatedMetrics for changed, unchanged, and invalid feedback items.

## Validation
- python -m pytest plexus/cli/metrics/aggregation_test.py infrastructure/lambda_functions/metrics_aggregator/test_procedure_metrics.py infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py

## Notes
- Deployment and backfill should run only through the normal Amplify Gen2 CI/CD and approved operational process.