### PR TITLE
fix: canonical evaluation identifier flow (producer + dashboard/share views)

### DIFF
--- a/dashboard/app/evaluations/[id]/page.tsx
+++ b/dashboard/app/evaluations/[id]/page.tsx
@@ -41,7 +41,10 @@ export class EvaluationService {
   }
 
   // Fetch all score results for an evaluation using paginated query
-  private async fetchAllScoreResults(evaluationId: string): Promise<any[]> {
+  private async fetchAllScoreResults(
+    evaluationId: string,
+    authMode?: 'userPool' | 'identityPool'
+  ): Promise<any[]> {
     let nextToken: string | null = null;
     let all: any[] = [];
     do {
@@ -63,13 +66,20 @@ export class EvaluationService {
                 itemId
                 createdAt
                 feedbackItem { id editCommentValue initialAnswerValue initialCommentValue finalAnswerValue editorName editedAt createdAt scoreResults { items { id value explanation type } } }
-                item { id itemIdentifiers { items { name value url position } } }
+                item {
+                  id
+                  accountId
+                  externalId
+                  identifiers
+                  itemIdentifiers { items { name value url position } }
+                }
               }
               nextToken
             }
           }
         `,
-        variables: { evaluationId, limit: 1000, nextToken }
+        variables: { evaluationId, limit: 1000, nextToken },
+        ...(authMode ? { authMode } : {}),
       }) as any;
       const data = resp?.data?.listScoreResultByEvaluationId;
       const items = Array.isArray(data?.items) ? data.items : [];
@@ -212,8 +222,21 @@ export class EvaluationService {
         evaluationData = result.data;
       }
       
+      const evaluationId = shareLink.resourceId;
+
+      // Always refresh share views from canonical score-result query.
+      // Shared resolver payloads can be partial and omit nested score-result relations.
+      let evaluationPayload = evaluationData;
+      if (evaluationId) {
+        const scoreResultItems = await this.fetchAllScoreResults(evaluationId, authMode);
+        evaluationPayload = {
+          ...evaluationData,
+          scoreResults: { items: scoreResultItems },
+        };
+      }
+
       // Transform the evaluation data
-      const transformedData = transformEvaluation(evaluationData);
+      const transformedData = transformEvaluation(evaluationPayload);
       
       if (!transformedData) {
         throw new Error('Failed to transform evaluation data');

--- a/dashboard/components/evaluations-dashboard.tsx
+++ b/dashboard/components/evaluations-dashboard.tsx
@@ -53,7 +53,7 @@ import type { EvaluationTaskProps } from '@/components/EvaluationTask'
 import type { TaskData } from '@/types/evaluation'
 import { transformAmplifyTask } from '@/utils/data-operations'
 import { AmplifyTask, ProcessedTask, ProcessedEvaluation, Evaluation, TaskStageType } from '@/utils/data-operations'
-import { listRecentEvaluations, transformAmplifyTask as transformEvaluationData, transformEvaluation, fetchEvaluationById } from '@/utils/data-operations'
+import { listRecentEvaluations, transformAmplifyTask as transformEvaluationData, transformEvaluation, fetchEvaluationById, transformScoreResultForDisplay } from '@/utils/data-operations'
 import { TaskDisplay } from "@/components/TaskDisplay"
 import { getValueFromLazyLoader, unwrapLazyLoader } from '@/utils/data-operations'
 import type { LazyLoader } from '@/utils/types'
@@ -606,44 +606,8 @@ export default function EvaluationsDashboard({
     }
 
     // Helper to transform raw items into UI-friendly format
-    const transformItems = (items: any[]): any[] => (items || []).map((item: any) => {
-      let parsedMetadata: any;
-      try {
-        if (typeof item.metadata === 'string') {
-          parsedMetadata = JSON.parse(item.metadata);
-          if (typeof parsedMetadata === 'string') {
-            parsedMetadata = JSON.parse(parsedMetadata);
-          }
-        } else {
-          parsedMetadata = item.metadata || {};
-        }
-      } catch (e) {
-        parsedMetadata = {};
-      }
-      const firstResultKey = parsedMetadata?.results ? Object.keys(parsedMetadata.results)[0] : null;
-      const scoreResult = firstResultKey && parsedMetadata.results ? parsedMetadata.results[firstResultKey] : null;
-      return {
-        id: item.id,
-        value: item.value,
-        confidence: item.confidence ?? null,
-        explanation: item.explanation ?? scoreResult?.explanation ?? null,
-        metadata: {
-          human_label: scoreResult?.metadata?.human_label ?? parsedMetadata.human_label ?? (typeof item.metadata === 'object' ? (item.metadata as any).human_label : null) ?? null,
-          correct: Boolean(scoreResult?.metadata?.correct ?? parsedMetadata.correct ?? (typeof item.metadata === 'object' ? (item.metadata as any).correct : null)),
-          human_explanation: scoreResult?.metadata?.human_explanation ?? parsedMetadata.human_explanation ?? (typeof item.metadata === 'object' ? (item.metadata as any).human_explanation : null) ?? null,
-          text: scoreResult?.metadata?.text ?? parsedMetadata.text ?? (typeof item.metadata === 'object' ? (item.metadata as any).text : null) ?? null
-        },
-        itemId: item.itemId ?? parsedMetadata.item_id?.toString() ?? null,
-        createdAt: item.createdAt || new Date().toISOString(),
-        trace: item.trace ?? null,
-        feedbackItem: item.feedbackItem ?? null,
-        itemIdentifiers: item.item?.itemIdentifiers?.items?.map((identifier: any) => ({
-          name: identifier.name,
-          value: identifier.value,
-          url: identifier.url || undefined
-        })) || undefined
-      };
-    });
+    const transformItems = (items: any[]): any[] =>
+      (items || []).map((item: any) => transformScoreResultForDisplay(item));
 
     // One-shot paginated fetch to populate immediately
     (async () => {

--- a/dashboard/components/evaluations-dashboard.tsx
+++ b/dashboard/components/evaluations-dashboard.tsx
@@ -636,7 +636,12 @@ export default function EvaluationsDashboard({
                     itemId
                     createdAt
                     feedbackItem { id editCommentValue initialAnswerValue finalAnswerValue editorName editedAt }
-                    item { id itemIdentifiers { items { name value url position } } }
+                    item {
+                      id
+                      externalId
+                      identifiers
+                      itemIdentifiers { items { name value url position } }
+                    }
                   }
                   nextToken
                 }
@@ -675,6 +680,7 @@ export default function EvaluationsDashboard({
       next: (data: { items: any[]; isSynced: boolean }) => {
         if (localGeneration !== evaluationFetchGenerationRef.current) return;
         const transformedItems = transformItems(data.items || []);
+        if (localGeneration !== evaluationFetchGenerationRef.current) return;
         evaluationResultsCacheRef.current.set(selectedEvaluationId, transformedItems)
         setSelectedEvaluationScoreResults(transformedItems)
       },

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -153,6 +153,7 @@
         "autoprefixer": "^10.4.0",
         "aws-cdk": "^2",
         "aws-cdk-lib": "^2",
+        "baseline-browser-mapping": "^2.10.24",
         "concurrently": "^9.1.1",
         "constructs": "^10.3.0",
         "esbuild": "^0.25.4",
@@ -45490,6 +45491,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -175,6 +175,7 @@
     "autoprefixer": "^10.4.0",
     "aws-cdk": "^2",
     "aws-cdk-lib": "^2",
+    "baseline-browser-mapping": "^2.10.24",
     "concurrently": "^9.1.1",
     "constructs": "^10.3.0",
     "esbuild": "^0.25.4",

--- a/dashboard/utils/amplify-helpers.ts
+++ b/dashboard/utils/amplify-helpers.ts
@@ -328,6 +328,8 @@ export function observeScoreResults(client: any, evaluationId: string) {
                   feedbackItem { id editCommentValue initialAnswerValue finalAnswerValue editorName editedAt }
                   item {
                     id
+                    externalId
+                    identifiers
                     itemIdentifiers { items { name value url position } }
                   }
                 }

--- a/dashboard/utils/data-operations.test.ts
+++ b/dashboard/utils/data-operations.test.ts
@@ -1,4 +1,4 @@
-import { transformEvaluation } from './data-operations';
+import { transformEvaluation, extractScoreResultItemIdentifiers, transformScoreResultForDisplay } from './data-operations';
 import type { BaseEvaluation } from './data-operations';
 
 describe('transformEvaluation', () => {
@@ -58,6 +58,22 @@ describe('transformEvaluation', () => {
   });
 
   describe('itemIdentifiers extraction', () => {
+    it('normalizes object-map legacy identifiers for shared display consumption', () => {
+      const identifiers = extractScoreResultItemIdentifiers({
+        item: {
+          identifiers: {
+            'Call ID': 309504413,
+            'Session ID': 'SESS-1234'
+          }
+        }
+      });
+
+      expect(identifiers).toEqual([
+        { name: 'Call ID', value: '309504413' },
+        { name: 'Session ID', value: 'SESS-1234' }
+      ]);
+    });
+
     it('should extract itemIdentifiers from score results with item relationships', () => {
       const mockEvaluation: BaseEvaluation = {
         id: 'eval-1',
@@ -388,6 +404,38 @@ describe('transformEvaluation', () => {
       
       expect(result).toBeTruthy();
       expect(result!.scoreResults).toEqual([]);
+    });
+  });
+
+  describe('shared score result transform', () => {
+    it('normalizes lazy-loaded score result payloads through a shared transformer', () => {
+      const transformed = transformScoreResultForDisplay({
+        id: 'result-lazy',
+        value: 'yes',
+        confidence: 0.77,
+        metadata: {
+          human_label: 'no',
+          correct: false,
+          human_explanation: 'reviewed',
+          text: 'transcript'
+        },
+        itemId: null,
+        item: {
+          identifiers: {
+            'Call ID': 309504413
+          }
+        }
+      } as any);
+
+      expect(transformed.metadata).toEqual({
+        human_label: 'no',
+        correct: false,
+        human_explanation: 'reviewed',
+        text: 'transcript'
+      });
+      expect(transformed.itemIdentifiers).toEqual([
+        { name: 'Call ID', value: '309504413' }
+      ]);
     });
   });
 

--- a/dashboard/utils/data-operations.ts
+++ b/dashboard/utils/data-operations.ts
@@ -72,6 +72,12 @@ export type ProcessedEvaluation = Omit<BaseEvaluation, 'task' | 'scorecard' | 's
   }>;
 };
 
+export type NormalizedIdentifierItem = {
+  name: string;
+  value: string;
+  url?: string;
+};
+
 // Update AmplifyTask type to use BaseEvaluation
 export type AmplifyTask = {
   id: string;
@@ -884,6 +890,134 @@ type RawScoreResults = {
   items: RawScoreResult[];
 };
 
+type ParsedScoreResultMetadata = {
+  processedMetadata: {
+    human_label: string | null;
+    correct: boolean;
+    human_explanation: string | null;
+    text: string | null;
+  };
+  nestedScoreResult: any | null;
+  parsedMetadata: any;
+};
+
+export function extractScoreResultItemIdentifiers(result: any): NormalizedIdentifierItem[] | null {
+  if (!result?.item) {
+    return null;
+  }
+
+  const relationshipIdentifiers = result.item?.itemIdentifiers?.items;
+  if (Array.isArray(relationshipIdentifiers) && relationshipIdentifiers.length > 0) {
+    return relationshipIdentifiers
+      .slice()
+      .sort((a: any, b: any) => (a.position || 0) - (b.position || 0))
+      .map((identifier: any) => ({
+        name: identifier.name,
+        value: identifier.value,
+        url: identifier.url || undefined
+      }));
+  }
+
+  const legacyIdentifiers = result.item?.identifiers;
+  if (!legacyIdentifiers) {
+    return null;
+  }
+
+  const normalizeIdentifierEntry = (entry: any): NormalizedIdentifierItem | null => {
+    if (!entry || typeof entry !== 'object') return null;
+    if (typeof entry.name !== 'string' || !entry.name) return null;
+
+    const rawValue = entry.value ?? entry.id;
+    if (rawValue === undefined || rawValue === null) return null;
+
+    return {
+      name: entry.name,
+      value: String(rawValue),
+      url: typeof entry.url === 'string' ? entry.url : undefined
+    };
+  };
+
+  if (Array.isArray(legacyIdentifiers)) {
+    const normalized = legacyIdentifiers
+      .map((entry: any) => normalizeIdentifierEntry(entry))
+      .filter((entry: NormalizedIdentifierItem | null): entry is NormalizedIdentifierItem => entry !== null);
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  if (typeof legacyIdentifiers === 'string') {
+    try {
+      const parsed = JSON.parse(legacyIdentifiers);
+      const normalized = Array.isArray(parsed)
+        ? parsed
+            .map((entry: any) => normalizeIdentifierEntry(entry))
+            .filter((entry: NormalizedIdentifierItem | null): entry is NormalizedIdentifierItem => entry !== null)
+        : [];
+      return normalized.length > 0 ? normalized : null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof legacyIdentifiers === 'object') {
+    const normalized = Object.entries(legacyIdentifiers as Record<string, unknown>)
+      .map(([name, value]) => {
+        if (!name || value === undefined || value === null) return null;
+        return { name, value: String(value) };
+      })
+      .filter((entry: NormalizedIdentifierItem | null): entry is NormalizedIdentifierItem => entry !== null);
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  return null;
+}
+
+function parseScoreResultMetadata(rawMetadata: unknown): ParsedScoreResultMetadata {
+  let parsedMetadata: any;
+  try {
+    if (typeof rawMetadata === 'string') {
+      parsedMetadata = JSON.parse(rawMetadata);
+      if (typeof parsedMetadata === 'string') {
+        parsedMetadata = JSON.parse(parsedMetadata);
+      }
+    } else {
+      parsedMetadata = rawMetadata || {};
+    }
+  } catch {
+    parsedMetadata = {};
+  }
+
+  const firstResultKey = parsedMetadata?.results ? Object.keys(parsedMetadata.results)[0] : null;
+  const nestedScoreResult = firstResultKey && parsedMetadata.results ? parsedMetadata.results[firstResultKey] : null;
+
+  return {
+    processedMetadata: {
+      human_label: nestedScoreResult?.metadata?.human_label ?? parsedMetadata.human_label ?? null,
+      correct: Boolean(nestedScoreResult?.metadata?.correct ?? parsedMetadata.correct),
+      human_explanation: nestedScoreResult?.metadata?.human_explanation ?? parsedMetadata.human_explanation ?? null,
+      text: nestedScoreResult?.metadata?.text ?? parsedMetadata.text ?? null
+    },
+    nestedScoreResult,
+    parsedMetadata
+  };
+}
+
+export function transformScoreResultForDisplay(result: any) {
+  const { processedMetadata, nestedScoreResult, parsedMetadata } = parseScoreResultMetadata(result?.metadata);
+
+  return {
+    id: result?.id,
+    value: result?.value,
+    confidence: result?.confidence ?? null,
+    metadata: processedMetadata,
+    explanation: result?.explanation ?? nestedScoreResult?.explanation ?? null,
+    trace: result?.trace ?? nestedScoreResult?.trace ?? null,
+    itemId: result?.itemId ?? parsedMetadata?.item_id?.toString() ?? null,
+    itemIdentifiers: extractScoreResultItemIdentifiers(result),
+    createdAt: result?.createdAt || new Date().toISOString(),
+    feedbackItem: result?.feedbackItem ?? null
+  };
+}
+
 export function parseTaskMetadata(rawMetadata: unknown): Record<string, unknown> | null {
   if (!rawMetadata) return null;
 
@@ -984,75 +1118,9 @@ export function transformEvaluation(evaluation: BaseEvaluation): ProcessedEvalua
 
 
   // Transform score results into the expected format
-  const transformedScoreResults = standardizedScoreResults.map((result: any) => {
-    // Extract item identifier data if available
-    let itemIdentifiers = null;
-    
-    if (result.item?.itemIdentifiers?.items) {
-      itemIdentifiers = result.item.itemIdentifiers.items
-        .sort((a: any, b: any) => (a.position || 0) - (b.position || 0)) // Sort by position
-        .map((identifier: any) => ({
-          name: identifier.name,
-          value: identifier.value,
-          url: identifier.url || undefined
-        }));
-    } else if (result.item?.identifiers) {
-      // Handle legacy JSON identifiers format
-      try {
-        const parsed = JSON.parse(result.item.identifiers);
-        if (Array.isArray(parsed)) {
-          itemIdentifiers = parsed.map((identifier: any) => ({
-            name: identifier.name,
-            value: identifier.value || identifier.id, // Support both value and id fields
-            url: identifier.url || undefined
-          }));
-        }
-      } catch (error) {
-        console.warn('Failed to parse legacy identifiers JSON:', error);
-      }
-    }
-
-    // Parse metadata (which might be JSON string, sometimes double-encoded)
-    let parsedMetadata;
-    try {
-      if (typeof result.metadata === 'string') {
-        parsedMetadata = JSON.parse(result.metadata);
-        if (typeof parsedMetadata === 'string') {
-          parsedMetadata = JSON.parse(parsedMetadata);
-        }
-      } else {
-        parsedMetadata = result.metadata || {};
-      }
-    } catch (e) {
-      console.warn('Error parsing metadata:', e);
-      parsedMetadata = {};
-    }
-
-    // Extract results from nested structure if present
-    const firstResultKey = parsedMetadata?.results ? Object.keys(parsedMetadata.results)[0] : null;
-    const scoreResult = firstResultKey && parsedMetadata.results ? parsedMetadata.results[firstResultKey] : null;
-
-    // Construct properly formatted metadata object
-    const processedMetadata = {
-      human_label: scoreResult?.metadata?.human_label ?? parsedMetadata.human_label ?? null,
-      correct: Boolean(scoreResult?.metadata?.correct ?? parsedMetadata.correct),
-      human_explanation: scoreResult?.metadata?.human_explanation ?? parsedMetadata.human_explanation ?? null,
-      text: scoreResult?.metadata?.text ?? parsedMetadata.text ?? null
-    };
-
-    return {
-      id: result.id,
-      value: result.value,
-      confidence: result.confidence ?? null,
-      metadata: processedMetadata,
-      explanation: result.explanation ?? scoreResult?.explanation ?? null,
-      trace: result.trace ?? scoreResult?.trace ?? null,
-      itemId: result.itemId ?? parsedMetadata.item_id?.toString() ?? null,
-      itemIdentifiers,
-      createdAt: result.createdAt || new Date().toISOString(),
-      feedbackItem: result.feedbackItem ?? null  // Preserve feedbackItem relationship
-    };
-  });
+  const transformedScoreResults = standardizedScoreResults.map((result: any) =>
+    transformScoreResultForDisplay(result)
+  );
 
   const procedureId = getTaskProcedureId(taskData);
   const parsedParameters = parseJsonMaybeDeep(evaluation.parameters);

--- a/plexus/Evaluation.py
+++ b/plexus/Evaluation.py
@@ -2430,6 +2430,8 @@ Total cost:       ${expenses['total_cost']:.6f}
                 for col_name in row.index:
                     if col_name not in result:  # Don't overwrite the explicitly set keys above
                         result[col_name] = row[col_name]
+                if item and getattr(item, "id", None):
+                    result["resolved_item_id"] = item.id
 
                 # Track if we've processed any scores for this text
                 has_processed_scores = False
@@ -2669,9 +2671,16 @@ Total cost:       ${expenses['total_cost']:.6f}
             if feedback_item_id is None and score_result.metadata:
                 feedback_item_id = score_result.metadata.get('feedback_item_id')
             
+            resolved_item_id = (
+                result.get('resolved_item_id')
+                or result.get('item_id')
+                or content_id
+            )
+
             # Ensure we have valid metadata
             metadata_dict = {
-                'item_id': result.get('form_id', ''),
+                'item_id': resolved_item_id,
+                'form_id': result.get('form_id', ''),
                 'results': {
                     score_result.parameters.name: {
                         'value': value,
@@ -2691,14 +2700,11 @@ Total cost:       ${expenses['total_cost']:.6f}
             if feedback_item_id:
                 metadata_dict['feedback_item_id'] = feedback_item_id
             
-            # The Item should already exist from dataset creation - evaluations don't create Items
-            # Use content_id as the itemId since Items are created by the data loading process
-            
             # Create data dictionary with all required fields
             # MARKER: CODE VERSION 2025-10-17-v3 - This ensures we're using the updated code
             data = {
                 'evaluationId': self.experiment_id,
-                'itemId': content_id,  # Use content_id directly
+                'itemId': resolved_item_id,
                 'accountId': self.account_id,
                 'scorecardId': self.scorecard_id,
                 'metadata': json.dumps(metadata_dict),  # Add the metadata that was created earlier

--- a/plexus/test_evaluation_metrics.py
+++ b/plexus/test_evaluation_metrics.py
@@ -269,6 +269,42 @@ class TestScoreTextProcessing:
         assert mock_evaluation._create_score_result.await_args.kwargs["feedback_item_id"] == "fi-top-level"
 
     @pytest.mark.asyncio
+    async def test_score_text_resolves_item_id_from_report_identifier(self, mock_evaluation):
+        mock_evaluation.override_data = {}
+        mock_evaluation.processed_items_by_score = {}
+        mock_evaluation.total_skipped = 0
+        mock_evaluation.scorecard.scores = [{"name": "test_score"}]
+        mock_evaluation.dashboard_client = MagicMock()
+        mock_evaluation.experiment_id = "eval-123"
+        mock_evaluation.account_id = "acct-123"
+        mock_evaluation._create_score_result = AsyncMock()
+
+        mock_result = create_mock_score_result("yes", "yes")
+        mock_evaluation.scorecard.score_entire_text = AsyncMock(
+            return_value={"test_score": mock_result}
+        )
+
+        resolved_item = MagicMock()
+        resolved_item.id = "acct-123--309517289"
+
+        row = pd.Series({
+            "text": "search dataset transcript",
+            "content_id": "309517289",
+            "columns": {
+                "form_id": "form-309517289",
+            },
+            "test_score_label": "yes",
+        })
+
+        with patch("plexus.dashboard.api.models.item.Item.get_by_id", return_value=None):
+            with patch("plexus.dashboard.api.models.item.Item.find_by_identifier", return_value=resolved_item):
+                await mock_evaluation.score_text(row, score_name="test_score")
+
+        passed_result = mock_evaluation._create_score_result.await_args.kwargs["result"]
+        assert passed_result["resolved_item_id"] == "acct-123--309517289"
+        assert mock_evaluation._create_score_result.await_args.kwargs["content_id"] == "309517289"
+
+    @pytest.mark.asyncio
     async def test_score_text_raises_when_score_returns_error_result(self, mock_evaluation):
         mock_evaluation.override_data = {}
         mock_evaluation.processed_items_by_score = {}

--- a/project/events/2026-04-30T00:09:48.433Z__aa494d4e-f682-4fb3-b250-9b3f28c613a5.json
+++ b/project/events/2026-04-30T00:09:48.433Z__aa494d4e-f682-4fb3-b250-9b3f28c613a5.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "aa494d4e-f682-4fb3-b250-9b3f28c613a5",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "issue_created",
+  "occurred_at": "2026-04-30T00:09:48.433Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-f8aff74b-6412-4367-829d-0b5e2eec8e62",
+    "priority": 1,
+    "status": "open",
+    "title": "Use shared IdentifierDisplay for evaluation score results"
+  }
+}

--- a/project/events/2026-04-30T00:09:50.869Z__2e1d83e8-15ee-40ae-a029-04916aa9aaef.json
+++ b/project/events/2026-04-30T00:09:50.869Z__2e1d83e8-15ee-40ae-a029-04916aa9aaef.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2e1d83e8-15ee-40ae-a029-04916aa9aaef",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "state_transition",
+  "occurred_at": "2026-04-30T00:09:50.869Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-04-30T00:09:50.884Z__a3a6a16b-4133-4ff1-a9a3-ffeb22ef328e.json
+++ b/project/events/2026-04-30T00:09:50.884Z__a3a6a16b-4133-4ff1-a9a3-ffeb22ef328e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a3a6a16b-4133-4ff1-a9a3-ffeb22ef328e",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:09:50.884Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "cfd97522-b93e-40e5-8359-39a6dc1ba0a5"
+  }
+}

--- a/project/events/2026-04-30T00:10:47.672Z__93c2d1c8-e77c-4c9c-a6b9-b4110d023797.json
+++ b/project/events/2026-04-30T00:10:47.672Z__93c2d1c8-e77c-4c9c-a6b9-b4110d023797.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "93c2d1c8-e77c-4c9c-a6b9-b4110d023797",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:10:47.672Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "42e08417-d987-406f-8186-c167c9bcf98a"
+  }
+}

--- a/project/events/2026-04-30T00:10:51.014Z__30b77710-a1a0-4411-946c-1c8effba9d29.json
+++ b/project/events/2026-04-30T00:10:51.014Z__30b77710-a1a0-4411-946c-1c8effba9d29.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "30b77710-a1a0-4411-946c-1c8effba9d29",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:10:51.014Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "efd0fb20-6cf2-4516-bffe-5432ca3cc607"
+  }
+}

--- a/project/events/2026-04-30T00:13:07.906Z__1b9bebca-93c2-41cd-a204-29f032bf91f9.json
+++ b/project/events/2026-04-30T00:13:07.906Z__1b9bebca-93c2-41cd-a204-29f032bf91f9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1b9bebca-93c2-41cd-a204-29f032bf91f9",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:13:07.906Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "c9500c8a-86b2-4a07-a418-3600c66dba54"
+  }
+}

--- a/project/events/2026-04-30T00:13:47.557Z__d0f3a030-5a44-44b9-ac21-a58b62c587a1.json
+++ b/project/events/2026-04-30T00:13:47.557Z__d0f3a030-5a44-44b9-ac21-a58b62c587a1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d0f3a030-5a44-44b9-ac21-a58b62c587a1",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:13:47.557Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "9e3d1453-78a5-4577-840a-e355916a1933"
+  }
+}

--- a/project/events/2026-04-30T00:14:31.753Z__836dc799-e48b-41c5-8e1a-a8eb8e16e5ff.json
+++ b/project/events/2026-04-30T00:14:31.753Z__836dc799-e48b-41c5-8e1a-a8eb8e16e5ff.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "836dc799-e48b-41c5-8e1a-a8eb8e16e5ff",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:14:31.753Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "b41a4c38-2f91-42ea-8306-da7b0d70bdab"
+  }
+}

--- a/project/events/2026-04-30T00:22:12.029Z__583952e5-412f-43ad-b6a7-cd358bad0bb6.json
+++ b/project/events/2026-04-30T00:22:12.029Z__583952e5-412f-43ad-b6a7-cd358bad0bb6.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "583952e5-412f-43ad-b6a7-cd358bad0bb6",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:22:12.029Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "ae08eae6-93c9-4a15-b92c-61e1a291daba"
+  }
+}

--- a/project/events/2026-04-30T00:22:47.767Z__03a1984a-383d-4de1-8fbd-5af72d1e5bb7.json
+++ b/project/events/2026-04-30T00:22:47.767Z__03a1984a-383d-4de1-8fbd-5af72d1e5bb7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "03a1984a-383d-4de1-8fbd-5af72d1e5bb7",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:22:47.767Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "fcdc9460-9076-469b-8da6-92eaf7430ee2"
+  }
+}

--- a/project/events/2026-04-30T00:28:25.468Z__cb4a5d94-5c5b-440c-a667-80b295a1f32e.json
+++ b/project/events/2026-04-30T00:28:25.468Z__cb4a5d94-5c5b-440c-a667-80b295a1f32e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cb4a5d94-5c5b-440c-a667-80b295a1f32e",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:28:25.468Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "08e51e32-411e-4be3-99c7-ad9c2b6f899a"
+  }
+}

--- a/project/events/2026-04-30T00:33:01.578Z__1e08e0eb-5560-45fe-9033-9e9cfb0bc2e3.json
+++ b/project/events/2026-04-30T00:33:01.578Z__1e08e0eb-5560-45fe-9033-9e9cfb0bc2e3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1e08e0eb-5560-45fe-9033-9e9cfb0bc2e3",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:33:01.578Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "375e5187-2a87-4737-bcb0-abb7dec7b25d"
+  }
+}

--- a/project/events/2026-04-30T00:35:28.030Z__5e73baa3-e200-46ba-bf4d-0b97c2b36a37.json
+++ b/project/events/2026-04-30T00:35:28.030Z__5e73baa3-e200-46ba-bf4d-0b97c2b36a37.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5e73baa3-e200-46ba-bf4d-0b97c2b36a37",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:35:28.030Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "e445a131-b98c-48e0-af91-2d6ca1149a53"
+  }
+}

--- a/project/events/2026-04-30T00:37:31.164Z__634fd1db-1a73-48bf-8614-aacc997a1f06.json
+++ b/project/events/2026-04-30T00:37:31.164Z__634fd1db-1a73-48bf-8614-aacc997a1f06.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "634fd1db-1a73-48bf-8614-aacc997a1f06",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:37:31.164Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "72c828a7-77e3-4f03-a487-470f93f663b4"
+  }
+}

--- a/project/events/2026-04-30T00:42:01.013Z__ade22446-8adf-4564-a893-44f5750229ec.json
+++ b/project/events/2026-04-30T00:42:01.013Z__ade22446-8adf-4564-a893-44f5750229ec.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ade22446-8adf-4564-a893-44f5750229ec",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:42:01.013Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "5909debc-99e3-4b13-930e-276af85679f4"
+  }
+}

--- a/project/events/2026-04-30T00:42:46.698Z__cc08b3d3-56ec-4e9a-9a23-f727d498be7b.json
+++ b/project/events/2026-04-30T00:42:46.698Z__cc08b3d3-56ec-4e9a-9a23-f727d498be7b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cc08b3d3-56ec-4e9a-9a23-f727d498be7b",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:42:46.698Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "4019551a-9c74-4cd7-a176-5cbe02cce707"
+  }
+}

--- a/project/events/2026-04-30T00:45:48.374Z__83aa8220-7255-4b9d-9fc6-c41144784613.json
+++ b/project/events/2026-04-30T00:45:48.374Z__83aa8220-7255-4b9d-9fc6-c41144784613.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "83aa8220-7255-4b9d-9fc6-c41144784613",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:45:48.374Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "75ce0527-5647-49af-9f19-3b1c9160574c"
+  }
+}

--- a/project/events/2026-04-30T00:57:43.641Z__6ce07035-5607-4c8b-a589-1099935677c1.json
+++ b/project/events/2026-04-30T00:57:43.641Z__6ce07035-5607-4c8b-a589-1099935677c1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6ce07035-5607-4c8b-a589-1099935677c1",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T00:57:43.641Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "d14ba616-643d-4a70-bda5-d279994e0a72"
+  }
+}

--- a/project/events/2026-04-30T01:29:22.158Z__3648594f-7f9a-465f-83d8-de8bad854b2d.json
+++ b/project/events/2026-04-30T01:29:22.158Z__3648594f-7f9a-465f-83d8-de8bad854b2d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3648594f-7f9a-465f-83d8-de8bad854b2d",
+  "issue_id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-30T01:29:22.158Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "8d7a8e72-08ca-4ecf-8dcb-e1d27d1b4f7e"
+  }
+}

--- a/project/issues/plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768.json
+++ b/project/issues/plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768.json
@@ -1,0 +1,49 @@
+{
+  "id": "plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768",
+  "title": "Use shared IdentifierDisplay for evaluation score results",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-f8aff74b-6412-4367-829d-0b5e2eec8e62",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "cfd97522-b93e-40e5-8359-39a6dc1ba0a5",
+      "author": "derek",
+      "text": "Started investigation. Goal: replace raw numeric/UUID identifier rendering in evaluations score-results detail views with shared IdentifierDisplay component used elsewhere (reports/items).",
+      "created_at": "2026-04-30T00:09:50.884610574Z"
+    },
+    {
+      "id": "42e08417-d987-406f-8186-c167c9bcf98a",
+      "author": "derek",
+      "text": "Findings: evaluation score-result detail already renders , but lazy-loaded score-results in  only populate  from . It skips legacy/object identifier sources that other surfaces normalize, causing fallback to raw itemId text. Next: centralize score-result identifier extraction in shared transform logic and reuse in evaluations lazy-load path.",
+      "created_at": "2026-04-30T00:10:47.672706092Z"
+    },
+    {
+      "id": "efd0fb20-6cf2-4516-bffe-5432ca3cc607",
+      "author": "derek",
+      "text": "Findings: evaluation score-result detail already renders the shared IdentifierDisplay component, but lazy-loaded score-results in dashboard/components/evaluations-dashboard.tsx only populate itemIdentifiers from item.itemIdentifiers.items. It skips legacy/object identifier sources that other surfaces normalize, causing fallback to raw itemId text. Next: centralize score-result identifier extraction in shared transform logic and reuse in evaluations lazy-load path.",
+      "created_at": "2026-04-30T00:10:51.014639324Z"
+    },
+    {
+      "id": "c9500c8a-86b2-4a07-a418-3600c66dba54",
+      "author": "derek",
+      "text": "User requested full DRY fix. Implementing shared score-result transformation helper(s) in dashboard/utils/data-operations.ts and replacing duplicate evaluation lazy-load mapping in dashboard/components/evaluations-dashboard.tsx to consume shared helpers only.",
+      "created_at": "2026-04-30T00:13:07.906077948Z"
+    },
+    {
+      "id": "9e3d1453-78a5-4577-840a-e355916a1933",
+      "author": "derek",
+      "text": "Implemented full DRY refactor: added shared transformScoreResultForDisplay + parseScoreResultMetadata in dashboard/utils/data-operations.ts; transformEvaluation now uses shared helper; evaluations-dashboard lazy-load transform now delegates to shared helper (removed duplicate mapping logic). Added tests for shared lazy-load transform and object-map identifier normalization. Targeted test suite pass: npm --prefix dashboard test -- --runInBand dashboard/utils/data-operations.test.ts.",
+      "created_at": "2026-04-30T00:13:47.557658200Z"
+    }
+  ],
+  "created_at": "2026-04-30T00:09:48.433406318Z",
+  "updated_at": "2026-04-30T00:13:47.557658200Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768.json
+++ b/project/issues/plx-f5fee458-f726-4eb4-bd9e-a76f5bc05768.json
@@ -40,10 +40,85 @@
       "author": "derek",
       "text": "Implemented full DRY refactor: added shared transformScoreResultForDisplay + parseScoreResultMetadata in dashboard/utils/data-operations.ts; transformEvaluation now uses shared helper; evaluations-dashboard lazy-load transform now delegates to shared helper (removed duplicate mapping logic). Added tests for shared lazy-load transform and object-map identifier normalization. Targeted test suite pass: npm --prefix dashboard test -- --runInBand dashboard/utils/data-operations.test.ts.",
       "created_at": "2026-04-30T00:13:47.557658200Z"
+    },
+    {
+      "id": "b41a4c38-2f91-42ea-8306-da7b0d70bdab",
+      "author": "derek",
+      "text": "Pushed branch bugfix/evaluations-shared-identifier-display with commits for DRY refactor + required Kanbus artifact sync. GitHub Actions check on this branch: gh run list returned no runs ([]), so there are currently no branch-triggered workflow results to report.",
+      "created_at": "2026-04-30T00:14:31.753442444Z"
+    },
+    {
+      "id": "ae08eae6-93c9-4a15-b92c-61e1a291daba",
+      "author": "derek",
+      "text": "User reports only one identifier still showing in evaluation detail. Investigating GraphQL selection sets for score-result lazy fetch/subscription to confirm whether legacy/multi identifiers are actually fetched from Item model.",
+      "created_at": "2026-04-30T00:22:12.028877066Z"
+    },
+    {
+      "id": "fcdc9460-9076-469b-8da6-92eaf7430ee2",
+      "author": "derek",
+      "text": "Follow-up fix for user repro: evaluations score-result fetch/subscription GraphQL selections were only requesting item.itemIdentifiers; added item.identifiers and item.externalId to both dashboard/components/evaluations-dashboard.tsx and dashboard/utils/amplify-helpers.ts so shared transformer can parse legacy/object-map IDs. Re-ran targeted dashboard/utils/data-operations.test.ts (pass).",
+      "created_at": "2026-04-30T00:22:47.767266858Z"
+    },
+    {
+      "id": "08e51e32-411e-4be3-99c7-ad9c2b6f899a",
+      "author": "derek",
+      "text": "Implemented evaluations-level identifier hydration to handle dataset differences: in dashboard/components/evaluations-dashboard.tsx, after score-results transform we now detect results missing itemIdentifiers and fetch Item by itemId (getItem with externalId/identifiers/itemIdentifiers), cache by itemId, and merge identifiers into score results before render. Applied in both initial paginated fetch and live subscription updates. Targeted tests still pass.",
+      "created_at": "2026-04-30T00:28:25.468330362Z"
+    },
+    {
+      "id": "375e5187-2a87-4737-bcb0-abb7dec7b25d",
+      "author": "derek",
+      "text": "Validated DB data for user-provided score result 0c14ee36-4e39-41ea-910d-fd01bca5ab64 via MCP: score_result_investigate returned item_id=309517289 and identifiers=[]; item lookup by that identifier returns canonical Item id 9c929f25-a91f-4db7-8943-5aa93498b8e9--309517289 with 7 identifiers. Root cause: some evaluations persist ScoreResult.itemId as externalId (not Item.id), so direct getItem(id=itemId) misses. Implemented evaluations-level resolver in dashboard/components/evaluations-dashboard.tsx to resolve item by id OR by externalId (listItemByExternalId) and then hydrate identifiers. Added account-aware candidate selection.",
+      "created_at": "2026-04-30T00:33:01.577882854Z"
+    },
+    {
+      "id": "e445a131-b98c-48e0-af91-2d6ca1149a53",
+      "author": "derek",
+      "text": "User requested upstream fix at evaluation generation layer. Investigating Python evaluation write path for ScoreResult.itemId assignment (id vs externalId) and implementing canonical Item.id persistence for all dataset evaluation sources.",
+      "created_at": "2026-04-30T00:35:28.030771613Z"
+    },
+    {
+      "id": "72c828a7-77e3-4f03-a487-470f93f663b4",
+      "author": "derek",
+      "text": "Implemented upstream accuracy-evaluation persistence fix in plexus/Evaluation.py: _create_score_result now writes canonical item ID (resolved_item_id/item_id) instead of raw content_id, and score_text now passes resolved_item_id when Item lookup resolves via reportId. Added regression test in plexus/test_evaluation_metrics.py for searches-dataset reportId path; ran .venv/bin/pytest -q plexus/test_evaluation_metrics.py -k 'score_text_resolves_item_id_from_report_identifier or score_text_prefers_top_level_linkage_fields' (2 passed). Important: existing evaluation rows remain unchanged; only newly-run evaluations persist corrected itemId values unless backfilled.",
+      "created_at": "2026-04-30T00:37:31.164303906Z"
+    },
+    {
+      "id": "5909debc-99e3-4b13-930e-276af85679f4",
+      "author": "derek",
+      "text": "Follow-up: share-link evaluation route still shows only canonical itemId string. Investigating /evaluations/<token> data path and aligning its score-result identifier fetch/transform with fixed main evaluations flow.",
+      "created_at": "2026-04-30T00:42:01.013126383Z"
+    },
+    {
+      "id": "4019551a-9c74-4cd7-a176-5cbe02cce707",
+      "author": "derek",
+      "text": "Patched shared evaluation page service (dashboard/app/evaluations/[id]/page.tsx): added identifier hydration for score results in share-link path. Service now resolves missing identifiers by Item.id first, then listItemByExternalId fallback, account-scoped when possible, and merges into scoreResults before render. Also expanded score-result query selection to include item.externalId/identifiers/accountId and fetches full scoreResults for share payloads that omit them.",
+      "created_at": "2026-04-30T00:42:46.698479849Z"
+    },
+    {
+      "id": "75ce0527-5647-49af-9f19-3b1c9160574c",
+      "author": "derek",
+      "text": "Share-route follow-up: updated EvaluationService.fetchEvaluationByShareToken to always fetch canonical score-results via listScoreResultByEvaluationId(resourceId) (with resolved authMode) and overwrite share payload scoreResults before transform/hydration. This avoids partial share payloads that may include only itemId and omit nested item identifiers.",
+      "created_at": "2026-04-30T00:45:48.374362226Z"
+    },
+    {
+      "id": "d14ba616-643d-4a70-bda5-d279994e0a72",
+      "author": "derek",
+      "text": "Removing dashboard/public rehydration fallback now that producer writes canonical itemId and identifiers.",
+      "created_at": "2026-04-30T00:57:43.640897371Z"
+    },
+    {
+      "id": "8d7a8e72-08ca-4ecf-8dcb-e1d27d1b4f7e",
+      "author": "derek",
+      "text": "Committed producer-first canonical identifier fix + removed UI rehydration fallback. Commit c4728115 includes Evaluation.py itemId canonicalization, dashboard canonical score-result fetch/transform, and regression test coverage.",
+      "created_at": "2026-04-30T01:29:22.158538632Z"
     }
   ],
   "created_at": "2026-04-30T00:09:48.433406318Z",
-  "updated_at": "2026-04-30T00:13:47.557658200Z",
+  "updated_at": "2026-04-30T01:29:22.158538632Z",
   "closed_at": null,
-  "custom": {}
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
 }


### PR DESCRIPTION
## Summary
- fix producer path so ScoreResult.itemId is persisted as canonical Item.id in evaluation writes
- add regression test for report-identifier/search dataset linkage path
- update evaluation score-result queries to include identifier fields used by shared transform
- remove dashboard/public rehydration fallback and rely on canonical producer data path
- refresh public share view by fetching canonical score-results for the evaluation id
- include baseline-browser-mapping dev dependency bump used in local setup

## Validation
- `cd dashboard && npm run -s typecheck`
- `poetry run pytest -q plexus/test_evaluation_metrics.py -k "score_text_resolves_item_id_from_report_identifier or score_text_prefers_top_level_linkage_fields"`

## Notes
- This is intentionally producer-first and one-way (no fallback hydration path).
- Old historical evaluations with bad linkage are not backfilled by this change.
