### PR TITLE
Use procedure scoreVersionId GSI for version procedure list

### DIFF
--- a/dashboard/components/ui/__tests__/score-procedure-list.test.tsx
+++ b/dashboard/components/ui/__tests__/score-procedure-list.test.tsx
@@ -60,9 +60,6 @@ describe('ScoreProcedureList', () => {
     for (const key of Object.keys(subscriptionHandlers)) delete subscriptionHandlers[key]
 
     mockGraphql.mockImplementation(({ query }: { query: string; variables?: Record<string, any> }) => {
-      if (query.includes('onCreateProcedureScoreVersion')) return subscriptionResult('createProcedureScoreVersion')
-      if (query.includes('onUpdateProcedureScoreVersion')) return subscriptionResult('updateProcedureScoreVersion')
-      if (query.includes('onDeleteProcedureScoreVersion')) return subscriptionResult('deleteProcedureScoreVersion')
       if (query.includes('onCreateProcedure')) return subscriptionResult('createProcedure')
       if (query.includes('onUpdateProcedure')) return subscriptionResult('updateProcedure')
       if (query.includes('onDeleteProcedure')) return subscriptionResult('deleteProcedure')
@@ -146,24 +143,21 @@ describe('ScoreProcedureList', () => {
           },
         }
       }
-      if (query.includes('listProcedureScoreVersionByScoreVersionIdAndUpdatedAt')) {
+      if (query.includes('listProcedureByScoreVersionIdAndUpdatedAt')) {
         return {
           data: {
-            listProcedureScoreVersionByScoreVersionIdAndUpdatedAt: {
+            listProcedureByScoreVersionIdAndUpdatedAt: {
               items: [
                 {
-                  id: 'link-proc-version',
-                  procedure: {
-                    id: 'proc-version',
-                    name: 'Version Associated Run',
-                    description: 'Direct version procedure',
-                    status: 'COMPLETED',
-                    metadata: null,
-                    updatedAt: '2026-04-26T00:00:00Z',
-                    scoreId: 'score-1',
-                    scoreVersionId: null,
-                    accountId: 'account-1',
-                  },
+                  id: 'proc-version',
+                  name: 'Version Associated Run',
+                  description: 'Direct version procedure',
+                  status: 'COMPLETED',
+                  metadata: null,
+                  updatedAt: '2026-04-26T00:00:00Z',
+                  scoreId: 'score-1',
+                  scoreVersionId: 'version-2',
+                  accountId: 'account-1',
                 },
               ],
             },
@@ -299,7 +293,7 @@ describe('ScoreProcedureList', () => {
     )
   })
 
-  it('loads version-scoped procedures through the procedure-score-version index', async () => {
+  it('loads version-scoped procedures through the procedure scoreVersionId index', async () => {
     render(
       <ScoreProcedureList
         scoreId="score-1"
@@ -319,7 +313,7 @@ describe('ScoreProcedureList', () => {
     expect(screen.queryByText('Other Run')).not.toBeInTheDocument()
     expect(mockGraphql).toHaveBeenCalledWith(
       expect.objectContaining({
-        query: expect.stringContaining('listProcedureScoreVersionByScoreVersionIdAndUpdatedAt'),
+        query: expect.stringContaining('listProcedureByScoreVersionIdAndUpdatedAt'),
         variables: expect.objectContaining({ scoreVersionId: 'version-2' }),
       })
     )

--- a/dashboard/components/ui/optimizer-results-utils.ts
+++ b/dashboard/components/ui/optimizer-results-utils.ts
@@ -157,40 +157,6 @@ export const PROCEDURE_DELETE_SUBSCRIPTION_FOR_CARDS = `
   }
 `
 
-export const PROCEDURE_SCORE_VERSION_CREATE_SUBSCRIPTION_FOR_CARDS = `
-  subscription OnCreateProcedureScoreVersionForCards {
-    onCreateProcedureScoreVersion {
-      id
-      scoreVersionId
-      procedure {
-        ${PROCEDURE_CARD_FIELDS}
-      }
-    }
-  }
-`
-
-export const PROCEDURE_SCORE_VERSION_UPDATE_SUBSCRIPTION_FOR_CARDS = `
-  subscription OnUpdateProcedureScoreVersionForCards {
-    onUpdateProcedureScoreVersion {
-      id
-      scoreVersionId
-      procedure {
-        ${PROCEDURE_CARD_FIELDS}
-      }
-    }
-  }
-`
-
-export const PROCEDURE_SCORE_VERSION_DELETE_SUBSCRIPTION_FOR_CARDS = `
-  subscription OnDeleteProcedureScoreVersionForCards {
-    onDeleteProcedureScoreVersion {
-      id
-      procedureId
-      scoreVersionId
-    }
-  }
-`
-
 export const EVALUATION_CREATE_SUBSCRIPTION_FOR_CARDS = `
   subscription OnCreateEvaluationForCards {
     onCreateEvaluation {
@@ -1145,22 +1111,20 @@ async function loadProcedureRecordsByScoreVersionId(
   do {
     const procedureResponse = await client.graphql({
       query: `
-        query ListProcedureScoreVersionByScoreVersionIdAndUpdatedAtWorkbench(
+        query ListProcedureByScoreVersionIdAndUpdatedAtWorkbench(
           $scoreVersionId: String!
           $sortDirection: ModelSortDirection
           $limit: Int
           $nextToken: String
         ) {
-          listProcedureScoreVersionByScoreVersionIdAndUpdatedAt(
+          listProcedureByScoreVersionIdAndUpdatedAt(
             scoreVersionId: $scoreVersionId
             sortDirection: $sortDirection
             limit: $limit
             nextToken: $nextToken
           ) {
             items {
-              procedure {
-                ${PROCEDURE_CARD_FIELDS}
-              }
+              ${PROCEDURE_CARD_FIELDS}
             }
             nextToken
           }
@@ -1174,8 +1138,8 @@ async function loadProcedureRecordsByScoreVersionId(
       },
     }) as any
 
-    const page = procedureResponse.data?.listProcedureScoreVersionByScoreVersionIdAndUpdatedAt
-    procedures.push(...(page?.items ?? []).map((item: any) => item?.procedure).filter(Boolean))
+    const page = procedureResponse.data?.listProcedureByScoreVersionIdAndUpdatedAt
+    procedures.push(...(page?.items ?? []))
     nextToken = page?.nextToken ?? null
   } while (nextToken)
 

--- a/dashboard/components/ui/score-procedure-list.tsx
+++ b/dashboard/components/ui/score-procedure-list.tsx
@@ -49,9 +49,6 @@ import {
   procedureToOptimizerRunView,
   PROCEDURE_CREATE_SUBSCRIPTION_FOR_CARDS,
   PROCEDURE_DELETE_SUBSCRIPTION_FOR_CARDS,
-  PROCEDURE_SCORE_VERSION_CREATE_SUBSCRIPTION_FOR_CARDS,
-  PROCEDURE_SCORE_VERSION_DELETE_SUBSCRIPTION_FOR_CARDS,
-  PROCEDURE_SCORE_VERSION_UPDATE_SUBSCRIPTION_FOR_CARDS,
   PROCEDURE_UPDATE_SUBSCRIPTION_FOR_CARDS,
   refreshOptimizerRunManifest,
   scorecardGuideRelativePath,
@@ -377,32 +374,6 @@ export function ScoreProcedureList({
       },
       'delete procedure'
     )
-    if (scope === 'version') {
-      const upsertProcedureLink = (rawLink: any) => {
-        if (rawLink?.scoreVersionId !== versionId) return
-        upsertProcedure(rawLink.procedure)
-      }
-
-      subscribe(
-        PROCEDURE_SCORE_VERSION_CREATE_SUBSCRIPTION_FOR_CARDS,
-        (data) => upsertProcedureLink(data?.onCreateProcedureScoreVersion),
-        'create procedure score version'
-      )
-      subscribe(
-        PROCEDURE_SCORE_VERSION_UPDATE_SUBSCRIPTION_FOR_CARDS,
-        (data) => upsertProcedureLink(data?.onUpdateProcedureScoreVersion),
-        'update procedure score version'
-      )
-      subscribe(
-        PROCEDURE_SCORE_VERSION_DELETE_SUBSCRIPTION_FOR_CARDS,
-        (data) => {
-          const deleted = data?.onDeleteProcedureScoreVersion
-          if (deleted?.scoreVersionId !== versionId || !deleted?.procedureId) return
-          setRuns((previous) => previous.filter((run) => run.procedureId !== deleted.procedureId))
-        },
-        'delete procedure score version'
-      )
-    }
     subscribe(
       EVALUATION_CREATE_SUBSCRIPTION_FOR_CARDS,
       (data) => {

--- a/project/events/2026-05-02T00:48:15.158Z__944e54d0-e4ea-45d5-a6e0-a8caec787427.json
+++ b/project/events/2026-05-02T00:48:15.158Z__944e54d0-e4ea-45d5-a6e0-a8caec787427.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "944e54d0-e4ea-45d5-a6e0-a8caec787427",
+  "issue_id": "plx-10efce0e-574a-47ea-9017-559785f48603",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-02T00:48:15.158Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Confirm the deployed score-version procedure association index works for the Scorecards dashboard Procedures tab. Test the direct query path against real deployed data and capture any follow-up issues.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Verify deployed score-version procedure GSI"
+  }
+}

--- a/project/events/2026-05-02T00:48:24.102Z__1cf3d748-58e3-4646-89c9-d29469ad200a.json
+++ b/project/events/2026-05-02T00:48:24.102Z__1cf3d748-58e3-4646-89c9-d29469ad200a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1cf3d748-58e3-4646-89c9-d29469ad200a",
+  "issue_id": "plx-10efce0e-574a-47ea-9017-559785f48603",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-02T00:48:24.102Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-02T00:51:12.966Z__dcbaa0b9-c1a5-46cd-a66a-26d3efa25256.json
+++ b/project/events/2026-05-02T00:51:12.966Z__dcbaa0b9-c1a5-46cd-a66a-26d3efa25256.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "dcbaa0b9-c1a5-46cd-a66a-26d3efa25256",
+  "issue_id": "plx-10efce0e-574a-47ea-9017-559785f48603",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-02T00:51:12.966Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a6c8daa7-5587-482b-8bac-b6ccf466bf72"
+  }
+}

--- a/project/issues/plx-10efce0e-574a-47ea-9017-559785f48603.json
+++ b/project/issues/plx-10efce0e-574a-47ea-9017-559785f48603.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-10efce0e-574a-47ea-9017-559785f48603",
+  "title": "Verify deployed score-version procedure GSI",
+  "description": "Confirm the deployed score-version procedure association index works for the Scorecards dashboard Procedures tab. Test the direct query path against real deployed data and capture any follow-up issues.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "a6c8daa7-5587-482b-8bac-b6ccf466bf72",
+      "author": "ryan",
+      "text": "Verified deployed GraphQL schema exposes both procedure scoreVersionId and ProcedureScoreVersion queries. ProcedureScoreVersion table currently has zero rows, while listProcedureByScoreVersionIdAndUpdatedAt returned two real procedures for scoreVersionId 63892e5d-bacc-483c-89ff-429ff2131100 with no nextToken. Updated dashboard version-scoped procedure loading to use the direct Procedure scoreVersionId GSI path.",
+      "created_at": "2026-05-02T00:51:12.966354Z"
+    }
+  ],
+  "created_at": "2026-05-02T00:48:15.157480Z",
+  "updated_at": "2026-05-02T00:51:12.966354Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Verifies the deployed score-version procedure GSI is available and returns real procedures.
- Switches the Scorecards dashboard version-scoped procedure list to query `listProcedureByScoreVersionIdAndUpdatedAt` directly.
- Removes the unused `ProcedureScoreVersion` subscription/query path from the procedure list UI.

## Verification
- Deployed API query `listProcedureScoreVersions(limit: 20)` returned 0 link records.
- Deployed API query `listProcedureByScoreVersionIdAndUpdatedAt(scoreVersionId: "63892e5d-bacc-483c-89ff-429ff2131100", sortDirection: DESC, limit: 100)` returned 2 procedure records, no `nextToken`.
- `cd dashboard && npm test -- --runTestsByPath components/ui/__tests__/score-procedure-list.test.tsx --runInBand`
- `cd dashboard && npm run typecheck`

## Kanbus
- plx-10efce
