### PR TITLE
Add score-version procedure association index

### DIFF
--- a/dashboard/amplify/data/resource.ts
+++ b/dashboard/amplify/data/resource.ts
@@ -48,6 +48,7 @@ type DataSourceIndexFields = "accountId" | "scorecardId" | "scoreId" | "name" | 
 type DataSourceVersionIndexFields = "dataSourceId" | "createdAt" | "updatedAt";
 type DataSetIndexFields = "accountId" | "scorecardId" | "scoreId" | "scoreVersionId" | "dataSourceVersionId" | "createdAt" | "updatedAt";
 type ProcedureIndexFields = "accountId" | "scorecardId" | "scoreId" | "scoreVersionId" | "parentProcedureId" | "updatedAt" | "createdAt" | "category" | "version" | "status";
+type ProcedureScoreVersionIndexFields = "procedureId" | "scoreVersionId" | "scoreId" | "updatedAt";
 
 // New index types for Feedback Alignment
 // type FeedbackAlignmentIndexFields = "accountId" | "scorecardId" | "createdAt"; // REMOVED
@@ -207,7 +208,8 @@ const schema = a.schema({
             childVersions: a.hasMany('ScoreVersion', 'parentVersionId'),
             evaluations: a.hasMany('Evaluation', 'scoreVersionId'),
             dataSets: a.hasMany('DataSet', 'scoreVersionId'),
-            procedures: a.hasMany('Procedure', 'scoreVersionId')
+            procedures: a.hasMany('Procedure', 'scoreVersionId'),
+            procedureLinks: a.hasMany('ProcedureScoreVersion', 'scoreVersionId')
         })
         .authorization((allow) => [
             allow.publicApiKey(),
@@ -884,6 +886,7 @@ const schema = a.schema({
             score: a.belongsTo('Score', 'scoreId'),
             scoreVersionId: a.string(),
             scoreVersion: a.belongsTo('ScoreVersion', 'scoreVersionId'),
+            scoreVersionLinks: a.hasMany('ProcedureScoreVersion', 'procedureId'),
             chatSessions: a.hasMany('ChatSession', 'procedureId'),
             chatMessages: a.hasMany('ChatMessage', 'procedureId'),
         })
@@ -899,6 +902,29 @@ const schema = a.schema({
             idx("parentProcedureId").sortKeys(["updatedAt"]),
             idx("category").sortKeys(["version"]).name("byCategory"),
             idx("status").sortKeys(["updatedAt"]).name("byStatus")
+        ]),
+
+    ProcedureScoreVersion: a
+        .model({
+            procedureId: a.string().required(),
+            procedure: a.belongsTo('Procedure', 'procedureId'),
+            scoreVersionId: a.string().required(),
+            scoreVersion: a.belongsTo('ScoreVersion', 'scoreVersionId'),
+            accountId: a.string().required(),
+            scorecardId: a.string(),
+            scoreId: a.string(),
+            relationshipTypes: a.string().array(),
+            createdAt: a.datetime().required(),
+            updatedAt: a.datetime().required(),
+        })
+        .authorization((allow) => [
+            allow.publicApiKey(),
+            allow.authenticated()
+        ])
+        .secondaryIndexes((idx: (field: ProcedureScoreVersionIndexFields) => any) => [
+            idx("procedureId").sortKeys(["updatedAt"]),
+            idx("scoreVersionId").sortKeys(["updatedAt"]),
+            idx("scoreId").sortKeys(["updatedAt"])
         ]),
 
     ChatSession: a

--- a/dashboard/components/ui/__tests__/score-evaluation-list.test.tsx
+++ b/dashboard/components/ui/__tests__/score-evaluation-list.test.tsx
@@ -50,13 +50,37 @@ describe('ScoreEvaluationList', () => {
     jest.clearAllMocks()
     for (const key of Object.keys(subscriptionHandlers)) delete subscriptionHandlers[key]
 
-    mockGraphql.mockImplementation(({ query }: { query: string }) => {
+    mockGraphql.mockImplementation(({ query }: { query: string; variables?: Record<string, any> }) => {
       const text = String(query)
       if (text.includes('onCreateEvaluation')) return subscriptionResult('createEvaluation')
       if (text.includes('onUpdateEvaluation')) return subscriptionResult('updateEvaluation')
       if (text.includes('onDeleteEvaluation')) return subscriptionResult('deleteEvaluation')
       if (text.includes('onUpdateTaskStage')) return subscriptionResult('updateTaskStage')
       if (text.includes('onUpdateTask')) return subscriptionResult('updateTask')
+
+      if (text.includes('listEvaluationByScoreVersionIdAndCreatedAt')) {
+        return Promise.resolve({
+          data: {
+            listEvaluationByScoreVersionIdAndCreatedAt: {
+              items: [
+                {
+                  id: 'eval-version-2',
+                  type: 'accuracy',
+                  status: 'FAILED',
+                  updatedAt: '2026-04-24T00:00:00Z',
+                  createdAt: '2026-04-24T00:00:00Z',
+                  scoreId: 'score-1',
+                  scoreVersionId: 'version-2',
+                  parameters: JSON.stringify({ notes: 'Version evaluation note' }),
+                  accuracy: 75.0,
+                  cost: 0.2,
+                  metrics: JSON.stringify({ alignment: 0.51, precision: 0.91, recall: 0.62 }),
+                },
+              ],
+            },
+          },
+        })
+      }
 
       return Promise.resolve({
       data: {
@@ -68,6 +92,7 @@ describe('ScoreEvaluationList', () => {
               status: 'COMPLETED',
               updatedAt: '2026-04-25T00:00:00Z',
               createdAt: '2026-04-25T00:00:00Z',
+              scoreId: 'score-1',
               scoreVersionId: 'version-1',
               parameters: JSON.stringify({ notes: 'Evaluation note 1' }),
               accuracy: 92.5,
@@ -86,6 +111,7 @@ describe('ScoreEvaluationList', () => {
               status: 'FAILED',
               updatedAt: '2026-04-24T00:00:00Z',
               createdAt: '2026-04-24T00:00:00Z',
+              scoreId: 'score-1',
               scoreVersionId: 'version-2',
               parameters: JSON.stringify({ notes: 'Evaluation note 2' }),
               accuracy: 75.0,
@@ -98,6 +124,7 @@ describe('ScoreEvaluationList', () => {
               status: 'COMPLETED',
               updatedAt: '2026-04-23T00:00:00Z',
               createdAt: '2026-04-23T00:00:00Z',
+              scoreId: 'score-1',
               scoreVersionId: 'version-3',
               parameters: JSON.stringify({ notes: 'Evaluation note 3' }),
               accuracy: 80.0,
@@ -127,14 +154,25 @@ describe('ScoreEvaluationList', () => {
     expect(screen.getByRole('menuitem', { name: /copy evaluation id/i })).toBeInTheDocument()
   })
 
-  it('filters version-scoped evaluations to the selected version', async () => {
+  it('loads version-scoped evaluations through the scoreVersionId index', async () => {
     render(<ScoreEvaluationList scoreId="score-1" scope="version" versionId="version-2" />)
 
     await waitFor(() => {
-      expect(screen.getByText('eval-2')).toBeInTheDocument()
+      expect(screen.getByText('eval-version-2')).toBeInTheDocument()
     })
 
     expect(screen.queryByText('eval-1')).not.toBeInTheDocument()
+    expect(mockGraphql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining('listEvaluationByScoreVersionIdAndCreatedAt'),
+        variables: expect.objectContaining({ scoreVersionId: 'version-2' }),
+      })
+    )
+    expect(
+      mockGraphql.mock.calls.some(([call]) =>
+        String(call.query).includes('listEvaluationByScoreIdAndUpdatedAt')
+      )
+    ).toBe(false)
   })
 
   it('sorts by precision, recall, and cost with missing values after present values', async () => {

--- a/dashboard/components/ui/__tests__/score-procedure-list.test.tsx
+++ b/dashboard/components/ui/__tests__/score-procedure-list.test.tsx
@@ -59,7 +59,10 @@ describe('ScoreProcedureList', () => {
     jest.clearAllMocks()
     for (const key of Object.keys(subscriptionHandlers)) delete subscriptionHandlers[key]
 
-    mockGraphql.mockImplementation(({ query }: { query: string }) => {
+    mockGraphql.mockImplementation(({ query }: { query: string; variables?: Record<string, any> }) => {
+      if (query.includes('onCreateProcedureScoreVersion')) return subscriptionResult('createProcedureScoreVersion')
+      if (query.includes('onUpdateProcedureScoreVersion')) return subscriptionResult('updateProcedureScoreVersion')
+      if (query.includes('onDeleteProcedureScoreVersion')) return subscriptionResult('deleteProcedureScoreVersion')
       if (query.includes('onCreateProcedure')) return subscriptionResult('createProcedure')
       if (query.includes('onUpdateProcedure')) return subscriptionResult('updateProcedure')
       if (query.includes('onDeleteProcedure')) return subscriptionResult('deleteProcedure')
@@ -136,6 +139,30 @@ describe('ScoreProcedureList', () => {
                         statusMessage: 'Saved optimizer result',
                       },
                     ],
+                  },
+                },
+              ],
+            },
+          },
+        }
+      }
+      if (query.includes('listProcedureScoreVersionByScoreVersionIdAndUpdatedAt')) {
+        return {
+          data: {
+            listProcedureScoreVersionByScoreVersionIdAndUpdatedAt: {
+              items: [
+                {
+                  id: 'link-proc-version',
+                  procedure: {
+                    id: 'proc-version',
+                    name: 'Version Associated Run',
+                    description: 'Direct version procedure',
+                    status: 'COMPLETED',
+                    metadata: null,
+                    updatedAt: '2026-04-26T00:00:00Z',
+                    scoreId: 'score-1',
+                    scoreVersionId: null,
+                    accountId: 'account-1',
                   },
                 },
               ],
@@ -272,7 +299,7 @@ describe('ScoreProcedureList', () => {
     )
   })
 
-  it('filters version-scoped procedures to runs that touched the selected version', async () => {
+  it('loads version-scoped procedures through the procedure-score-version index', async () => {
     render(
       <ScoreProcedureList
         scoreId="score-1"
@@ -285,10 +312,22 @@ describe('ScoreProcedureList', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Optimizer Run 1')).toBeInTheDocument()
+      expect(screen.getByText('Version Associated Run')).toBeInTheDocument()
     })
 
+    expect(screen.queryByText('Optimizer Run 1')).not.toBeInTheDocument()
     expect(screen.queryByText('Other Run')).not.toBeInTheDocument()
+    expect(mockGraphql).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining('listProcedureScoreVersionByScoreVersionIdAndUpdatedAt'),
+        variables: expect.objectContaining({ scoreVersionId: 'version-2' }),
+      })
+    )
+    expect(
+      mockGraphql.mock.calls.some(([call]) =>
+        String(call.query).includes('listProcedureByScoreIdAndUpdatedAt')
+      )
+    ).toBe(false)
   })
 
   it('inserts live matching procedures and updates task/stage state', async () => {

--- a/dashboard/components/ui/optimizer-results-utils.ts
+++ b/dashboard/components/ui/optimizer-results-utils.ts
@@ -83,6 +83,7 @@ export const EVALUATION_CARD_FIELDS = `
   updatedAt
   createdAt
   parameters
+  scoreId
   scoreVersionId
   accuracy
   processedItems
@@ -152,6 +153,40 @@ export const PROCEDURE_DELETE_SUBSCRIPTION_FOR_CARDS = `
       scoreId
       scoreVersionId
       accountId
+    }
+  }
+`
+
+export const PROCEDURE_SCORE_VERSION_CREATE_SUBSCRIPTION_FOR_CARDS = `
+  subscription OnCreateProcedureScoreVersionForCards {
+    onCreateProcedureScoreVersion {
+      id
+      scoreVersionId
+      procedure {
+        ${PROCEDURE_CARD_FIELDS}
+      }
+    }
+  }
+`
+
+export const PROCEDURE_SCORE_VERSION_UPDATE_SUBSCRIPTION_FOR_CARDS = `
+  subscription OnUpdateProcedureScoreVersionForCards {
+    onUpdateProcedureScoreVersion {
+      id
+      scoreVersionId
+      procedure {
+        ${PROCEDURE_CARD_FIELDS}
+      }
+    }
+  }
+`
+
+export const PROCEDURE_SCORE_VERSION_DELETE_SUBSCRIPTION_FOR_CARDS = `
+  subscription OnDeleteProcedureScoreVersionForCards {
+    onDeleteProcedureScoreVersion {
+      id
+      procedureId
+      scoreVersionId
     }
   }
 `
@@ -1052,7 +1087,7 @@ export async function refreshOptimizerRunManifest(run: OptimizerRunView): Promis
   }
 }
 
-export async function loadOptimizerRuns(scoreId: string, pageSize: number = 100): Promise<OptimizerRunView[]> {
+async function loadProcedureRecordsByScoreId(scoreId: string, pageSize: number): Promise<ProcedureRecord[]> {
   const client = getAmplifyClient()
   const procedures: ProcedureRecord[] = []
   let nextToken: string | null | undefined = null
@@ -1092,6 +1127,61 @@ export async function loadOptimizerRuns(scoreId: string, pageSize: number = 100)
     nextToken = page?.nextToken ?? null
   } while (nextToken)
 
+  return procedures
+}
+
+async function loadProcedureRecordsByScoreVersionId(
+  scoreVersionId: string,
+  pageSize: number
+): Promise<ProcedureRecord[]> {
+  const client = getAmplifyClient()
+  const procedures: ProcedureRecord[] = []
+  let nextToken: string | null | undefined = null
+
+  do {
+    const procedureResponse = await client.graphql({
+      query: `
+        query ListProcedureScoreVersionByScoreVersionIdAndUpdatedAtWorkbench(
+          $scoreVersionId: String!
+          $sortDirection: ModelSortDirection
+          $limit: Int
+          $nextToken: String
+        ) {
+          listProcedureScoreVersionByScoreVersionIdAndUpdatedAt(
+            scoreVersionId: $scoreVersionId
+            sortDirection: $sortDirection
+            limit: $limit
+            nextToken: $nextToken
+          ) {
+            items {
+              procedure {
+                ${PROCEDURE_CARD_FIELDS}
+              }
+            }
+            nextToken
+          }
+        }
+      `,
+      variables: {
+        scoreVersionId,
+        sortDirection: 'DESC',
+        limit: pageSize,
+        nextToken,
+      },
+    }) as any
+
+    const page = procedureResponse.data?.listProcedureScoreVersionByScoreVersionIdAndUpdatedAt
+    procedures.push(...(page?.items ?? []).map((item: any) => item?.procedure).filter(Boolean))
+    nextToken = page?.nextToken ?? null
+  } while (nextToken)
+
+  return procedures
+}
+
+async function procedureRecordsToOptimizerRunViews(
+  procedures: ProcedureRecord[]
+): Promise<OptimizerRunView[]> {
+  const client = getAmplifyClient()
   const accountIds = [...new Set(procedures.map((procedure) => procedure.accountId).filter(Boolean))]
   const taskResponses = await Promise.all(
     accountIds.map((accountId) =>
@@ -1137,6 +1227,19 @@ export async function loadOptimizerRuns(scoreId: string, pageSize: number = 100)
       return procedureToOptimizerRunView(procedure, task)
     })
   )
+}
+
+export async function loadOptimizerRuns(scoreId: string, pageSize: number = 100): Promise<OptimizerRunView[]> {
+  const procedures = await loadProcedureRecordsByScoreId(scoreId, pageSize)
+  return procedureRecordsToOptimizerRunViews(procedures)
+}
+
+export async function loadScoreVersionOptimizerRuns(
+  scoreVersionId: string,
+  pageSize: number = 100
+): Promise<OptimizerRunView[]> {
+  const procedures = await loadProcedureRecordsByScoreVersionId(scoreVersionId, pageSize)
+  return procedureRecordsToOptimizerRunViews(procedures)
 }
 
 export function evaluationToScoreEvaluationView(item: any): ScoreEvaluationView {
@@ -1195,5 +1298,38 @@ export async function loadScoreEvaluations(scoreId: string, limit: number = 100)
   }) as any
 
   const items = response.data?.listEvaluationByScoreIdAndUpdatedAt?.items ?? []
+  return items.map(evaluationToScoreEvaluationView)
+}
+
+export async function loadScoreVersionEvaluations(
+  scoreVersionId: string,
+  limit: number = 100
+): Promise<ScoreEvaluationView[]> {
+  const response = await getAmplifyClient().graphql({
+    query: `
+      query ListEvaluationByScoreVersionIdAndCreatedAtForWorkbench(
+        $scoreVersionId: String!
+        $sortDirection: ModelSortDirection!
+        $limit: Int
+      ) {
+        listEvaluationByScoreVersionIdAndCreatedAt(
+          scoreVersionId: $scoreVersionId
+          sortDirection: $sortDirection
+          limit: $limit
+        ) {
+          items {
+            ${EVALUATION_CARD_FIELDS}
+          }
+        }
+      }
+    `,
+    variables: {
+      scoreVersionId,
+      sortDirection: 'DESC',
+      limit,
+    },
+  }) as any
+
+  const items = response.data?.listEvaluationByScoreVersionIdAndCreatedAt?.items ?? []
   return items.map(evaluationToScoreEvaluationView)
 }

--- a/dashboard/components/ui/score-evaluation-list.tsx
+++ b/dashboard/components/ui/score-evaluation-list.tsx
@@ -16,6 +16,7 @@ import {
   EVALUATION_UPDATE_SUBSCRIPTION_FOR_CARDS,
   evaluationToScoreEvaluationView,
   loadScoreEvaluations,
+  loadScoreVersionEvaluations,
   mergeTaskIntoEvaluation,
   mergeTaskStageIntoEvaluation,
   taskMatchesEvaluation,
@@ -226,7 +227,10 @@ export function ScoreEvaluationList({
       setEvaluations([])
       setIsLoading(true)
       try {
-        const loadedEvaluations = await loadScoreEvaluations(scoreId)
+        const loadedEvaluations =
+          scope === 'version' && versionId
+            ? await loadScoreVersionEvaluations(versionId)
+            : await loadScoreEvaluations(scoreId)
         if (!cancelled) {
           setEvaluations(loadedEvaluations)
         }
@@ -246,7 +250,7 @@ export function ScoreEvaluationList({
     return () => {
       cancelled = true
     }
-  }, [scoreId])
+  }, [scoreId, scope, versionId])
 
   React.useEffect(() => {
     if (!scoreId) return
@@ -270,7 +274,11 @@ export function ScoreEvaluationList({
 
     const upsertEvaluation = (rawEvaluation: any) => {
       if (!rawEvaluation?.id) return
-      if (rawEvaluation.scoreId && rawEvaluation.scoreId !== scoreId) return
+      if (scope === 'version') {
+        if (rawEvaluation.scoreVersionId !== versionId) return
+      } else if (rawEvaluation.scoreId !== scoreId) {
+        return
+      }
       const nextEvaluation = evaluationToScoreEvaluationView(rawEvaluation)
       setEvaluations((previous) => {
         const existingIndex = previous.findIndex((evaluation) => evaluation.id === nextEvaluation.id)
@@ -300,7 +308,11 @@ export function ScoreEvaluationList({
       (data) => {
         const deleted = data?.onDeleteEvaluation
         if (!deleted?.id) return
-        if (deleted.scoreId && deleted.scoreId !== scoreId) return
+        if (scope === 'version') {
+          if (deleted.scoreVersionId !== versionId) return
+        } else if (deleted.scoreId !== scoreId) {
+          return
+        }
         setEvaluations((previous) => previous.filter((evaluation) => evaluation.id !== deleted.id))
       },
       'delete evaluation'
@@ -363,7 +375,7 @@ export function ScoreEvaluationList({
         }
       })
     }
-  }, [scoreId])
+  }, [scope, scoreId, versionId])
 
   const applyControlChange = React.useCallback((apply: () => void) => {
     if (controlLoadingTimeoutRef.current) {
@@ -378,19 +390,14 @@ export function ScoreEvaluationList({
   }, [])
 
   const visibleEvaluations = React.useMemo(() => {
-    const filteredByScope =
-      scope === 'version' && versionId
-        ? evaluations.filter((evaluation) => evaluation.scoreVersionId === versionId)
-        : evaluations
-
-    const filtered = filteredByScope.filter((evaluation) => {
+    const filtered = evaluations.filter((evaluation) => {
       if (statusFilter !== 'all' && (evaluation.status ?? 'unknown') !== statusFilter) return false
       if (typeFilter !== 'all' && (evaluation.type ?? 'unknown') !== typeFilter) return false
       return true
     })
 
     return sortEvaluations(filtered, sortBy)
-  }, [evaluations, scope, sortBy, statusFilter, typeFilter, versionId])
+  }, [evaluations, sortBy, statusFilter, typeFilter])
 
   const statuses = React.useMemo(
     () => ['all', ...new Set(evaluations.map((evaluation) => evaluation.status ?? 'unknown'))],

--- a/dashboard/components/ui/score-procedure-list.tsx
+++ b/dashboard/components/ui/score-procedure-list.tsx
@@ -34,10 +34,10 @@ import {
   hydrateProcedureRunFeedbackEvaluation,
   hydrateProcedureRunsFeedbackEvaluations,
   loadOptimizerRuns,
+  loadScoreVersionOptimizerRuns,
   mergeFeedbackEvaluationIntoProcedureRun,
   mergeTaskIntoProcedureRun,
   mergeTaskStageIntoProcedureRun,
-  manifestTouchesVersion,
   OPTIMIZER_DATASETS,
   OPTIMIZER_METRICS,
   optimizerDatasetLabel,
@@ -49,6 +49,9 @@ import {
   procedureToOptimizerRunView,
   PROCEDURE_CREATE_SUBSCRIPTION_FOR_CARDS,
   PROCEDURE_DELETE_SUBSCRIPTION_FOR_CARDS,
+  PROCEDURE_SCORE_VERSION_CREATE_SUBSCRIPTION_FOR_CARDS,
+  PROCEDURE_SCORE_VERSION_DELETE_SUBSCRIPTION_FOR_CARDS,
+  PROCEDURE_SCORE_VERSION_UPDATE_SUBSCRIPTION_FOR_CARDS,
   PROCEDURE_UPDATE_SUBSCRIPTION_FOR_CARDS,
   refreshOptimizerRunManifest,
   scorecardGuideRelativePath,
@@ -258,7 +261,10 @@ export function ScoreProcedureList({
       setRuns([])
       setIsLoading(true)
       try {
-        const loadedRuns = await loadOptimizerRuns(scoreId)
+        const loadedRuns =
+          scope === 'version' && versionId
+            ? await loadScoreVersionOptimizerRuns(versionId)
+            : await loadOptimizerRuns(scoreId)
         const hydratedRuns = await hydrateProcedureRunsFeedbackEvaluations(loadedRuns)
         if (!cancelled) {
           setRuns(hydratedRuns)
@@ -279,7 +285,7 @@ export function ScoreProcedureList({
     return () => {
       cancelled = true
     }
-  }, [scoreId])
+  }, [scoreId, scope, versionId])
 
   const scheduleManifestRefresh = React.useCallback((procedureId: string) => {
     const existingTimer = manifestRefreshTimersRef.current.get(procedureId)
@@ -323,7 +329,11 @@ export function ScoreProcedureList({
 
     const upsertProcedure = (rawProcedure: any) => {
       if (!rawProcedure?.id) return
-      if (rawProcedure.scoreId && rawProcedure.scoreId !== scoreId) return
+      if (scope === 'version') {
+        if (rawProcedure.scoreVersionId !== versionId) return
+      } else if (rawProcedure.scoreId !== scoreId) {
+        return
+      }
       void procedureToOptimizerRunView(rawProcedure, null).then((nextRun) => {
         setRuns((previous) => {
           const existingIndex = previous.findIndex((run) => run.procedureId === nextRun.procedureId)
@@ -356,17 +366,51 @@ export function ScoreProcedureList({
       (data) => {
         const deleted = data?.onDeleteProcedure
         if (!deleted?.id) return
-        if (deleted.scoreId && deleted.scoreId !== scoreId) return
+        if (scope === 'version') {
+          if (deleted.scoreVersionId !== versionId) return
+        } else if (deleted.scoreId !== scoreId) {
+          return
+        }
         setRuns((previous) => previous.filter((run) => run.procedureId !== deleted.id))
       },
       'delete procedure'
     )
+    if (scope === 'version') {
+      const upsertProcedureLink = (rawLink: any) => {
+        if (rawLink?.scoreVersionId !== versionId) return
+        upsertProcedure(rawLink.procedure)
+      }
+
+      subscribe(
+        PROCEDURE_SCORE_VERSION_CREATE_SUBSCRIPTION_FOR_CARDS,
+        (data) => upsertProcedureLink(data?.onCreateProcedureScoreVersion),
+        'create procedure score version'
+      )
+      subscribe(
+        PROCEDURE_SCORE_VERSION_UPDATE_SUBSCRIPTION_FOR_CARDS,
+        (data) => upsertProcedureLink(data?.onUpdateProcedureScoreVersion),
+        'update procedure score version'
+      )
+      subscribe(
+        PROCEDURE_SCORE_VERSION_DELETE_SUBSCRIPTION_FOR_CARDS,
+        (data) => {
+          const deleted = data?.onDeleteProcedureScoreVersion
+          if (deleted?.scoreVersionId !== versionId || !deleted?.procedureId) return
+          setRuns((previous) => previous.filter((run) => run.procedureId !== deleted.procedureId))
+        },
+        'delete procedure score version'
+      )
+    }
     subscribe(
       EVALUATION_CREATE_SUBSCRIPTION_FOR_CARDS,
       (data) => {
         const rawEvaluation = data?.onCreateEvaluation
         if (!rawEvaluation?.id) return
-        if (rawEvaluation.scoreId && rawEvaluation.scoreId !== scoreId) return
+        if (scope === 'version') {
+          if (rawEvaluation.scoreVersionId !== versionId) return
+        } else if (rawEvaluation.scoreId !== scoreId) {
+          return
+        }
         const evaluation = evaluationToScoreEvaluationView(rawEvaluation)
         setRuns((previous) => previous.map((run) => mergeFeedbackEvaluationIntoProcedureRun(run, evaluation)))
       },
@@ -377,7 +421,11 @@ export function ScoreProcedureList({
       (data) => {
         const rawEvaluation = data?.onUpdateEvaluation
         if (!rawEvaluation?.id) return
-        if (rawEvaluation.scoreId && rawEvaluation.scoreId !== scoreId) return
+        if (scope === 'version') {
+          if (rawEvaluation.scoreVersionId !== versionId) return
+        } else if (rawEvaluation.scoreId !== scoreId) {
+          return
+        }
         const evaluation = evaluationToScoreEvaluationView(rawEvaluation)
         setRuns((previous) => previous.map((run) => mergeFeedbackEvaluationIntoProcedureRun(run, evaluation)))
       },
@@ -388,7 +436,11 @@ export function ScoreProcedureList({
       (data) => {
         const deleted = data?.onDeleteEvaluation
         if (!deleted?.id) return
-        if (deleted.scoreId && deleted.scoreId !== scoreId) return
+        if (scope === 'version') {
+          if (deleted.scoreVersionId !== versionId) return
+        } else if (deleted.scoreId !== scoreId) {
+          return
+        }
         setRuns((previous) =>
           previous.map((run) =>
             currentProcedureFeedbackEvaluationId(run.manifest) === deleted.id
@@ -473,7 +525,7 @@ export function ScoreProcedureList({
         }
       })
     }
-  }, [scheduleManifestRefresh, scoreId])
+  }, [scheduleManifestRefresh, scope, scoreId, versionId])
 
   const applySort = React.useCallback((nextSort: ProcedureSort) => {
     setIsApplyingControls(true)
@@ -484,22 +536,14 @@ export function ScoreProcedureList({
   }, [])
 
   const visibleRuns = React.useMemo(() => {
-    const filtered = scope === 'version' && versionId
-      ? runs.filter((run) => {
-          if (manifestTouchesVersion(run.manifest, versionId)) return true
-          if (run.scoreVersionId === versionId) return true
-          if (run.metadataText?.includes(versionId)) return true
-          return false
-        })
-      : runs
-    return sortProcedureRuns(filtered, sortBy)
-  }, [runs, scope, sortBy, versionId])
+    return sortProcedureRuns(runs, sortBy)
+  }, [runs, sortBy])
 
   const title = scope === 'score' ? 'Procedures' : 'Version Procedures'
   const description =
     scope === 'score'
       ? 'All procedures for this score, newest first by default.'
-      : 'Procedures that touched the selected version.'
+      : 'Procedures associated with the selected version.'
   const usesSlotSurface = surface === 'slot'
   const shouldShowListSkeleton = isLoading || isApplyingControls
 

--- a/plexus/cli/shared/optimizer_results.py
+++ b/plexus/cli/shared/optimizer_results.py
@@ -136,6 +136,39 @@ def _sort_by_updated_at_desc(items: Iterable[Dict[str, Any]]) -> List[Dict[str, 
     )
 
 
+def _optimizer_manifest_score_version_links(manifest: Dict[str, Any]) -> Dict[str, List[str]]:
+    links: Dict[str, List[str]] = {}
+
+    def add(version_id: Any, relationship_type: str) -> None:
+        if not isinstance(version_id, str) or not version_id:
+            return
+        relationship_types = links.setdefault(version_id, [])
+        if relationship_type not in relationship_types:
+            relationship_types.append(relationship_type)
+
+    baseline = manifest.get("baseline") or {}
+    if isinstance(baseline, dict):
+        add(baseline.get("version_id"), "baseline")
+
+    best = manifest.get("best") or {}
+    if isinstance(best, dict):
+        add(best.get("winning_version_id"), "winning")
+        add(best.get("last_accepted_version_id"), "accepted")
+
+    for cycle in manifest.get("cycles") or []:
+        if not isinstance(cycle, dict):
+            continue
+        add(cycle.get("version_id"), "cycle")
+        for candidate in cycle.get("candidates") or []:
+            if isinstance(candidate, dict):
+                add(candidate.get("version_id"), "candidate")
+        for candidate in cycle.get("no_version_candidates") or []:
+            if isinstance(candidate, dict):
+                add(candidate.get("version_id"), "no_version_candidate")
+
+    return links
+
+
 def _evaluation_url(evaluation_id: Optional[str]) -> Optional[str]:
     return f"{LAB_EVALUATION_BASE_URL}/{evaluation_id}" if evaluation_id else None
 
@@ -614,6 +647,115 @@ class OptimizerResultsService:
             "runtime_log": f"tasks/{task_id}/{OPTIMIZER_RUNTIME_LOG_SUFFIX}",
         }
 
+    def _list_score_version_links_for_procedure(self, procedure_id: str) -> List[Dict[str, Any]]:
+        query = """
+        query ListProcedureScoreVersionByProcedureIdAndUpdatedAtForOptimizer(
+            $procedureId: String!
+            $limit: Int
+            $nextToken: String
+        ) {
+            listProcedureScoreVersionByProcedureIdAndUpdatedAt(
+                procedureId: $procedureId
+                sortDirection: DESC
+                limit: $limit
+                nextToken: $nextToken
+            ) {
+                items {
+                    id
+                    procedureId
+                    scoreVersionId
+                }
+                nextToken
+            }
+        }
+        """
+        links: List[Dict[str, Any]] = []
+        next_token: Optional[str] = None
+        while True:
+            variables: Dict[str, Any] = {"procedureId": procedure_id, "limit": 100}
+            if next_token:
+                variables["nextToken"] = next_token
+            result = self.client.execute(query, variables)
+            payload = result.get("listProcedureScoreVersionByProcedureIdAndUpdatedAt", {})
+            links.extend(item for item in payload.get("items") or [] if isinstance(item, dict))
+            next_token = payload.get("nextToken")
+            if not next_token:
+                break
+        return links
+
+    def _sync_optimizer_score_version_links(
+        self,
+        *,
+        procedure: Dict[str, Any],
+        manifest: Dict[str, Any],
+    ) -> None:
+        procedure_id = str(procedure.get("id") or "")
+        account_id = str(procedure.get("accountId") or "")
+        if not procedure_id or not account_id:
+            return
+
+        now = _utc_now_iso()
+        desired = _optimizer_manifest_score_version_links(manifest)
+        existing = self._list_score_version_links_for_procedure(procedure_id)
+        existing_by_version = {
+            item.get("scoreVersionId"): item
+            for item in existing
+            if isinstance(item.get("scoreVersionId"), str)
+        }
+
+        create_mutation = """
+        mutation CreateProcedureScoreVersionForOptimizer($input: CreateProcedureScoreVersionInput!) {
+            createProcedureScoreVersion(input: $input) {
+                id
+            }
+        }
+        """
+        update_mutation = """
+        mutation UpdateProcedureScoreVersionForOptimizer($input: UpdateProcedureScoreVersionInput!) {
+            updateProcedureScoreVersion(input: $input) {
+                id
+            }
+        }
+        """
+        delete_mutation = """
+        mutation DeleteProcedureScoreVersionForOptimizer($input: DeleteProcedureScoreVersionInput!) {
+            deleteProcedureScoreVersion(input: $input) {
+                id
+            }
+        }
+        """
+
+        for version_id, relationship_types in desired.items():
+            existing_item = existing_by_version.get(version_id)
+            input_data = {
+                "procedureId": procedure_id,
+                "scoreVersionId": version_id,
+                "accountId": account_id,
+                "scorecardId": procedure.get("scorecardId"),
+                "scoreId": procedure.get("scoreId"),
+                "relationshipTypes": relationship_types,
+                "updatedAt": now,
+            }
+            if existing_item:
+                self.client.execute(
+                    update_mutation,
+                    {"input": {"id": existing_item["id"], **input_data}},
+                )
+            else:
+                link_id = f"{procedure_id}:{version_id}"
+                self.client.execute(
+                    create_mutation,
+                    {"input": {"id": link_id, "createdAt": now, **input_data}},
+                )
+
+        desired_versions = set(desired.keys())
+        for existing_item in existing:
+            version_id = existing_item.get("scoreVersionId")
+            link_id = existing_item.get("id")
+            if version_id in desired_versions or not link_id:
+                continue
+            self.client.execute(delete_mutation, {"input": {"id": link_id}})
+
     def index_optimizer_run(
         self,
         procedure_id: str,
@@ -644,6 +786,7 @@ class OptimizerResultsService:
             raise RuntimeError("aws.storage.task_attachments_bucket is required for optimizer artifacts.")
 
         manifest = self.build_manifest(procedure=procedure, task=task, state=state)
+        self._sync_optimizer_score_version_links(procedure=procedure, manifest=manifest)
         artifact_keys = self._artifact_keys_for_task(task.id)
         upload_task_attachment_bytes(
             bucket_name=bucket_name,

--- a/plexus/cli/shared/optimizer_results_test.py
+++ b/plexus/cli/shared/optimizer_results_test.py
@@ -10,8 +10,22 @@ from plexus.cli.shared.optimizer_results import (
 class _FakeClient:
     def __init__(self):
         self.update_calls = []
+        self.link_creates = []
+        self.link_updates = []
+        self.link_deletes = []
 
     def execute(self, query, variables):
+        if "listProcedureScoreVersionByProcedureIdAndUpdatedAt" in query:
+            return {"listProcedureScoreVersionByProcedureIdAndUpdatedAt": {"items": [], "nextToken": None}}
+        if "createProcedureScoreVersion" in query:
+            self.link_creates.append({"query": query, "variables": variables})
+            return {"createProcedureScoreVersion": {"id": variables["input"]["id"]}}
+        if "updateProcedureScoreVersion" in query:
+            self.link_updates.append({"query": query, "variables": variables})
+            return {"updateProcedureScoreVersion": {"id": variables["input"]["id"]}}
+        if "deleteProcedureScoreVersion" in query:
+            self.link_deletes.append({"query": query, "variables": variables})
+            return {"deleteProcedureScoreVersion": {"id": variables["input"]["id"]}}
         if "updateProcedure(input:" in query:
             self.update_calls.append({"query": query, "variables": variables})
             return {"updateProcedure": {"id": variables["input"]["id"], "metadata": variables["input"]["metadata"]}}
@@ -158,6 +172,14 @@ def test_index_optimizer_run_persists_manifest_and_pointer(monkeypatch):
     pointer = saved_metadata[OPTIMIZER_ARTIFACTS_METADATA_KEY]
     assert pointer["task_id"] == "task-123"
     assert pointer["manifest"] == "tasks/task-123/optimizer/manifest.json"
+    linked_versions = {
+        call["variables"]["input"]["scoreVersionId"]: call["variables"]["input"]["relationshipTypes"]
+        for call in client.link_creates
+    }
+    assert linked_versions["version-baseline"] == ["baseline"]
+    assert linked_versions["version-accepted"] == ["winning", "accepted", "cycle"]
+    assert linked_versions["version-1"] == ["cycle"]
+    assert linked_versions["version-candidate"] == ["candidate"]
 
 
 def test_list_optimizer_candidates_for_score_aggregates_best_visible_metrics(monkeypatch):

--- a/project/events/2026-05-01T21:43:19.086Z__df09b854-1b79-4418-addb-a898de42c925.json
+++ b/project/events/2026-05-01T21:43:19.086Z__df09b854-1b79-4418-addb-a898de42c925.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "df09b854-1b79-4418-addb-a898de42c925",
+  "issue_id": "plx-2668dcc4-0205-4a04-ac81-5a458c7c9389",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-01T21:43:19.086Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Fix the Scorecards dashboard score-version detail tabs so Procedures and Evaluations show the records associated with the selected score version using first-class keyed access, not scans or slow client-side filtering.\n\nDefinition of Done:\n- Procedures tab shows procedures associated with the selected score version.\n- Evaluations tab shows evaluations associated with the selected score version.\n- Data access uses the intended indexed association/query path.\n- Regression coverage proves the score-version scoping behavior.",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": "plx-b13120eb-5b86-4098-94e6-422ffc0412a3",
+    "priority": 1,
+    "status": "open",
+    "title": "Score version activity tabs use direct associations"
+  }
+}

--- a/project/events/2026-05-01T21:43:26.692Z__1243e011-6fce-4ac9-8582-b58ef5ec44ed.json
+++ b/project/events/2026-05-01T21:43:26.692Z__1243e011-6fce-4ac9-8582-b58ef5ec44ed.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "1243e011-6fce-4ac9-8582-b58ef5ec44ed",
+  "issue_id": "plx-e4c251bd-19ee-4682-9b89-b65280355b2d",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-01T21:43:26.692Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "As a scorecard operator, I want the score-version detail Procedures and Evaluations tabs to show records associated with the selected score version, so that I can audit optimization and evaluation history for that exact version without waiting on broad scans.\n\nFeature: Score version activity tabs\n\nScenario: Procedures are scoped to the selected score version\nGiven a score has multiple versions\nAnd procedures exist for more than one score version\nWhen I open the Procedures tab for one score version\nThen I see only procedures associated with that score version\nAnd the query uses the direct indexed association for scoreVersionId.\n\nScenario: Evaluations are scoped to the selected score version\nGiven a score has multiple versions\nAnd evaluations exist for more than one score version\nWhen I open the Evaluations tab for one score version\nThen I see evaluations associated with that score version\nAnd the query uses the direct indexed association for scoreVersionId.",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-2668dcc4-0205-4a04-ac81-5a458c7c9389",
+    "priority": 1,
+    "status": "open",
+    "title": "Score-version activity tabs show version-scoped records"
+  }
+}

--- a/project/events/2026-05-01T21:43:26.692Z__94a12ef1-2065-4772-8edf-a3ae3abd313a.json
+++ b/project/events/2026-05-01T21:43:26.692Z__94a12ef1-2065-4772-8edf-a3ae3abd313a.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "94a12ef1-2065-4772-8edf-a3ae3abd313a",
+  "issue_id": "plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-01T21:43:26.692Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "The Scorecards dashboard score-version detail tabs do not reliably show version-associated activity. Evaluations are missing associated records, and procedures appear to work through a slow or incorrect query path. Investigate the schema/generated client hooks and update the dashboard to use the intended direct association or GSI-backed query path.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-2668dcc4-0205-4a04-ac81-5a458c7c9389",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix score-version procedure and evaluation queries"
+  }
+}

--- a/project/events/2026-05-01T21:43:30.634Z__4c3e9fbf-7945-44f4-b702-79e431cea5d7.json
+++ b/project/events/2026-05-01T21:43:30.634Z__4c3e9fbf-7945-44f4-b702-79e431cea5d7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4c3e9fbf-7945-44f4-b702-79e431cea5d7",
+  "issue_id": "plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-01T21:43:30.634Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-01T21:43:30.639Z__22a10998-5736-4327-bf9c-efdd7379aacd.json
+++ b/project/events/2026-05-01T21:43:30.639Z__22a10998-5736-4327-bf9c-efdd7379aacd.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "22a10998-5736-4327-bf9c-efdd7379aacd",
+  "issue_id": "plx-2668dcc4-0205-4a04-ac81-5a458c7c9389",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-01T21:43:30.639Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-01T21:43:30.643Z__3217b9c5-b39c-4b8d-8844-2430c66f0716.json
+++ b/project/events/2026-05-01T21:43:30.643Z__3217b9c5-b39c-4b8d-8844-2430c66f0716.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3217b9c5-b39c-4b8d-8844-2430c66f0716",
+  "issue_id": "plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-01T21:43:30.643Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e826ad18-4cfc-4b9e-a4cf-f05dc967e665"
+  }
+}

--- a/project/events/2026-05-01T21:47:51.806Z__8ddbaffb-9c82-43d2-b47a-44f7e3680822.json
+++ b/project/events/2026-05-01T21:47:51.806Z__8ddbaffb-9c82-43d2-b47a-44f7e3680822.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8ddbaffb-9c82-43d2-b47a-44f7e3680822",
+  "issue_id": "plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-01T21:47:51.806Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "d24fe8d0-2032-49ae-9d96-c78705d15b98"
+  }
+}

--- a/project/events/2026-05-01T21:59:37.490Z__acdfc7eb-803c-4d92-aa2c-6cd88399d11c.json
+++ b/project/events/2026-05-01T21:59:37.490Z__acdfc7eb-803c-4d92-aa2c-6cd88399d11c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "acdfc7eb-803c-4d92-aa2c-6cd88399d11c",
+  "issue_id": "plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-01T21:59:37.490Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "509e76dd-2e40-4d73-b123-9b2ce7a50d58"
+  }
+}

--- a/project/events/2026-05-01T22:01:02.916Z__7f2ecb38-db61-456b-b656-3fcb50295804.json
+++ b/project/events/2026-05-01T22:01:02.916Z__7f2ecb38-db61-456b-b656-3fcb50295804.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7f2ecb38-db61-456b-b656-3fcb50295804",
+  "issue_id": "plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-01T22:01:02.916Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e1fbe759-8d80-4f38-9b57-df0fb84c01e9"
+  }
+}

--- a/project/events/2026-05-01T22:01:54.713Z__72fc1e2f-85ed-4ac7-860d-e160cf0d3451.json
+++ b/project/events/2026-05-01T22:01:54.713Z__72fc1e2f-85ed-4ac7-860d-e160cf0d3451.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "72fc1e2f-85ed-4ac7-860d-e160cf0d3451",
+  "issue_id": "plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-01T22:01:54.713Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "67bd9e33-d6e1-41f5-a974-44ee0ae019e9"
+  }
+}

--- a/project/issues/plx-2668dcc4-0205-4a04-ac81-5a458c7c9389.json
+++ b/project/issues/plx-2668dcc4-0205-4a04-ac81-5a458c7c9389.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-2668dcc4-0205-4a04-ac81-5a458c7c9389",
+  "title": "Score version activity tabs use direct associations",
+  "description": "Fix the Scorecards dashboard score-version detail tabs so Procedures and Evaluations show the records associated with the selected score version using first-class keyed access, not scans or slow client-side filtering.\n\nDefinition of Done:\n- Procedures tab shows procedures associated with the selected score version.\n- Evaluations tab shows evaluations associated with the selected score version.\n- Data access uses the intended indexed association/query path.\n- Regression coverage proves the score-version scoping behavior.",
+  "type": "epic",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b13120eb-5b86-4098-94e6-422ffc0412a3",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-01T21:43:19.085275Z",
+  "updated_at": "2026-05-01T21:43:30.639237Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5.json
+++ b/project/issues/plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5.json
@@ -1,0 +1,49 @@
+{
+  "id": "plx-c6730fae-f3cc-40c0-9189-7476a5b4bcc5",
+  "title": "Fix score-version procedure and evaluation queries",
+  "description": "The Scorecards dashboard score-version detail tabs do not reliably show version-associated activity. Evaluations are missing associated records, and procedures appear to work through a slow or incorrect query path. Investigate the schema/generated client hooks and update the dashboard to use the intended direct association or GSI-backed query path.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2668dcc4-0205-4a04-ac81-5a458c7c9389",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "e826ad18-4cfc-4b9e-a4cf-f05dc967e665",
+      "author": "ryan",
+      "text": "Starting investigation. I will trace the Scorecards dashboard score-version tabs, generated data model/indexes, and existing hooks/tests before making changes.",
+      "created_at": "2026-05-01T21:43:30.643637Z"
+    },
+    {
+      "id": "d24fe8d0-2032-49ae-9d96-c78705d15b98",
+      "author": "ryan",
+      "text": "Updated local develop from origin and fast-forwarded the current branch onto develop. Implemented version-scope dashboard loaders using listEvaluationByScoreVersionIdAndCreatedAt and listProcedureByScoreVersionIdAndUpdatedAt, with focused Jest tests and dashboard typecheck passing.",
+      "created_at": "2026-05-01T21:47:51.806029Z"
+    },
+    {
+      "id": "509e76dd-2e40-4d73-b123-9b2ce7a50d58",
+      "author": "ryan",
+      "text": "Found root cause for empty Procedures tab: Procedure.scoreVersionId is a single FK and does not represent optimizer runs that touch multiple generated/candidate versions. The dashboard's direct GSI query is fast but returns no rows for versions that only appear in optimizer manifests. Next fix is a first-class ProcedureScoreVersion link model populated during optimizer indexing, queried directly by scoreVersionId.",
+      "created_at": "2026-05-01T21:59:37.489493Z"
+    },
+    {
+      "id": "e1fbe759-8d80-4f38-9b57-df0fb84c01e9",
+      "author": "ryan",
+      "text": "Implemented first-class optimizer procedure-to-score-version indexing. Added ProcedureScoreVersion model with scoreVersionId+updatedAt GSI, populated links during optimizer artifact indexing from baseline/winning/cycle/candidate versions, and changed the dashboard version Procedures tab to query the link table directly. Verification: focused dashboard Jest tests, optimizer_results pytest, and dashboard typecheck all pass.",
+      "created_at": "2026-05-01T22:01:02.915835Z"
+    },
+    {
+      "id": "67bd9e33-d6e1-41f5-a974-44ee0ae019e9",
+      "author": "ryan",
+      "text": "Added ProcedureScoreVersion create/update/delete subscriptions for the version Procedures tab so newly indexed links can appear live. Re-ran focused dashboard Jest tests, optimizer_results pytest, and dashboard typecheck successfully.",
+      "created_at": "2026-05-01T22:01:54.713112Z"
+    }
+  ],
+  "created_at": "2026-05-01T21:43:26.692109Z",
+  "updated_at": "2026-05-01T22:01:54.713112Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-e4c251bd-19ee-4682-9b89-b65280355b2d.json
+++ b/project/issues/plx-e4c251bd-19ee-4682-9b89-b65280355b2d.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-e4c251bd-19ee-4682-9b89-b65280355b2d",
+  "title": "Score-version activity tabs show version-scoped records",
+  "description": "As a scorecard operator, I want the score-version detail Procedures and Evaluations tabs to show records associated with the selected score version, so that I can audit optimization and evaluation history for that exact version without waiting on broad scans.\n\nFeature: Score version activity tabs\n\nScenario: Procedures are scoped to the selected score version\nGiven a score has multiple versions\nAnd procedures exist for more than one score version\nWhen I open the Procedures tab for one score version\nThen I see only procedures associated with that score version\nAnd the query uses the direct indexed association for scoreVersionId.\n\nScenario: Evaluations are scoped to the selected score version\nGiven a score has multiple versions\nAnd evaluations exist for more than one score version\nWhen I open the Evaluations tab for one score version\nThen I see evaluations associated with that score version\nAnd the query uses the direct indexed association for scoreVersionId.",
+  "type": "story",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2668dcc4-0205-4a04-ac81-5a458c7c9389",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-01T21:43:26.692081Z",
+  "updated_at": "2026-05-01T21:43:26.692081Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- add ProcedureScoreVersion link model and scoreVersionId/updatedAt index for score-version procedure tabs
- populate links during optimizer artifact indexing for baseline, accepted/winning, cycle, and candidate versions
- update Scorecards dashboard version tabs to query direct score-version indexes for procedures and evaluations

## Verification
- npm test -- --runTestsByPath components/ui/__tests__/score-procedure-list.test.tsx components/ui/__tests__/score-evaluation-list.test.tsx --runInBand
- pytest plexus/cli/shared/optimizer_results_test.py -q
- npm run typecheck

## Deployment note
The Procedures tab requires this backend schema/index to be deployed before the new query is available. Existing optimizer runs need re-index/backfill to create ProcedureScoreVersion rows.