### PR TITLE
fix(dashboard): restore champion promotion after composite-index change

### DIFF
--- a/dashboard/components/ui/score-component.tsx
+++ b/dashboard/components/ui/score-component.tsx
@@ -3124,6 +3124,11 @@ export function ScoreComponent({
         metadata: Record<string, any>,
         options?: { isFeatured?: string | null }
       ) => {
+        const targetVersion = versions.find((item) => item.id === targetVersionId);
+        if (!targetVersion) {
+          throw new Error(`Unable to update score version ${targetVersionId}: version not found in local state`);
+        }
+
         const updateMetadataResponse = await getAmplifyClient().graphql({
           query: `
             mutation UpdateScoreVersionMetadata($input: UpdateScoreVersionInput!) {
@@ -3139,6 +3144,7 @@ export function ScoreComponent({
               id: String(targetVersionId),
               metadata: JSON.stringify(metadata),
               ...(options?.isFeatured !== undefined ? { isFeatured: options.isFeatured } : {}),
+              ...(options?.isFeatured !== undefined ? { createdAt: targetVersion.createdAt } : {}),
             }
           }
         });

--- a/project/events/2026-04-29T19:35:26.898Z__942751cf-8c17-4de0-84b8-97203e088607.json
+++ b/project/events/2026-04-29T19:35:26.898Z__942751cf-8c17-4de0-84b8-97203e088607.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "942751cf-8c17-4de0-84b8-97203e088607",
+  "issue_id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-29T19:35:26.898Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-b635a3df-a18f-4e58-8fd0-93a68a9b2b5d",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix champion promotion mutation to include full composite index key"
+  }
+}

--- a/project/events/2026-04-29T19:35:32.913Z__02da6acc-5679-4730-b788-aeb2166921ae.json
+++ b/project/events/2026-04-29T19:35:32.913Z__02da6acc-5679-4730-b788-aeb2166921ae.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "02da6acc-5679-4730-b788-aeb2166921ae",
+  "issue_id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-29T19:35:32.913Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-29T19:35:32.922Z__df34ae61-a6f8-40d6-8fd0-5378d3b19858.json
+++ b/project/events/2026-04-29T19:35:32.922Z__df34ae61-a6f8-40d6-8fd0-5378d3b19858.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "df34ae61-a6f8-40d6-8fd0-5378d3b19858",
+  "issue_id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T19:35:32.922Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "bbb73b47-52de-4eee-a5e1-3991c414bd10"
+  }
+}

--- a/project/events/2026-04-29T19:36:00.526Z__a788b726-6d5e-4ecb-b60b-90b87230e856.json
+++ b/project/events/2026-04-29T19:36:00.526Z__a788b726-6d5e-4ecb-b60b-90b87230e856.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a788b726-6d5e-4ecb-b60b-90b87230e856",
+  "issue_id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T19:36:00.526Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "5b924a05-040a-4364-8393-3bd6f4f8233f"
+  }
+}

--- a/project/events/2026-04-29T19:50:17.794Z__c418703a-c6b3-4a36-bdd3-e096f6dd9aeb.json
+++ b/project/events/2026-04-29T19:50:17.794Z__c418703a-c6b3-4a36-bdd3-e096f6dd9aeb.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c418703a-c6b3-4a36-bdd3-e096f6dd9aeb",
+  "issue_id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T19:50:17.794Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "a9c57771-991b-410f-98d8-a6e0f6a9b7fd"
+  }
+}

--- a/project/events/2026-04-29T19:50:20.645Z__0282535c-9fe2-49f2-a8ab-7db65a953546.json
+++ b/project/events/2026-04-29T19:50:20.645Z__0282535c-9fe2-49f2-a8ab-7db65a953546.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0282535c-9fe2-49f2-a8ab-7db65a953546",
+  "issue_id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T19:50:20.645Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "83d24181-5317-477d-9caa-88b0ddc1856f"
+  }
+}

--- a/project/events/2026-04-29T19:50:58.797Z__4a315299-f085-4325-a62a-02254e170203.json
+++ b/project/events/2026-04-29T19:50:58.797Z__4a315299-f085-4325-a62a-02254e170203.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4a315299-f085-4325-a62a-02254e170203",
+  "issue_id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T19:50:58.797Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "be9d3d8f-961e-4c51-b1ed-0f189ecfd197"
+  }
+}

--- a/project/events/2026-04-29T19:57:15.753Z__bd7bd170-a2ab-4981-ae95-561e14c10923.json
+++ b/project/events/2026-04-29T19:57:15.753Z__bd7bd170-a2ab-4981-ae95-561e14c10923.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bd7bd170-a2ab-4981-ae95-561e14c10923",
+  "issue_id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T19:57:15.753Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "c94137a2-03c5-4e39-bef6-5aad4ce51e7c"
+  }
+}

--- a/project/issues/plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35.json
+++ b/project/issues/plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35.json
@@ -40,10 +40,16 @@
       "author": "derek",
       "text": "Code fix committed and pushed on branch bugfix/champion-promotion-composite-key (commit f0452df). GitHub Actions check via gh run list --commit f0452df returned no workflows triggered for this branch push (CI appears PR/main-triggered only). Awaiting merge/PR workflow execution for full CI signal.",
       "created_at": "2026-04-29T19:50:58.797240579Z"
+    },
+    {
+      "id": "c94137a2-03c5-4e39-bef6-5aad4ce51e7c",
+      "author": "derek",
+      "text": "Opened PR #252 to develop from bugfix/champion-promotion-composite-key with root cause/fix details and validation notes. Waiting on GitHub Actions checks.",
+      "created_at": "2026-04-29T19:57:15.753402233Z"
     }
   ],
   "created_at": "2026-04-29T19:35:26.898481283Z",
-  "updated_at": "2026-04-29T19:50:58.797240579Z",
+  "updated_at": "2026-04-29T19:57:15.753402233Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35.json
+++ b/project/issues/plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35.json
@@ -1,0 +1,43 @@
+{
+  "id": "plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35",
+  "title": "Fix champion promotion mutation to include full composite index key",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b635a3df-a18f-4e58-8fd0-93a68a9b2b5d",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "bbb73b47-52de-4eee-a5e1-3991c414bd10",
+      "author": "derek",
+      "text": "Investigating regression: promoting ScoreVersion to champion now fails with composite index error requiring createdAt on byScoreIdAndIsFeaturedAndCreatedAt. Plan: identify mutation path, include required key fields in update payload, and verify champion promotion flow.",
+      "created_at": "2026-04-29T19:35:32.922437677Z"
+    },
+    {
+      "id": "5b924a05-040a-4364-8393-3bd6f4f8233f",
+      "author": "derek",
+      "text": "Implemented fix in dashboard/components/ui/score-component.tsx: champion promotion metadata update now resolves target version and includes createdAt whenever isFeatured is updated, satisfying byScoreIdAndIsFeaturedAndCreatedAt composite key requirements.",
+      "created_at": "2026-04-29T19:36:00.516865726Z"
+    },
+    {
+      "id": "a9c57771-991b-410f-98d8-a6e0f6a9b7fd",
+      "author": "derek",
+      "text": "Validation:  passed (2 tests). Note: repo lint script currently fails in this env due unsupported Next CLI flag (), and full typecheck exceeded 180s timeout without output; targeted test confirms changed path compiles/exercises.",
+      "created_at": "2026-04-29T19:50:17.794355294Z"
+    },
+    {
+      "id": "83d24181-5317-477d-9caa-88b0ddc1856f",
+      "author": "derek",
+      "text": "Validation: npm run -s test -- score-component passed (2 tests). Note: repo lint script currently fails in this env due unsupported Next CLI flag (next lint --no-cache), and full typecheck exceeded 180s timeout without output; targeted test confirms changed path compiles/exercises.",
+      "created_at": "2026-04-29T19:50:20.644929925Z"
+    }
+  ],
+  "created_at": "2026-04-29T19:35:26.898481283Z",
+  "updated_at": "2026-04-29T19:50:20.644929925Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35.json
+++ b/project/issues/plx-038a5f2c-82a8-4b64-8d50-53cf845e4d35.json
@@ -34,10 +34,16 @@
       "author": "derek",
       "text": "Validation: npm run -s test -- score-component passed (2 tests). Note: repo lint script currently fails in this env due unsupported Next CLI flag (next lint --no-cache), and full typecheck exceeded 180s timeout without output; targeted test confirms changed path compiles/exercises.",
       "created_at": "2026-04-29T19:50:20.644929925Z"
+    },
+    {
+      "id": "be9d3d8f-961e-4c51-b1ed-0f189ecfd197",
+      "author": "derek",
+      "text": "Code fix committed and pushed on branch bugfix/champion-promotion-composite-key (commit f0452df). GitHub Actions check via gh run list --commit f0452df returned no workflows triggered for this branch push (CI appears PR/main-triggered only). Awaiting merge/PR workflow execution for full CI signal.",
+      "created_at": "2026-04-29T19:50:58.797240579Z"
     }
   ],
   "created_at": "2026-04-29T19:35:26.898481283Z",
-  "updated_at": "2026-04-29T19:50:20.644929925Z",
+  "updated_at": "2026-04-29T19:50:58.797240579Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
## Summary
- fix champion promotion for `ScoreVersion` updates after the new composite index requirements
- include `createdAt` in promotion-time `updateScoreVersion` mutations whenever `isFeatured` is being changed
- keep the update helper strict by resolving the target version first and failing fast if missing

## Root Cause
Promoting a version sets `isFeatured`, and with index `byScoreIdAndIsFeaturedAndCreatedAt` this mutation now requires the full composite key. The previous mutation omitted `createdAt`, causing:
`Missing key: 'createdAt'`.

## Validation
- `npm run -s test -- score-component` (pass)
- CI to run on this PR
