### PR TITLE
Add RCA category filter feedback

### DIFF
--- a/dashboard/components/EvaluationTask.tsx
+++ b/dashboard/components/EvaluationTask.tsx
@@ -110,6 +110,8 @@ interface ScoreResult {
     correct: boolean
     human_explanation: string | null
     text: string | null
+    feedback_item_id?: string | null
+    item_id?: string | null
   }
   trace: any | null
   itemId: string | null
@@ -119,7 +121,14 @@ interface ScoreResult {
     url?: string
   }> | null
   feedbackItem: {
+    id?: string | null
     editCommentValue: string | null
+    initialAnswerValue?: string | null
+    initialCommentValue?: string | null
+    finalAnswerValue?: string | null
+    editorName?: string | null
+    editedAt?: string | null
+    createdAt?: string | null
   } | null
 }
 
@@ -836,6 +845,8 @@ function parseScoreResult(result: any): ParsedScoreResult {
   const correct = Boolean(scoreResult?.metadata?.correct ?? parsedMetadata.correct);
   const humanExplanation = scoreResult?.metadata?.human_explanation ?? parsedMetadata.human_explanation ?? null;
   const text = scoreResult?.metadata?.text ?? parsedMetadata.text ?? null;
+  const feedbackItemId = scoreResult?.metadata?.feedback_item_id ?? parsedMetadata.feedback_item_id ?? null;
+  const metadataItemId = scoreResult?.metadata?.item_id ?? parsedMetadata.item_id ?? null;
   const itemId = result.itemId || parsedMetadata.item_id?.toString() || null;
 
   // Parse feedbackItem data
@@ -843,6 +854,7 @@ function parseScoreResult(result: any): ParsedScoreResult {
     (sr: any) => sr.type === 'prediction'
   ) || null;
   const feedbackItem = result.feedbackItem ? {
+    id: result.feedbackItem.id || null,
     editCommentValue: result.feedbackItem.editCommentValue || null,
     initialAnswerValue: result.feedbackItem.initialAnswerValue || originalScoreResult?.value || null,
     initialCommentValue: result.feedbackItem.initialCommentValue || originalScoreResult?.explanation || null,
@@ -863,7 +875,9 @@ function parseScoreResult(result: any): ParsedScoreResult {
       human_label: humanLabel,
       correct,
       human_explanation: humanExplanation,
-      text
+      text,
+      feedback_item_id: feedbackItemId,
+      item_id: metadataItemId
     },
     trace,
     itemId,

--- a/dashboard/components/EvaluationTask.tsx
+++ b/dashboard/components/EvaluationTask.tsx
@@ -901,6 +901,7 @@ const DetailContent = React.memo(({
 
   const [containerWidth, setContainerWidth] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
+  const scoreResultsPanelRef = useRef<HTMLDivElement>(null)
   const [selectedPredictedActual, setSelectedPredictedActual] = useState<{
     predicted: string | null
     actual: string | null
@@ -1014,6 +1015,11 @@ const DetailContent = React.memo(({
       setSelectedPredictedActual({ predicted: null, actual: null })
       selectFirstFilteredScoreResult(itemIds)
     }
+    requestAnimationFrame(() => {
+      if (scoreResultsPanelRef.current && typeof scoreResultsPanelRef.current.scrollIntoView === 'function') {
+        scoreResultsPanelRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }
+    })
   }
 
   const handleCategoryFilter = (
@@ -1052,6 +1058,12 @@ const DetailContent = React.memo(({
     const selectedScoreResultIds = parsedScoreResults
       .filter(result => getScoreResultFilterKeys(result).some(key => normalizedLinkageIds.has(key)))
       .map(result => String(result.id).trim())
+    if (filteredClassifications.length > 0 && selectedScoreResultIds.length === 0) {
+      toast({
+        title: 'No linked score results',
+        description: 'This category has no score-result linkage in the current payload.',
+      })
+    }
 
     setSelectedTopicItemIds(null)
     setSelectedTopicLabel(null)
@@ -1061,6 +1073,11 @@ const DetailContent = React.memo(({
     setCategoryMissingItemIdCount(missingCount)
     setSelectedPredictedActual({ predicted: null, actual: null })
     selectFirstFilteredScoreResult(selectedScoreResultIds)
+    requestAnimationFrame(() => {
+      if (scoreResultsPanelRef.current && typeof scoreResultsPanelRef.current.scrollIntoView === 'function') {
+        scoreResultsPanelRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }
+    })
   }
 
   const clearCategoryFilter = () => {
@@ -1955,7 +1972,7 @@ const DetailContent = React.memo(({
 
         {/* Show score results panel during loading or when results exist, hidden only in narrow detail mode */}
         {(!showScoreResultInNarrowView) && (isResultsLoading || showResultsList) && (
-          <div className={`w-full ${showAsColumns ? 'h-full' : 'h-[500px] mt-6'} flex flex-col overflow-hidden`}>
+          <div ref={scoreResultsPanelRef} className={`w-full ${showAsColumns ? 'h-full' : 'h-[500px] mt-6'} flex flex-col overflow-hidden`}>
             {activeFilterChipLabel && (
               <div className="mb-2">
                 <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-foreground">

--- a/dashboard/components/__tests__/EvaluationTask.category-filter.test.tsx
+++ b/dashboard/components/__tests__/EvaluationTask.category-filter.test.tsx
@@ -183,7 +183,91 @@ const makeTaskWithMissingCategoryLinkage = () => {
   return task
 }
 
+const makeTaskWithFeedbackItemLinkedCategories = () => {
+  const scoreConfigurationFeedbackIds = Array.from({ length: 12 }, (_, i) => `fb-sc-${i + 1}`)
+  const informationGapFeedbackIds = Array.from({ length: 3 }, (_, i) => `fb-ig-${i + 1}`)
+
+  const scoreResults = [
+    ...scoreConfigurationFeedbackIds.map((feedbackId, i) => ({
+      id: `sr-sc-${i + 1}`,
+      value: 'No',
+      confidence: 0.8,
+      explanation: `Score config result ${i + 1}`,
+      metadata: {
+        human_label: 'Yes',
+        correct: false,
+        human_explanation: null,
+        text: `score config ${i + 1}`,
+        feedback_item_id: feedbackId,
+      },
+      trace: null,
+      itemId: null,
+      itemIdentifiers: [],
+      feedbackItem: { id: feedbackId, editCommentValue: null },
+    })),
+    ...informationGapFeedbackIds.map((feedbackId, i) => ({
+      id: `sr-ig-${i + 1}`,
+      value: 'No',
+      confidence: 0.7,
+      explanation: `Information gap result ${i + 1}`,
+      metadata: {
+        human_label: 'Yes',
+        correct: false,
+        human_explanation: null,
+        text: `information gap ${i + 1}`,
+        feedback_item_id: feedbackId,
+      },
+      trace: null,
+      itemId: null,
+      itemIdentifiers: [],
+      feedbackItem: { id: feedbackId, editCommentValue: null },
+    })),
+  ]
+
+  const task = makeTask()
+  task.data.scoreResults = scoreResults
+  task.data.totalItems = scoreResults.length
+  task.data.processedItems = scoreResults.length
+  task.data.parameters = JSON.stringify({
+    root_cause: {
+      misclassification_analysis: {
+        category_totals: {
+          score_configuration_problem: 12,
+          information_gap: 3,
+        },
+        item_classifications_all: [
+          ...scoreConfigurationFeedbackIds.map(feedbackId => ({
+            feedback_item_id: feedbackId,
+            primary_category: 'score_configuration_problem',
+            confidence: 'high',
+            rationale_full: `Config issue for ${feedbackId}.`,
+          })),
+          ...informationGapFeedbackIds.map(feedbackId => ({
+            feedback_item_id: feedbackId,
+            primary_category: 'information_gap',
+            confidence: 'medium',
+            rationale_full: `Info gap for ${feedbackId}.`,
+          })),
+        ],
+        category_summaries: {
+          score_configuration_problem: {
+            category_summary_text: 'Prompt/config causes most errors.',
+            item_count: 12,
+          },
+          information_gap: {
+            category_summary_text: 'Missing context causes a smaller set of errors.',
+            item_count: 3,
+          },
+        },
+      },
+    },
+  })
+  return task
+}
+
 describe('EvaluationTask category summary drill-down', () => {
+  const readSelectedItemIds = () => JSON.parse(screen.getByTestId('selected-item-ids').textContent || 'null')
+
   test('applies category filter and auto-selects first matching score result', async () => {
     const onSelectScoreResult = jest.fn()
     render(<EvaluationTask variant="detail" task={makeTask()} onSelectScoreResult={onSelectScoreResult} />)
@@ -218,6 +302,34 @@ describe('EvaluationTask category summary drill-down', () => {
     fireEvent.click(screen.getByRole('button', { name: /View items \(1\)/i }))
 
     expect(screen.getByTestId('selected-item-ids')).toHaveTextContent('[]')
+  })
+
+  test('filters full 12-item category when linkage is primarily feedback_item_id', async () => {
+    render(<EvaluationTask variant="detail" task={makeTaskWithFeedbackItemLinkedCategories()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /View items \(12\)/i }))
+
+    const selected = readSelectedItemIds()
+    expect(Array.isArray(selected)).toBe(true)
+    expect(selected).toHaveLength(12)
+    expect(selected).toEqual(expect.arrayContaining(['sr-sc-1', 'sr-sc-12']))
+    expect(selected).not.toEqual(expect.arrayContaining(['sr-ig-1']))
+  })
+
+  test('keeps category filters isolated between 12-item and 3-item categories', async () => {
+    render(<EvaluationTask variant="detail" task={makeTaskWithFeedbackItemLinkedCategories()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /View items \(12\)/i }))
+    const firstSelection = readSelectedItemIds()
+
+    fireEvent.click(screen.getByRole('button', { name: /View items \(3\)/i }))
+    const secondSelection = readSelectedItemIds()
+
+    expect(firstSelection).toHaveLength(12)
+    expect(secondSelection).toHaveLength(3)
+    expect(firstSelection).not.toEqual(secondSelection)
+    expect(secondSelection).toEqual(expect.arrayContaining(['sr-ig-1', 'sr-ig-3']))
+    expect(secondSelection).not.toEqual(expect.arrayContaining(['sr-sc-1']))
   })
 
   test('renders score version and procedure related-resource cards in detail view', async () => {

--- a/dashboard/utils/data-operations.test.ts
+++ b/dashboard/utils/data-operations.test.ts
@@ -215,7 +215,9 @@ describe('transformEvaluation', () => {
         human_label: 'correct_answer',
         correct: true,
         human_explanation: 'This is the right answer',
-        text: 'Sample input text'
+        text: 'Sample input text',
+        feedback_item_id: null,
+        item_id: null
       });
     });
 
@@ -496,7 +498,9 @@ describe('transformEvaluation', () => {
         human_label: 'correct',
         correct: true,
         human_explanation: null,
-        text: null
+        text: null,
+        feedback_item_id: null,
+        item_id: null
       });
       
       // Verify itemIdentifiers are correctly extracted and preserved

--- a/dashboard/utils/data-operations.ts
+++ b/dashboard/utils/data-operations.ts
@@ -68,6 +68,14 @@ export type ProcessedEvaluation = Omit<BaseEvaluation, 'task' | 'scorecard' | 's
       value: string;
       url?: string;
     }> | null;
+    feedbackItem?: {
+      id?: string | null;
+      editCommentValue?: string | null;
+      initialAnswerValue?: string | null;
+      finalAnswerValue?: string | null;
+      editorName?: string | null;
+      editedAt?: string | null;
+    } | null;
     createdAt: string;
   }>;
 };
@@ -896,6 +904,8 @@ type ParsedScoreResultMetadata = {
     correct: boolean;
     human_explanation: string | null;
     text: string | null;
+    feedback_item_id: string | null;
+    item_id: string | null;
   };
   nestedScoreResult: any | null;
   parsedMetadata: any;
@@ -994,7 +1004,9 @@ function parseScoreResultMetadata(rawMetadata: unknown): ParsedScoreResultMetada
       human_label: nestedScoreResult?.metadata?.human_label ?? parsedMetadata.human_label ?? null,
       correct: Boolean(nestedScoreResult?.metadata?.correct ?? parsedMetadata.correct),
       human_explanation: nestedScoreResult?.metadata?.human_explanation ?? parsedMetadata.human_explanation ?? null,
-      text: nestedScoreResult?.metadata?.text ?? parsedMetadata.text ?? null
+      text: nestedScoreResult?.metadata?.text ?? parsedMetadata.text ?? null,
+      feedback_item_id: nestedScoreResult?.metadata?.feedback_item_id ?? parsedMetadata.feedback_item_id ?? null,
+      item_id: nestedScoreResult?.metadata?.item_id ?? parsedMetadata.item_id ?? null
     },
     nestedScoreResult,
     parsedMetadata

--- a/dashboard/utils/data-operations.ts
+++ b/dashboard/utils/data-operations.ts
@@ -68,14 +68,7 @@ export type ProcessedEvaluation = Omit<BaseEvaluation, 'task' | 'scorecard' | 's
       value: string;
       url?: string;
     }> | null;
-    feedbackItem?: {
-      id?: string | null;
-      editCommentValue?: string | null;
-      initialAnswerValue?: string | null;
-      finalAnswerValue?: string | null;
-      editorName?: string | null;
-      editedAt?: string | null;
-    } | null;
+    feedbackItem?: any | null;
     createdAt: string;
   }>;
 };


### PR DESCRIPTION
## Summary
- Adds score-results panel scrolling after RCA category/topic filter selection.
- Shows a toast when an RCA category has classifications but no score-result linkage in the current payload.
- Keeps the existing score-result linkage behavior from PR #257.

## Validation
- `cd dashboard && npm test -- --runTestsByPath components/__tests__/EvaluationTask.category-filter.test.tsx --runInBand` -> 5 passed

## Context
This is the one remaining commit on the feature branch after PR #257 merged into `develop`.