### PR TITLE
Merge evaluation/procedure linkage and dashboard refinements into develop

### DIFF
--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -2741,6 +2741,7 @@ def _default_evaluation_runner(args: dict[str, Any], mcp: "FastMCP | None") -> d
     _append_optional_cli_arg(cmd, "--baseline", args.get("baseline"))
     _append_optional_cli_arg(cmd, "--current-baseline", args.get("current_baseline"))
     _append_optional_cli_arg(cmd, "--notes", args.get("notes"))
+    _append_optional_cli_arg(cmd, "--procedure-id", args.get("procedure_id"))
 
     child_budget = args.get("budget")
     env = os.environ.copy()
@@ -4804,6 +4805,8 @@ class PlexusRuntimeModule:
                 f"Unsupported Plexus runtime API: plexus.{namespace}.{method}"
             )
         parsed = _args(args)
+        if not parsed.get("procedure_id") and self._trace_id:
+            parsed["procedure_id"] = self._trace_id
         if not bool(parsed.get("async")):
             self._record_api_call("evaluation", "run")
             self.handle_protocol_required = ("evaluation", "run")

--- a/MCP/tools/tactus_runtime/execute_test.py
+++ b/MCP/tools/tactus_runtime/execute_test.py
@@ -1235,6 +1235,7 @@ def test_evaluation_run_async_creates_handle_and_records_budget() -> None:
         "score_name": "Tone",
         "async": True,
         "budget": budget,
+        "procedure_id": "trace-1",
     }
     assert gate.tool_calls == 3
     assert gate.spent_usd == pytest.approx(0.01)
@@ -1263,6 +1264,65 @@ def test_evaluation_run_async_requires_explicit_child_budget() -> None:
 
     assert called is False
     assert module.api_calls == ["plexus.evaluation.run"]
+
+
+def test_evaluation_run_async_preserves_explicit_procedure_id() -> None:
+    seen_args: dict = {}
+
+    def fake_runner(args: dict) -> dict:
+        seen_args.update(args)
+        return {
+            "status": "dispatched",
+            "evaluation_id": "eval-1",
+            "dashboard_url": "https://example.test/evaluations/eval-1",
+        }
+
+    module = execute.PlexusRuntimeModule(
+        FastMCP("test"),
+        trace_id="trace-1",
+        evaluation_runner=fake_runner,
+        handle_store=_MemoryHandleStore(),
+    )
+
+    module.evaluation.run(
+        {
+            "scorecard_name": "Compliance",
+            "async": True,
+            "budget": _child_budget(),
+            "procedure_id": "proc-explicit",
+        }
+    )
+
+    assert seen_args["procedure_id"] == "proc-explicit"
+
+
+def test_evaluation_run_async_injects_trace_id_procedure_id_when_missing() -> None:
+    seen_args: dict = {}
+
+    def fake_runner(args: dict) -> dict:
+        seen_args.update(args)
+        return {
+            "status": "dispatched",
+            "evaluation_id": "eval-2",
+            "dashboard_url": "https://example.test/evaluations/eval-2",
+        }
+
+    module = execute.PlexusRuntimeModule(
+        FastMCP("test"),
+        trace_id="proc-trace-123",
+        evaluation_runner=fake_runner,
+        handle_store=_MemoryHandleStore(),
+    )
+
+    module.evaluation.run(
+        {
+            "scorecard_name": "Compliance",
+            "async": True,
+            "budget": _child_budget(),
+        }
+    )
+
+    assert seen_args["procedure_id"] == "proc-trace-123"
 
 
 def test_async_child_budget_overrun_blocks_dispatch() -> None:
@@ -1325,6 +1385,7 @@ def test_default_evaluation_runner_dispatches_cli_without_mcp_loopback(
             "score_name": "Tone",
             "max_feedback_items": 25,
             "days": 30,
+            "procedure_id": "proc-123",
             "budget": _child_budget(),
         },
         FakeMCP(),
@@ -1351,6 +1412,8 @@ def test_default_evaluation_runner_dispatches_cli_without_mcp_loopback(
         "newest",
         "--days",
         "30",
+        "--procedure-id",
+        "proc-123",
     ]
     assert captured["kwargs"]["start_new_session"] is True
     assert json.loads(captured["kwargs"]["env"]["PLEXUS_CHILD_BUDGET"]) == _child_budget()

--- a/dashboard/components/EvaluationTask.tsx
+++ b/dashboard/components/EvaluationTask.tsx
@@ -2107,7 +2107,6 @@ const EvaluationTask = React.memo(function EvaluationTaskComponent({
     id: string;
     createdAt: string;
     note?: string | null;
-    isChampion: boolean;
   } | null>(null);
   const [scoreVersionLoadFailed, setScoreVersionLoadFailed] = useState(false);
   const [procedureInfo, setProcedureInfo] = useState<{
@@ -2160,9 +2159,6 @@ const EvaluationTask = React.memo(function EvaluationTaskComponent({
                 id
                 createdAt
                 note
-                score {
-                  championVersionId
-                }
               }
             }
           `,
@@ -2175,7 +2171,6 @@ const EvaluationTask = React.memo(function EvaluationTaskComponent({
             id: scoreVersion.id,
             createdAt: scoreVersion.createdAt,
             note: scoreVersion.note ?? null,
-            isChampion: scoreVersion.score?.championVersionId === task.scoreVersionId
           });
         } else {
           setScoreVersionInfo(null);
@@ -2898,36 +2893,6 @@ ${categoryLines}${mechanicalLines}
                   )}
               </div>
             )}
-            {taskWithDefaults.procedureId && (
-              <RelatedResourceCard
-                label="Procedure"
-                className="bg-card-selected"
-                href={`/lab/procedures/${taskWithDefaults.procedureId}`}
-                linkLabel="Open procedure"
-                summary={
-                  <span className="truncate">
-                    {procedureInfo?.name || (procedureLoadFailed ? 'Unavailable' : taskWithDefaults.procedureId)}
-                  </span>
-                }
-              >
-                {procedureInfo ? (
-                  <div className="space-y-1">
-                    <div>{procedureInfo.description || 'No description'}</div>
-                    <div className="flex flex-wrap items-center gap-2 text-xs">
-                      {procedureInfo.status && <span>Status: {procedureInfo.status}</span>}
-                      {procedureInfo.updatedAt && (
-                        <span>
-                          Updated <Timestamp time={procedureInfo.updatedAt} variant="relative" className="text-xs" />
-                        </span>
-                      )}
-                    </div>
-                    <div className="font-mono text-xs">{procedureInfo.id}</div>
-                  </div>
-                ) : (
-                  <span>{procedureLoadFailed ? 'This procedure could not be loaded.' : 'Loading procedure details...'}</span>
-                )}
-              </RelatedResourceCard>
-            )}
             {taskWithDefaults.dataSetId && (
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <span>Dataset:</span>
@@ -2985,31 +2950,57 @@ ${categoryLines}${mechanicalLines}
               isInProgress={data.status?.toUpperCase() === 'RUNNING'}
               className="text-muted-foreground"
             />
-            {taskWithDefaults.scorecardId && taskWithDefaults.scoreId && taskWithDefaults.scoreVersionId && (
-              <RelatedResourceCard
-                label="Score Version"
-                className="bg-card-selected"
-                collapsible={false}
-                href={`/lab/scorecards/${taskWithDefaults.scorecardId}/scores/${taskWithDefaults.scoreId}/versions/${taskWithDefaults.scoreVersionId}`}
-                linkLabel="Open score version"
-                summary={<span className="font-mono truncate">{shortHash(taskWithDefaults.scoreVersionId)}</span>}
-              >
-                {scoreVersionInfo ? (
-                  <div className="space-y-1">
-                    <div className="flex flex-wrap items-center gap-2 text-xs">
-                      <Timestamp time={scoreVersionInfo.createdAt} variant="relative" className="text-xs" />
-                      {scoreVersionInfo.isChampion && (
-                        <span className="px-1.5 py-0.5 rounded bg-primary/10 text-primary font-medium">
-                          Champion
-                        </span>
-                      )}
-                    </div>
-                    <div>{scoreVersionInfo.note || 'No note'}</div>
-                  </div>
-                ) : (
-                  <span>{scoreVersionLoadFailed ? 'This score version could not be loaded.' : 'Loading score version details...'}</span>
+            {(taskWithDefaults.procedureId || (taskWithDefaults.scorecardId && taskWithDefaults.scoreId && taskWithDefaults.scoreVersionId)) && (
+              <div className="space-y-0">
+                {taskWithDefaults.procedureId && (
+                  <RelatedResourceCard
+                    label="Procedure"
+                    className="bg-card-selected"
+                    collapsible={false}
+                    inlineLink={true}
+                    rowDensity="dense"
+                    href={`/lab/procedures/${taskWithDefaults.procedureId}`}
+                    linkLabel="Open procedure"
+                    rightMeta={
+                      procedureInfo?.updatedAt ? (
+                        <Timestamp time={procedureInfo.updatedAt} variant="relative" className="whitespace-nowrap text-xs text-muted-foreground" />
+                      ) : null
+                    }
+                    summary={
+                      <span className="truncate">
+                        {procedureInfo?.name || (procedureLoadFailed ? 'Unavailable' : taskWithDefaults.procedureId)}
+                      </span>
+                    }
+                  >
+                    {null}
+                  </RelatedResourceCard>
                 )}
-              </RelatedResourceCard>
+                {taskWithDefaults.scorecardId && taskWithDefaults.scoreId && taskWithDefaults.scoreVersionId && (
+                  <RelatedResourceCard
+                    label="Score Version"
+                    className="bg-card-selected"
+                    collapsible={false}
+                    inlineLink={true}
+                    rowDensity="dense"
+                    href={`/lab/scorecards/${taskWithDefaults.scorecardId}/scores/${taskWithDefaults.scoreId}/versions/${taskWithDefaults.scoreVersionId}`}
+                    linkLabel="Open score version"
+                    rightMeta={
+                      scoreVersionInfo?.createdAt ? (
+                        <Timestamp time={scoreVersionInfo.createdAt} variant="relative" className="whitespace-nowrap text-xs text-muted-foreground" />
+                      ) : null
+                    }
+                    summary={<span className="font-mono truncate">{shortHash(taskWithDefaults.scoreVersionId)}</span>}
+                  >
+                    {scoreVersionInfo ? (
+                      <div className="space-y-1">
+                        <div>{scoreVersionInfo.note || 'No note'}</div>
+                      </div>
+                    ) : (
+                      <span>{scoreVersionLoadFailed ? 'This score version could not be loaded.' : 'Loading score version details...'}</span>
+                    )}
+                  </RelatedResourceCard>
+                )}
+              </div>
             )}
             {evaluationNotes && (
               <div className="mt-1">

--- a/dashboard/components/TaskDisplay.test.tsx
+++ b/dashboard/components/TaskDisplay.test.tsx
@@ -269,6 +269,31 @@ describe('TaskDisplay Golden Path', () => {
       expect(screen.getByTestId('task-procedure-id')).toHaveTextContent('procedure-789');
     });
 
+    it('derives procedure id from task metadata when evaluationData does not provide it', () => {
+      const taskWithProcedureMetadata: AmplifyTask = {
+        ...mockTask,
+        metadata: JSON.stringify({ procedure_id: 'procedure-from-task-metadata' }),
+      };
+
+      const mockEvaluationData = {
+        id: 'eval-links-derived-procedure',
+        type: 'accuracy',
+        scorecardId: 'scorecard-123',
+        scoreId: 'score-456',
+        scoreResults: []
+      };
+
+      render(
+        <TaskDisplay
+          variant="detail"
+          task={taskWithProcedureMetadata}
+          evaluationData={mockEvaluationData}
+        />
+      );
+
+      expect(screen.getByTestId('task-procedure-id')).toHaveTextContent('procedure-from-task-metadata');
+    });
+
     it('passes through original and current baseline ids to EvaluationTask', () => {
       const mockEvaluationData = {
         id: 'eval-baselines',

--- a/dashboard/components/TaskDisplay.tsx
+++ b/dashboard/components/TaskDisplay.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, useRef } from 'react'
 import type { AmplifyTask, ProcessedTask } from '@/utils/data-operations'
-import { transformAmplifyTask, processTask } from '@/utils/data-operations'
+import { getTaskProcedureId, transformAmplifyTask, processTask } from '@/utils/data-operations'
 import type { EvaluationTaskProps } from '@/types/tasks/evaluation'
 import type { TaskStatus } from '@/types/shared'
 import EvaluationTask from '@/components/EvaluationTask'
@@ -274,7 +274,7 @@ export const TaskDisplay = React.memo(function TaskDisplayComponent({
     command: processedTask?.command,
     description: processedTask?.description,
     dispatchStatus: processedTask?.dispatchStatus,
-    metadata: processedTask?.metadata,
+    metadata: processedTask?.metadata || task?.metadata,
     errorMessage: processedTask?.errorMessage || (task ? (task.errorMessage || evaluationData?.errorMessage) : evaluationData?.errorMessage) || undefined,
     errorDetails: processedTask?.errorDetails || (task ? (task.errorDetails || evaluationData?.errorDetails) : evaluationData?.errorDetails) || undefined,
     celeryTaskId: (processedTask?.celeryTaskId || task?.celeryTaskId) ?? undefined,
@@ -287,13 +287,18 @@ export const TaskDisplay = React.memo(function TaskDisplayComponent({
 
   // Conditionally render EvaluationTask or ReportTask
   if (evaluationData) {
+    const derivedProcedureId = getTaskProcedureId({
+      metadata: commonTaskProps.metadata,
+      target: (processedTask?.target || task?.target || '') as string,
+    } as AmplifyTask)
+
     // Construct props specific to EvaluationTask
     const evaluationTaskProps = {
       task: {
         ...commonTaskProps,
         scorecard: evaluationData.scorecard?.name || evaluationData.scorecardId || '-',
         score: evaluationData.score?.name || evaluationData.scoreId || '-',
-        procedureId: evaluationData.procedureId ?? undefined,
+        procedureId: evaluationData.procedureId ?? derivedProcedureId ?? undefined,
         scorecardId: evaluationData.scorecardId,
         scoreId: evaluationData.scoreId,
         scoreVersionId: evaluationData.scoreVersionId,

--- a/dashboard/components/__tests__/EvaluationTask.category-filter.test.tsx
+++ b/dashboard/components/__tests__/EvaluationTask.category-filter.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import EvaluationTask from '@/components/EvaluationTask'
 
 jest.mock('@/components/EvaluationTaskScoreResults', () => ({
@@ -27,16 +27,13 @@ jest.mock('@/utils/amplify-client', () => ({
 
       return Promise.resolve({
         data: {
-          getScoreVersion: {
-            id: 'version-1',
-            createdAt: '2024-01-01T00:00:00Z',
-            note: 'Evaluation candidate version',
-            score: {
-              championVersionId: 'version-1',
+            getScoreVersion: {
+              id: 'version-1',
+              createdAt: '2024-01-01T00:00:00Z',
+              note: 'Evaluation candidate version',
             },
           },
-        },
-      })
+        })
     }),
   }),
 }))
@@ -280,10 +277,6 @@ describe('EvaluationTask category summary drill-down', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Clear category filter/i }))
     expect(screen.getByTestId('selected-item-ids')).toHaveTextContent('null')
-
-    await waitFor(() => {
-      expect(screen.getByText('Champion')).toBeInTheDocument()
-    })
   })
 
   test('filters by score_result_id linkage when item_id is unavailable', async () => {
@@ -335,13 +328,9 @@ describe('EvaluationTask category summary drill-down', () => {
   test('renders score version and procedure related-resource cards in detail view', async () => {
     const { container } = render(<EvaluationTask variant="detail" task={makeTask()} />)
 
-    await waitFor(() => {
-      expect(screen.getByText('Champion')).toBeInTheDocument()
-    })
-
     expect(screen.getByText('Score Version')).toBeInTheDocument()
     expect(screen.getByText('Procedure')).toBeInTheDocument()
-    expect(screen.getByText('Optimizer run')).toBeInTheDocument()
+    expect(await screen.findByText('Optimizer run')).toBeInTheDocument()
     expect(container.querySelector('a[href="/lab/scorecards/scorecard-1"]')).toBeTruthy()
     expect(container.querySelector('a[href="/lab/scorecards/scorecard-1/scores/score-1/versions/version-1"]')).toBeTruthy()
     expect(container.querySelector('a[href="/lab/procedures/procedure-1"]')).toBeTruthy()
@@ -352,10 +341,7 @@ describe('EvaluationTask category summary drill-down', () => {
 
     expect(screen.getByText('Score Version')).toBeInTheDocument()
     expect(screen.queryByText('Procedure')).not.toBeInTheDocument()
-
-    await waitFor(() => {
-      expect(screen.getByText('Champion')).toBeInTheDocument()
-    })
+    expect(await screen.findByText('Evaluation candidate version')).toBeInTheDocument()
   })
 
   test('does not render procedure related-resource card in grid mode', () => {

--- a/dashboard/components/ui/related-resource-card.tsx
+++ b/dashboard/components/ui/related-resource-card.tsx
@@ -16,6 +16,8 @@ export interface RelatedResourceCardProps {
   linkLabel?: string
   collapsible?: boolean
   rowDensity?: "default" | "dense"
+  rightMeta?: React.ReactNode
+  inlineLink?: boolean
 }
 
 export function RelatedResourceCard({
@@ -27,6 +29,8 @@ export function RelatedResourceCard({
   linkLabel = "Open related resource",
   collapsible = true,
   rowDensity = "default",
+  rightMeta,
+  inlineLink = false,
 }: RelatedResourceCardProps) {
   const [isOpen, setIsOpen] = React.useState(false)
   const hasContent = children !== null && children !== undefined && children !== false && children !== ""
@@ -43,48 +47,66 @@ export function RelatedResourceCard({
 
   const header = (
     <div className="flex min-w-0 items-center gap-0.5 pr-2">
-      {collapsible ? (
-        <CollapsibleTrigger asChild>
-          <button type="button" className="min-w-0 py-2 text-left">
+      <div className="min-w-0 flex-1">
+        {collapsible ? (
+          <CollapsibleTrigger asChild>
+            <button type="button" className="min-w-0 py-2 text-left">
+              <div className="flex min-w-0 items-center gap-2">
+                {isOpen ? (
+                  <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <div className="flex min-w-0 items-center gap-1.5 text-xs truncate">
+                  <span className="font-medium truncate">{label}</span>
+                  <span className="text-muted-foreground">·</span>
+                  <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground truncate">
+                    {summary}
+                  </span>
+                </div>
+              </div>
+            </button>
+          </CollapsibleTrigger>
+        ) : (
+          <div className={cn("min-w-0 text-left", nonCollapsibleHeaderPadding)}>
             <div className="flex min-w-0 items-center gap-2">
-              {isOpen ? (
-                <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-              ) : (
-                <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-              )}
               <div className="flex min-w-0 items-center gap-1.5 text-xs truncate">
                 <span className="font-medium truncate">{label}</span>
-                <span className="text-muted-foreground">·</span>
+                <span className="text-muted-foreground">:</span>
                 <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground truncate">
                   {summary}
                 </span>
+                {inlineLink && href && (
+                  <NextLink
+                    href={href}
+                    aria-label={linkLabel}
+                    title={linkLabel}
+                    className={cn("shrink-0 rounded-sm text-foreground hover:bg-card", linkPadding)}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    <LinkIcon className="h-4 w-4" />
+                  </NextLink>
+                )}
               </div>
             </div>
-          </button>
-        </CollapsibleTrigger>
-      ) : (
-        <div className={cn("min-w-0 text-left", nonCollapsibleHeaderPadding)}>
-          <div className="flex min-w-0 items-center gap-2">
-            <div className="flex min-w-0 items-center gap-1.5 text-xs truncate">
-              <span className="font-medium truncate">{label}</span>
-              <span className="text-muted-foreground">:</span>
-              <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground truncate">
-                {summary}
-              </span>
-            </div>
           </div>
+        )}
+      </div>
+      {((href && !inlineLink) || rightMeta) && (
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          {href && !inlineLink && (
+            <NextLink
+              href={href}
+              aria-label={linkLabel}
+              title={linkLabel}
+              className={cn("shrink-0 rounded-sm text-foreground hover:bg-card", linkPadding)}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <LinkIcon className="h-4 w-4" />
+            </NextLink>
+          )}
+          {rightMeta}
         </div>
-      )}
-      {href && (
-        <NextLink
-          href={href}
-          aria-label={linkLabel}
-          title={linkLabel}
-          className={cn("shrink-0 rounded-sm text-foreground hover:bg-card", linkPadding)}
-          onClick={(event) => event.stopPropagation()}
-        >
-          <LinkIcon className="h-4 w-4" />
-        </NextLink>
       )}
     </div>
   )

--- a/dashboard/utils/data-operations.test.ts
+++ b/dashboard/utils/data-operations.test.ts
@@ -34,6 +34,29 @@ describe('transformEvaluation', () => {
     expect(result!.procedureId).toBe('procedure-999');
   });
 
+  it('derives procedureId from task target when metadata is missing', () => {
+    const mockEvaluation: BaseEvaluation = {
+      id: 'eval-procedure-target',
+      type: 'accuracy',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      status: 'COMPLETED',
+      accountId: 'account-1',
+      task: {
+        id: 'task-2',
+        type: 'Accuracy Evaluation',
+        status: 'COMPLETED',
+        target: 'procedure/run/procedure-abc123',
+        command: 'evaluate accuracy --scorecard test',
+      } as any,
+    } as any;
+
+    const result = transformEvaluation(mockEvaluation);
+
+    expect(result).toBeTruthy();
+    expect(result!.procedureId).toBe('procedure-abc123');
+  });
+
   it('extracts canonical baseline ids from evaluation parameters metadata', () => {
     const mockEvaluation: BaseEvaluation = {
       id: 'eval-baselines',

--- a/dashboard/utils/data-operations.ts
+++ b/dashboard/utils/data-operations.ts
@@ -1044,10 +1044,25 @@ export function parseTaskMetadata(rawMetadata: unknown): Record<string, unknown>
 
 export function getTaskProcedureId(task: AmplifyTask | null | undefined): string | null {
   const metadata = parseTaskMetadata(task?.metadata);
-  if (!metadata) return null;
+  if (metadata) {
+    const procedureId = metadata.procedure_id ?? metadata.procedureId;
+    if (typeof procedureId === 'string' && procedureId.trim()) {
+      return procedureId.trim();
+    }
+  }
 
-  const procedureId = metadata.procedure_id ?? metadata.procedureId;
-  return typeof procedureId === 'string' && procedureId.trim() ? procedureId : null;
+  const target = typeof task?.target === 'string' ? task.target.trim() : '';
+  if (!target) return null;
+  if (target.startsWith('procedure/run/')) {
+    const extracted = target.slice('procedure/run/'.length).trim();
+    return extracted || null;
+  }
+  if (target.startsWith('procedure/')) {
+    const extracted = target.slice('procedure/'.length).trim();
+    return extracted || null;
+  }
+
+  return null;
 }
 
 export function transformEvaluation(evaluation: BaseEvaluation): ProcessedEvaluation | null {

--- a/plexus/cli/evaluation/evaluations.py
+++ b/plexus/cli/evaluation/evaluations.py
@@ -2032,6 +2032,25 @@ def get_latest_score_version(client, score_id: str) -> Optional[str]:
         logging.error(f"Error fetching latest ScoreVersion for score {score_id}: {str(e)}")
         return None
 
+
+def _build_evaluation_task_metadata(
+    *,
+    task_type: str,
+    scorecard: str,
+    score: Optional[str] = None,
+    procedure_id: Optional[str] = None,
+) -> Dict[str, str]:
+    metadata: Dict[str, str] = {
+        "type": task_type,
+        "scorecard": scorecard,
+        "task_type": task_type,
+    }
+    if score:
+        metadata["score"] = score
+    if procedure_id:
+        metadata["procedure_id"] = procedure_id
+    return metadata
+
 @evaluate.command()
 @click.option('--scorecard', 'scorecard', default=None, help='Scorecard identifier (ID, name, key, or external ID)')
 @click.option('--yaml', is_flag=True, help='Load scorecard from individual YAML files (from fetch_score_configurations) instead of the API')
@@ -2060,6 +2079,7 @@ def get_latest_score_version(client, score_id: str) -> Optional[str]:
 @click.option('--current-baseline', default=None, type=str, help='Current baseline evaluation ID (latest accepted version) for dual baseline dashboard display.')
 @click.option('--json-only', is_flag=True, default=False, help='Emit JSON summary payload instead of rich console output.')
 @click.option('--notes', default=None, type=str, help='Freeform notes explaining why this evaluation is being run. Stored in evaluation parameters.')
+@click.option('--procedure-id', default=None, type=str, help='Procedure ID to associate with the evaluation task metadata.')
 @click.option('--emit-id-file', default=None, type=str, help='Write the evaluation ID to this file as soon as the record is created (used by programmatic dispatch).')
 @_enforce_child_budget_from_env("evaluation.accuracy")
 def accuracy(
@@ -2090,6 +2110,7 @@ def accuracy(
     current_baseline: Optional[str],
     json_only: bool,
     notes: Optional[str] = None,
+    procedure_id: Optional[str] = None,
     emit_id_file: Optional[str] = None,
     ):
     """
@@ -2399,11 +2420,11 @@ def accuracy(
                             description=f"Accuracy evaluation for {scorecard}",
                             dispatch_status="DISPATCHED",
                             prevent_new_task=False,
-                            metadata={
-                                "type": "Accuracy Evaluation",
-                                "scorecard": scorecard,
-                                "task_type": "Accuracy Evaluation"
-                            },
+                            metadata=_build_evaluation_task_metadata(
+                                task_type="Accuracy Evaluation",
+                                scorecard=scorecard,
+                                procedure_id=procedure_id,
+                            ),
                             account_id=account.id
                         )
 
@@ -2497,11 +2518,11 @@ def accuracy(
                     description=f"Accuracy evaluation for {scorecard}",
                     dispatch_status="DISPATCHED",
                     prevent_new_task=True,  # Prevent new task creation since we have one
-                    metadata={
-                        "type": "Accuracy Evaluation",
-                        "scorecard": scorecard,
-                        "task_type": "Accuracy Evaluation"
-                    },
+                    metadata=_build_evaluation_task_metadata(
+                        task_type="Accuracy Evaluation",
+                        scorecard=scorecard,
+                        procedure_id=procedure_id,
+                    ),
                     account_id=account.id
                 )
                 
@@ -4203,6 +4224,7 @@ def last(account_key: str, type: Optional[str]):
 @click.option('--yaml', 'use_yaml', is_flag=True, help='Load scorecard from local YAML files instead of the API')
 @click.option('--task-id', default=None, type=str, help='Task ID for progress tracking')
 @click.option('--notes', default=None, type=str, help='Freeform notes explaining why this evaluation is being run. Stored in evaluation parameters.')
+@click.option('--procedure-id', default=None, type=str, help='Procedure ID to associate with the evaluation task metadata.')
 @click.option(
     '--score-rubric-consistency-check',
     is_flag=True,
@@ -4224,6 +4246,7 @@ def feedback(
     use_yaml: bool,
     task_id: Optional[str],
     notes: Optional[str] = None,
+    procedure_id: Optional[str] = None,
     score_rubric_consistency_check: bool = False,
     emit_id_file: Optional[str] = None,
 ):
@@ -4523,11 +4546,12 @@ def feedback(
                         description=f"Feedback accuracy evaluation for {scorecard} > {score}",
                         dispatch_status="DISPATCHED",
                         prevent_new_task=False,
-                        metadata={
-                            "type": "Feedback Accuracy Evaluation",
-                            "scorecard": scorecard,
-                            "task_type": "Feedback Accuracy Evaluation"
-                        },
+                        metadata=_build_evaluation_task_metadata(
+                            task_type="Feedback Accuracy Evaluation",
+                            scorecard=scorecard,
+                            score=score,
+                            procedure_id=procedure_id,
+                        ),
                         account_id=account_id,
                         client=client
                     )

--- a/plexus/cli/evaluation/evaluations_procedure_metadata_test.py
+++ b/plexus/cli/evaluation/evaluations_procedure_metadata_test.py
@@ -1,0 +1,27 @@
+from plexus.cli.evaluation.evaluations import _build_evaluation_task_metadata
+
+
+def test_build_evaluation_task_metadata_includes_procedure_id_when_present() -> None:
+    metadata = _build_evaluation_task_metadata(
+        task_type="Feedback Accuracy Evaluation",
+        scorecard="Test Scorecard",
+        score="Test Score",
+        procedure_id="proc-123",
+    )
+
+    assert metadata["type"] == "Feedback Accuracy Evaluation"
+    assert metadata["scorecard"] == "Test Scorecard"
+    assert metadata["score"] == "Test Score"
+    assert metadata["procedure_id"] == "proc-123"
+
+
+def test_build_evaluation_task_metadata_omits_procedure_id_when_absent() -> None:
+    metadata = _build_evaluation_task_metadata(
+        task_type="Accuracy Evaluation",
+        scorecard="Test Scorecard",
+    )
+
+    assert metadata["type"] == "Accuracy Evaluation"
+    assert metadata["scorecard"] == "Test Scorecard"
+    assert "score" not in metadata
+    assert "procedure_id" not in metadata

--- a/plexus/cli/procedure/mcp_transport.py
+++ b/plexus/cli/procedure/mcp_transport.py
@@ -13,6 +13,7 @@ access for procedure contexts.
 import asyncio
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Callable, Union
 from dataclasses import dataclass, field
@@ -756,6 +757,44 @@ class EmbeddedMCPServer:
                     "success": bool(True if success is None else success),
                     "reason": reason,
                     "tool": "done",
+                }
+
+            @tool_capture.tool()
+            async def get_plexus_documentation(filename: str):
+                """Get documentation content for specific Plexus topics by markdown slug."""
+                slug = str(filename or "").strip().lower()
+                if not slug:
+                    return {"error": "filename is required"}
+
+                docs_root = os.path.normpath(
+                    os.path.join(os.path.dirname(__file__), "..", "..", "docs")
+                )
+                candidate_name = f"{slug}.md"
+                matches: List[str] = []
+                for root, _dirs, files in os.walk(docs_root):
+                    if candidate_name in files:
+                        matches.append(os.path.join(root, candidate_name))
+
+                if not matches:
+                    return {
+                        "error": (
+                            f"Documentation file not found: {slug}. "
+                            "Expected a markdown file under plexus/docs."
+                        )
+                    }
+
+                # Use deterministic path ordering if duplicates exist.
+                selected_path = sorted(matches)[0]
+                try:
+                    with open(selected_path, "r", encoding="utf-8") as handle:
+                        content = handle.read()
+                except Exception as exc:
+                    return {"error": f"Failed to read documentation file {selected_path}: {exc}"}
+
+                return {
+                    "filename": slug,
+                    "path": selected_path,
+                    "documentation": content,
                 }
             
             # Register execute_tactus so LLM agents (e.g. console chat) can query

--- a/plexus/cli/procedure/test_mcp_transport.py
+++ b/plexus/cli/procedure/test_mcp_transport.py
@@ -272,6 +272,22 @@ class TestEmbeddedMCPServer:
             assert server.transport.client_info["name"] == "Procedure Client"
             assert server.transport.client_info["version"] == "1.0.0"
 
+    @pytest.mark.asyncio
+    async def test_register_plexus_tools_includes_get_documentation(self, server):
+        """Procedure MCP transport should expose get_plexus_documentation."""
+        server.register_plexus_tools()
+        await server.transport.initialize({"name": "Test"})
+
+        result = await server.transport.call_tool(
+            "get_plexus_documentation",
+            {"filename": "optimizer-cookbook"},
+        )
+        payload = json.loads(result["content"][0]["text"])
+        assert payload["filename"] == "optimizer-cookbook"
+        assert "documentation" in payload
+        assert isinstance(payload["documentation"], str)
+        assert "optimizer" in payload["documentation"].lower()
+
 
 def test_advance_task_to_stage_by_name_uses_long_running_retry_policy():
     client = Mock()


### PR DESCRIPTION
## Summary
This PR brings the complete set of changes from feature/plx-07dc0d-execute-tactus-mcp-tool into develop for record-keeping and integration.

## What this includes
- Propagates procedure_id through procedure-driven evaluation execution paths (runtime + CLI plumbing + tests).
- Adds and updates evaluation metadata handling used by dashboard task rendering.
- Updates EvaluationTask related-resource UI to show linked Procedure and Score Version with consistent compact styling and timestamp placement.
- Extends dashboard tests for category filtering and related-link behavior in evaluation task views.
- Includes supporting fixes in MCP runtime execution tests and procedure transport paths landed on this branch.

## Validation
- Focused dashboard tests run for EvaluationTask category-filter behavior.
- Dashboard typecheck run during implementation.

## Notes
- PR is being used primarily as an integration record; intent is to merge branch changes directly into develop.
