### PR TITLE
Fix Console worker MCP tool path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,10 +34,10 @@ project/
 *.jsonl.gz.gz
 
 # ConsoleChatResponder imports the in-process Plexus MCP tool modules at runtime.
-# Keep non-Python MCP artifacts excluded by the broad rules above.
+# Re-include the full MCP tree after the broad project exclusions so Docker
+# cannot prune parent directories needed for Python namespace package imports.
 !MCP/
-!MCP/**/
-!MCP/**/*.py
+!MCP/**
 
 # IDE
 .vscode/

--- a/dashboard/amplify/functions/consoleRunWorker/Dockerfile
+++ b/dashboard/amplify/functions/consoleRunWorker/Dockerfile
@@ -2,12 +2,19 @@ FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONPATH=/workspace:/workspace/MCP
 
 WORKDIR /var/task
 
 # Copy repository so the worker can import Plexus source directly.
 COPY . /workspace
+
+# The Console agent's model-facing dispatcher imports the repo's MCP tool modules
+# in-process. Fail the image build if those modules are missing from the context.
+RUN test -f /workspace/MCP/tools/scorecard/scorecards.py && \
+    test -f /workspace/MCP/tools/evaluation/evaluations.py && \
+    test -f /workspace/MCP/tools/chat/chats.py
 
 # Required for git-based dependencies (for example openai-cost-calculator).
 RUN apt-get update && apt-get install -y --no-install-recommends git && \

--- a/dashboard/amplify/functions/consoleRunWorker/test_docker_context.py
+++ b/dashboard/amplify/functions/consoleRunWorker/test_docker_context.py
@@ -7,7 +7,18 @@ def test_console_worker_docker_context_includes_mcp_python_tools():
 
     mcp_exclude_index = dockerignore_lines.index("MCP/")
     mcp_include_index = dockerignore_lines.index("!MCP/")
-    mcp_python_include_index = dockerignore_lines.index("!MCP/**/*.py")
+    mcp_tree_include_index = dockerignore_lines.index("!MCP/**")
 
     assert mcp_include_index > mcp_exclude_index
-    assert mcp_python_include_index > mcp_exclude_index
+    assert mcp_tree_include_index > mcp_exclude_index
+
+
+def test_console_worker_dockerfile_verifies_mcp_tool_modules():
+    repo_root = Path(__file__).resolve().parents[4]
+    dockerfile = repo_root.joinpath(
+        "dashboard/amplify/functions/consoleRunWorker/Dockerfile"
+    ).read_text()
+
+    assert "PYTHONPATH=/workspace:/workspace/MCP" in dockerfile
+    assert "test -f /workspace/MCP/tools/scorecard/scorecards.py" in dockerfile
+    assert "test -f /workspace/MCP/tools/evaluation/evaluations.py" in dockerfile

--- a/project/events/2026-04-29T19:47:15.077Z__77b90854-8cca-4193-b653-c19800ff8508.json
+++ b/project/events/2026-04-29T19:47:15.077Z__77b90854-8cca-4193-b653-c19800ff8508.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "77b90854-8cca-4193-b653-c19800ff8508",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T19:47:15.077Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "3eeb120b-f8f4-4b8b-99cf-c00476e18f12"
+  }
+}

--- a/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
+++ b/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
@@ -280,10 +280,16 @@
       "author": "ryan",
       "text": "Added Docker context fix for ConsoleChatResponder: re-include MCP Python tool modules so the cloud in-process dispatcher can import full Plexus MCP tools. Added regression test dashboard/amplify/functions/consoleRunWorker/test_docker_context.py. Focused checks passed: 85 passed, 9 warnings.",
       "created_at": "2026-04-29T18:42:45.844187Z"
+    },
+    {
+      "id": "3eeb120b-f8f4-4b8b-99cf-c00476e18f12",
+      "author": "ryan",
+      "text": "Post-main cloud smoke still shows Console dispatcher backed by only core/score-editor tools in Lambda. Locally the MCP server registers 52 tools, so I am adding worker image hardening/verification for MCP package availability and explicit MCP PYTHONPATH before another deploy.",
+      "created_at": "2026-04-29T19:47:15.077276Z"
     }
   ],
   "created_at": "2026-04-27T12:42:41.687340Z",
-  "updated_at": "2026-04-29T18:42:45.844187Z",
+  "updated_at": "2026-04-29T19:47:15.077276Z",
   "closed_at": null,
   "custom": {
     "project_label": "plx",


### PR DESCRIPTION
## Summary
- Re-include the full MCP tree in the Console worker Docker build context.
- Set the worker image PYTHONPATH to include both /workspace and /workspace/MCP.
- Add Dockerfile build-time checks so the image fails to build if required MCP modules are missing.

## Why
Cloud smoke after PR #249 showed the model-facing Console dispatcher was present, but its backing registry only contained core procedure and score-editor tools. Locally, the same MCP server registers 52 tools including plexus_scorecards_list, so the Lambda image needs to make the in-repo MCP tool modules unambiguously available.

## Tests
- python -m pytest dashboard/amplify/functions/consoleRunWorker/test_docker_context.py plexus/cli/procedure/test_procedure_executor_compat.py -q
- python local MCP registration smoke: create_procedure_mcp_server registers 52 tools and includes plexus_scorecards_list