### PR TITLE
chore(kanbus): sync task record updates

### DIFF
--- a/project/events/2026-04-29T21:16:26.421Z__57f303f0-547f-4fbd-9d7c-cd62e8936699.json
+++ b/project/events/2026-04-29T21:16:26.421Z__57f303f0-547f-4fbd-9d7c-cd62e8936699.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "57f303f0-547f-4fbd-9d7c-cd62e8936699",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T21:16:26.421Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "0947e660-3b87-4f42-93ca-9dec35926ec9"
+  }
+}

--- a/project/events/2026-04-29T21:22:49.229Z__2d7d5f95-5dff-48cb-8250-8a8b818feb85.json
+++ b/project/events/2026-04-29T21:22:49.229Z__2d7d5f95-5dff-48cb-8250-8a8b818feb85.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2d7d5f95-5dff-48cb-8250-8a8b818feb85",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T21:22:49.229Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "4b3c88f1-5131-40d7-8b69-33aacf64841b"
+  }
+}

--- a/project/events/2026-04-29T21:43:18.643Z__62f3cfb1-65fb-4bd6-ac1c-f86d6b873901.json
+++ b/project/events/2026-04-29T21:43:18.643Z__62f3cfb1-65fb-4bd6-ac1c-f86d6b873901.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "62f3cfb1-65fb-4bd6-ac1c-f86d6b873901",
+  "issue_id": "plx-9330f595-a374-42d5-9c33-d8a5eb63615d",
+  "event_type": "comment_added",
+  "occurred_at": "2026-04-29T21:43:18.643Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "de1e56a7-6449-44db-8cc2-8311d5ff38e8"
+  }
+}

--- a/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
+++ b/project/issues/plx-9330f595-a374-42d5-9c33-d8a5eb63615d.json
@@ -286,10 +286,28 @@
       "author": "ryan",
       "text": "Post-main cloud smoke still shows Console dispatcher backed by only core/score-editor tools in Lambda. Locally the MCP server registers 52 tools, so I am adding worker image hardening/verification for MCP package availability and explicit MCP PYTHONPATH before another deploy.",
       "created_at": "2026-04-29T19:47:15.077276Z"
+    },
+    {
+      "id": "0947e660-3b87-4f42-93ca-9dec35926ec9",
+      "author": "ryan",
+      "text": "PR #253 used develop directly as the head branch, so later develop pushes can invalidate branch protection review state. Creating a fixed release branch from current develop and replacing #253 with a stable release PR to main.",
+      "created_at": "2026-04-29T21:16:26.421397Z"
+    },
+    {
+      "id": "4b3c88f1-5131-40d7-8b69-33aacf64841b",
+      "author": "ryan",
+      "text": "Per git-flow policy, removed the fixed release branch PR. Release will continue through develop -> main only.",
+      "created_at": "2026-04-29T21:22:49.228952Z"
+    },
+    {
+      "id": "de1e56a7-6449-44db-8cc2-8311d5ff38e8",
+      "author": "ryan",
+      "text": "Closing broken develop -> main PR #253 and replacing it with a fresh develop -> main PR because branch protection/review state was invalidated by subsequent updates.",
+      "created_at": "2026-04-29T21:43:18.642719Z"
     }
   ],
   "created_at": "2026-04-27T12:42:41.687340Z",
-  "updated_at": "2026-04-29T19:47:15.077276Z",
+  "updated_at": "2026-04-29T21:43:18.642719Z",
   "closed_at": null,
   "custom": {
     "project_label": "plx",


### PR DESCRIPTION
Change-management PR only.

- Sync Kanbus task record updates generated locally (issue JSON + event JSONs).
- No product code changes.