### PR TITLE
Fix item dashboard identifier search

### DIFF
--- a/dashboard/__tests__/items-dashboard.test.tsx
+++ b/dashboard/__tests__/items-dashboard.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import ItemsDashboard from '../components/items-dashboard';
+import ItemsDashboard, {
+  ITEM_IDENTIFIER_SEARCH_QUERY,
+  buildItemIdentifierSearchVariables,
+  firstItemIdFromIdentifierSearchResponse,
+} from '../components/items-dashboard';
 
 // Mock the required modules
 jest.mock('next/navigation', () => ({
@@ -99,4 +103,44 @@ describe('ItemsDashboard Score Result Selection Logic', () => {
     
     expect(shouldShowDivider).toBe(false);
   });
-}); 
+});
+
+describe('ItemsDashboard Identifier Search', () => {
+  it('uses the account-scoped identifier value index', () => {
+    expect(ITEM_IDENTIFIER_SEARCH_QUERY).toContain('listIdentifierByAccountIdAndValue');
+    expect(ITEM_IDENTIFIER_SEARCH_QUERY).not.toContain('listIdentifierByValue');
+  });
+
+  it('builds exact identifier search variables for the selected account', () => {
+    expect(buildItemIdentifierSearchVariables('account-1', '  report-123  ')).toEqual({
+      accountId: 'account-1',
+      value: { eq: 'report-123' },
+      limit: 25,
+    });
+  });
+
+  it('returns the first item id from identifier search results', () => {
+    const itemId = firstItemIdFromIdentifierSearchResponse({
+      data: {
+        listIdentifierByAccountIdAndValue: {
+          items: [
+            { itemId: null, name: 'Report Id', value: '123', accountId: 'account-1' },
+            { itemId: 'item-123', name: 'ID', value: 'item-123', accountId: 'account-1' },
+          ],
+        },
+      },
+    });
+
+    expect(itemId).toBe('item-123');
+  });
+
+  it('returns null when identifier search has no item ids', () => {
+    expect(firstItemIdFromIdentifierSearchResponse({
+      data: {
+        listIdentifierByAccountIdAndValue: {
+          items: [],
+        },
+      },
+    })).toBeNull();
+  });
+});

--- a/dashboard/components/items-dashboard.tsx
+++ b/dashboard/components/items-dashboard.tsx
@@ -604,6 +604,59 @@ const transformItem = (item: any, options: { isNew?: boolean } = {}): Item => {
   };
 };
 
+type ItemIdentifierSearchResponse = {
+  data?: {
+    listIdentifierByAccountIdAndValue?: {
+      items?: Array<{
+        itemId?: string | null;
+        name?: string | null;
+        value?: string | null;
+        accountId?: string | null;
+      } | null> | null;
+    } | null;
+  } | null;
+};
+
+export const ITEM_IDENTIFIER_SEARCH_LIMIT = 25;
+
+export const ITEM_IDENTIFIER_SEARCH_QUERY = `
+  query ListIdentifierByAccountIdAndValue(
+    $accountId: String!
+    $value: ModelStringKeyConditionInput
+    $limit: Int
+  ) {
+    listIdentifierByAccountIdAndValue(
+      accountId: $accountId
+      value: $value
+      limit: $limit
+    ) {
+      items {
+        itemId
+        name
+        value
+        accountId
+      }
+    }
+  }
+`;
+
+export const buildItemIdentifierSearchVariables = (
+  accountId: string,
+  identifier: string,
+  limit = ITEM_IDENTIFIER_SEARCH_LIMIT
+) => ({
+  accountId,
+  value: { eq: identifier.trim() },
+  limit
+});
+
+export const firstItemIdFromIdentifierSearchResponse = (
+  response: ItemIdentifierSearchResponse
+) => {
+  const identifiers = response.data?.listIdentifierByAccountIdAndValue?.items ?? [];
+  return identifiers.find((identifier) => Boolean(identifier?.itemId))?.itemId ?? null;
+};
+
 function ItemsDashboardInner() {
   const searchParams = useSearchParams()
   const params = useParams()
@@ -752,45 +805,27 @@ function ItemsDashboardInner() {
   // Search for item by identifier
   const handleSearch = useCallback(async (identifier: string) => {
     if (!identifier.trim()) return;
+    if (!selectedAccount?.id) {
+      setSearchError('Select an account before searching');
+      return;
+    }
     
     setIsSearching(true);
     setSearchError(null);
     
     try {
-      const response = await graphqlRequest<{
-        listIdentifierByValue: {
-          items: Array<{
-            itemId: string;
-            name: string;
-          }>;
-        };
-      }>(`
-        query ListIdentifierByValue($value: String!) {
-          listIdentifierByValue(value: $value) {
-            items {
-              itemId
-              name
-            }
-          }
-        }
-      `, {
-        value: identifier.trim()
-      });
+      const response = await graphqlRequest<ItemIdentifierSearchResponse['data']>(
+        ITEM_IDENTIFIER_SEARCH_QUERY,
+        buildItemIdentifierSearchVariables(selectedAccount.id, identifier)
+      );
       
-      const identifiers = response.data?.listIdentifierByValue?.items;
+      const itemId = firstItemIdFromIdentifierSearchResponse(response);
       
-      if (identifiers && identifiers.length > 0) {
-        // Use the first item found
-        const identifier = identifiers[0];
-        const itemId = identifier.itemId;
-        if (itemId) {
-          // Navigate to the item without remount
-          window.history.pushState({}, '', `/lab/items/${itemId}`)
-          setSelectedItem(itemId)
-          setSearchValue(''); // Clear search on success
-        } else {
-          setSearchError('Item not found for this identifier');
-        }
+      if (itemId) {
+        // Navigate to the item without remount
+        window.history.pushState({}, '', `/lab/items/${itemId}`)
+        setSelectedItem(itemId)
+        setSearchValue(''); // Clear search on success
       } else {
         setSearchError('No item found with this identifier');
         // Set timeout to clear error after 5 seconds
@@ -814,7 +849,7 @@ function ItemsDashboardInner() {
     } finally {
       setIsSearching(false);
     }
-  }, []);
+  }, [selectedAccount?.id]);
 
   // Handle search form submission
   const handleSearchSubmit = useCallback((e: React.FormEvent) => {
@@ -3497,7 +3532,7 @@ function ItemsDashboardInner() {
                 </div>
                 <Input
                   type="text"
-                  placeholder="Search by ID"
+                  placeholder="Search by identifier"
                   value={searchValue}
                   onChange={(e) => {
                     setSearchValue(e.target.value);
@@ -3595,7 +3630,7 @@ function ItemsDashboardInner() {
                       </div>
                       <Input
                         type="text"
-                        placeholder="Search by ID"
+                        placeholder="Search by identifier"
                         value={searchValue}
                         onChange={(e) => {
                           setSearchValue(e.target.value);
@@ -3781,4 +3816,3 @@ export default function ItemsDashboard() {
     </Suspense>
   );
 }
-

--- a/project/events/2026-05-02T01:03:17.517Z__c9bdc814-3d1b-4f12-81d8-8aaf068e9f07.json
+++ b/project/events/2026-05-02T01:03:17.517Z__c9bdc814-3d1b-4f12-81d8-8aaf068e9f07.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c9bdc814-3d1b-4f12-81d8-8aaf068e9f07",
+  "issue_id": "plx-56f4abf4-2ee6-40c6-b86b-b1ec40860a11",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-02T01:03:17.517Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "The Items dashboard search is broken for item identifiers. Support searching by any item identifier, not just primary IDs or limited fields. Verify against dashboard tests and the relevant data query path.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Fix item dashboard identifier search"
+  }
+}

--- a/project/events/2026-05-02T01:03:24.300Z__d79cee78-b1b6-4e50-9188-b10cb556d3bf.json
+++ b/project/events/2026-05-02T01:03:24.300Z__d79cee78-b1b6-4e50-9188-b10cb556d3bf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d79cee78-b1b6-4e50-9188-b10cb556d3bf",
+  "issue_id": "plx-56f4abf4-2ee6-40c6-b86b-b1ec40860a11",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-02T01:03:24.300Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/issues/plx-56f4abf4-2ee6-40c6-b86b-b1ec40860a11.json
+++ b/project/issues/plx-56f4abf4-2ee6-40c6-b86b-b1ec40860a11.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-56f4abf4-2ee6-40c6-b86b-b1ec40860a11",
+  "title": "Fix item dashboard identifier search",
+  "description": "The Items dashboard search is broken for item identifiers. Support searching by any item identifier, not just primary IDs or limited fields. Verify against dashboard tests and the relevant data query path.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-02T01:03:17.517525Z",
+  "updated_at": "2026-05-02T01:03:24.300507Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Update Items dashboard search to resolve item identifiers through the account-scoped Identifier value index
- Search any stored item identifier value with an exact GSI lookup and navigate to the resolved item
- Update the search placeholder and add regression coverage for the query shape and result extraction

## Tests
- npm test -- --runTestsByPath __tests__/items-dashboard.test.tsx --runInBand
- npm run typecheck

Kanbus: plx-56f4ab