### PR TITLE
Fix Console worker MCP tool packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,6 +33,12 @@ project/
 *.jsonl.gz
 *.jsonl.gz.gz
 
+# ConsoleChatResponder imports the in-process Plexus MCP tool modules at runtime.
+# Keep non-Python MCP artifacts excluded by the broad rules above.
+!MCP/
+!MCP/**/
+!MCP/**/*.py
+
 # IDE
 .vscode/
 .cursor/

--- a/dashboard/amplify/functions/consoleRunWorker/test_docker_context.py
+++ b/dashboard/amplify/functions/consoleRunWorker/test_docker_context.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_console_worker_docker_context_includes_mcp_python_tools():
+    repo_root = Path(__file__).resolve().parents[4]
+    dockerignore_lines = repo_root.joinpath(".dockerignore").read_text().splitlines()
+
+    mcp_exclude_index = dockerignore_lines.index("MCP/")
+    mcp_include_index = dockerignore_lines.index("!MCP/")
+    mcp_python_include_index = dockerignore_lines.index("!MCP/**/*.py")
+
+    assert mcp_include_index > mcp_exclude_index
+    assert mcp_python_include_index > mcp_exclude_index

--- a/project/events/2026-04-29T18:41:37.919Z__8a0daafb-5ec4-402f-97a9-ab8bee01a198.json
+++ b/project/events/2026-04-29T18:41:37.919Z__8a0daafb-5ec4-402f-97a9-ab8bee01a198.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8a0daafb-5ec4-402f-97a9-ab8bee01a198",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T18:41:37.919Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "927a3a37-6933-4e5e-be6f-75a6d99d7cc6"
+  }
+}

--- a/project/events/2026-04-29T18:42:45.872Z__a5f44970-b81b-4c22-9b54-de869825c1e0.json
+++ b/project/events/2026-04-29T18:42:45.872Z__a5f44970-b81b-4c22-9b54-de869825c1e0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a5f44970-b81b-4c22-9b54-de869825c1e0",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T18:42:45.872Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "b3bdf37f-a400-4b74-a877-8d98c7fb327e"
+  }
+}

--- a/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
+++ b/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
@@ -268,10 +268,22 @@
       "author": "ryan",
       "text": "Prepared Console Plexus tool dispatcher for fresh develop PR. Tactus import resolves to 0.46.3 from /Users/ryan/Projects/Tactus. Focused verification passed: python -m pytest -q plexus/cli/procedure/test_procedure_executor_compat.py plexus/cli/procedure/test_builtin_procedures.py plexus/console/test_chat_runtime.py plexus/cli/procedure/lua_dsl/test_runtime_basic.py plexus/cli/procedure/lua_dsl/tests/test_agent_primitives.py (84 passed).",
       "created_at": "2026-04-29T17:45:02.636604Z"
+    },
+    {
+      "id": "927a3a37-6933-4e5e-be6f-75a6d99d7cc6",
+      "author": "ryan",
+      "text": "Cloud smoke found Lambda packaging gap: ConsoleChatResponder claimed cloud message and exposed the single plexus dispatcher, but dispatcher registry lacked MCP tools because Lambda image excluded MCP/. Fixing image include rules and adding regression coverage before another deploy.",
+      "created_at": "2026-04-29T18:41:37.918330Z"
+    },
+    {
+      "id": "b3bdf37f-a400-4b74-a877-8d98c7fb327e",
+      "author": "ryan",
+      "text": "Added Docker context fix for ConsoleChatResponder: re-include MCP Python tool modules so the cloud in-process dispatcher can import full Plexus MCP tools. Added regression test dashboard/amplify/functions/consoleRunWorker/test_docker_context.py. Focused checks passed: 85 passed, 9 warnings.",
+      "created_at": "2026-04-29T18:42:45.844187Z"
     }
   ],
   "created_at": "2026-04-27T12:42:41.687340Z",
-  "updated_at": "2026-04-29T17:45:02.636604Z",
+  "updated_at": "2026-04-29T18:42:45.844187Z",
   "closed_at": null,
   "custom": {
     "project_label": "plx",


### PR DESCRIPTION
## Summary
- Fixes the cloud ConsoleChatResponder image so it includes the MCP Python tool modules required by the in-process Plexus dispatcher.
- Keeps the model-facing Console tool surface as the single `plexus` dispatcher.
- Adds a regression test guarding the Docker context include rules.

## Why
Cloud smoke after the dispatcher deploy showed the Lambda claimed and ran the Console message, but the dispatcher could only see core helper/editor tools. Lambda logs showed `Could not import Plexus MCP tools: No module named 'tools'`, because `.dockerignore` excluded `MCP/` from the worker image.

## Verification
- `python -m pytest -q dashboard/amplify/functions/consoleRunWorker/test_docker_context.py plexus/cli/procedure/test_procedure_executor_compat.py plexus/cli/procedure/test_builtin_procedures.py plexus/console/test_chat_runtime.py plexus/cli/procedure/lua_dsl/test_runtime_basic.py plexus/cli/procedure/lua_dsl/tests/test_agent_primitives.py`
- Result: 85 passed, 9 warnings.

## Notes
- Leaves unrelated dirty diagram/doc files out of the PR.
