### PR TITLE
Document Plexus one-tool Tactus runtime

### DIFF
--- a/MCP/README.md
+++ b/MCP/README.md
@@ -1,163 +1,141 @@
-# Plexus MCP Server - Refactored Structure
+# Plexus MCP Server
 
-This directory contains the Plexus MCP server where each tool is organized into separate files for better maintainability and organization.
+The Plexus MCP server exposes one programmable tool: `execute_tactus`.
 
-> **For a comprehensive guide on using these tools with AI agents, see the [Agent Integration Guide](../AGENTS.md).**
+Instead of publishing a separate MCP tool for every Plexus operation, the server
+runs short Tactus/Lua snippets inside a sandboxed runtime. The runtime injects
+`plexus` as a global host module, so agents can call Plexus APIs
+programmatically without repeating the import boilerplate:
 
-## Directory Structure
-
-```
-MCP/
-├── server.py                    # Main server entry point
-├── shared/                      # Shared utilities and setup
-│   ├── setup.py                # Core setup and Plexus imports
-│   └── utils.py                # Common utility functions
-└── tools/                      # Individual tool implementations
-    ├── scorecard/              # Scorecard management tools
-    │   └── scorecards.py       # List, info, evaluation tools
-    ├── score/                  # Score management tools
-    │   └── management.py       # Score CRUD, configuration tools
-    ├── report/                 # Report management tools
-    │   └── reports.py          # Report listing and details
-    ├── item/                   # Item management tools
-    ├── task/                   # Task management tools
-    ├── feedback/               # Feedback analysis tools
-    └── util/                   # Utility tools
-        └── debug.py            # Debug, think, documentation tools
-```
-
-## Key Changes
-
-### 1. Modular Organization
-- Each category of tools is in its own directory
-- Individual tool files focus on related functionality
-- Clear separation of concerns
-
-### 2. Shared Infrastructure
-- `shared/setup.py`: Handles Plexus imports, stdout redirection, and core initialization
-- `shared/utils.py`: Common utility functions like URL generation, account management, helper functions
-
-### 3. Tool Registration Pattern
-Each tool file exports a `register_*_tools(mcp: FastMCP)` function that registers its tools with the MCP server:
-
-```python
-def register_scorecard_tools(mcp: FastMCP):
-    """Register scorecard tools with the MCP server"""
-    
-    @mcp.tool()
-    async def plexus_scorecards_list(...):
-        # Implementation
-```
-
-### 4. Consistent Error Handling
-All tools use the same pattern for:
-- Stdout capture and redirection
-- Error logging
-- Import error handling
-- Client creation and credential validation
-
-## Usage
-
-### Running the Server
-```bash
-# With environment directory
-python server.py --env-dir /path/to/env/dir
-
-# With specific transport
-python server.py --transport stdio
-
-# With custom host/port for SSE
-python server.py --host 0.0.0.0 --port 8003
-```
-
-### Setting Up MCP Server with Claude Code
-
-To use the Plexus MCP server with Claude Code, you need to configure it properly to handle complex arguments.
-
-#### Simple Setup (without complex arguments)
-```bash
-bclaude mcp add plexus /opt/anaconda3/envs/py311/bin/python /Users/ryan.porter/Projects/Plexus/MCP/plexus_fastmcp_wrapper.py
-```
-
-#### Advanced Setup (with arguments like --target-cwd)
-The `bclaude mcp add` command has limitations with complex arguments. For advanced configurations, manually edit your `~/.claude.json` file:
-
-```json
-{
-  "mcpServers": {
-    "plexus": {
-      "command": "/opt/anaconda3/envs/py311/bin/python",
-      "args": [
-        "/Users/ryan.porter/Projects/Plexus/MCP/plexus_fastmcp_wrapper.py",
-        "--target-cwd",
-        "/Users/ryan.porter/Projects/Plexus/"
-      ]
-    }
-  }
+```lua
+return plexus.score.info{
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
 }
 ```
 
-**Why this is necessary:** The `bclaude mcp add` command cannot properly parse complex argument strings with flags. When you try to pass a quoted string like `"command --flag value"`, it treats the entire string as the command name rather than parsing the arguments separately.
+The MCP interface stays small while the Plexus runtime surface can grow behind
+the `plexus` host module. This follows the broader Tactus
+[One Tool For Everything](https://tactus.anth.us/use-cases/one-tool-programmable-api/)
+pattern.
 
-#### Verifying the Connection
+## Discovery
+
+Start every session by discovering the available runtime API and docs from
+inside `execute_tactus`:
+
+```lua
+return plexus.api.list()
+```
+
+```lua
+return plexus.docs.list()
+```
+
+```lua
+return plexus.docs.get{ key = "overview" }
+```
+
+Docs live under `plexus/docs/` and are exposed through `plexus.docs.*`. The
+runtime rejects path traversal and unknown documentation keys.
+
+## Common Calls
+
+Run a local prediction:
+
+```lua
+return plexus.score.predict{
+  scorecard_name = "Quality Assurance v1.0",
+  score_name = "Compliance Check",
+  item_id = "item-123",
+  yaml = true,
+}
+```
+
+Find feedback items:
+
+```lua
+return plexus.feedback.find{
+  scorecard_name = "Quality Assurance v1.0",
+  score_name = "Compliance Check",
+  initial_value = "No",
+  final_value = "Yes",
+  limit = 5,
+  days = 30,
+}
+```
+
+Run a long evaluation with an async handle:
+
+```lua
+local handle = plexus.evaluation.run{
+  scorecard_name = "Quality Assurance v1.0",
+  score_name = "Compliance Check",
+  n_samples = 200,
+  yaml = true,
+  async = true,
+  budget = {
+    usd = 0.25,
+    wallclock_seconds = 900,
+    depth = 1,
+    tool_calls = 20,
+  },
+}
+
+return { evaluation_handle = handle }
+```
+
+Poll, await, or cancel a handle in a later `execute_tactus` call:
+
+```lua
+return plexus.handle.await{ id = "<handle-id>", timeout = "PT10M" }
+```
+
+## Runtime Contract
+
+`execute_tactus` returns a structured envelope with:
+
+- `ok`: whether execution completed successfully
+- `value`: the returned Lua/Tactus value, when successful
+- `error`: structured error details, when unsuccessful
+- `cost`: budget and usage information
+- `api_calls`: Plexus runtime calls made by the snippet
+- `trace_id` and trace metadata for debugging
+
+Long-running calls such as `plexus.evaluation.run`, `plexus.report.run`, and
+`plexus.procedure.run` require `async = true` with an explicit child `budget`.
+Blocking calls that need handle semantics fail with a structured
+`requires_handle_protocol` error.
+
+## Server Entry Points
+
+The main server entry point is `MCP/server.py`. It registers only
+`execute_tactus`:
+
 ```bash
-bclaude mcp list
+python MCP/server.py --transport stdio
 ```
 
-You should see:
-```
-plexus: /opt/anaconda3/envs/py311/bin/python /Users/ryan.porter/Projects/Plexus/MCP/plexus_fastmcp_wrapper.py - ✓ Connected
-```
+Authenticated ASGI usage is wired through `MCP/asgi_app.py`.
 
-### Adding New Tools
-1. Create a new tool file in the appropriate category directory
-2. Implement the tool functions with `@mcp.tool()` decorators
-3. Create a `register_*_tools(mcp)` function
-4. Import and call the registration function in `server.py`
+## Adding Plexus Capabilities
 
-Example:
-```python
-# tools/new_category/new_tools.py
-def register_new_tools(mcp: FastMCP):
-    @mcp.tool()
-    async def new_tool():
-        # Implementation
-        pass
+Do not add a new top-level MCP tool for each feature. Add capabilities to the
+Tactus runtime instead:
 
-# server.py
-from tools.new_category.new_tools import register_new_tools
+1. Implement or wire the Plexus SDK/service function.
+2. Expose it through `MCP/tools/tactus_runtime/execute.py`, preferably as a
+   direct handler.
+3. Make it discoverable through `plexus.api.list()`.
+4. Document the workflow under `plexus/docs/`.
+5. Add tests in `MCP/tools/tactus_runtime/execute_test.py`.
 
-def register_all_tools():
-    # ... existing registrations
-    register_new_tools(mcp)
-```
+This keeps the external MCP schema stable while giving agents a richer,
+composable programming surface.
 
-## Migration Status
+## Related Runtime Docs
 
-### Completed
-- ✅ Shared setup and utilities
-- ✅ Utility tools (debug, think, documentation)
-- ✅ Scorecard tools (list, info, evaluation)
-- ✅ Score management tools (info, delete - partial)
-- ✅ Report tools (list, info - partial)
-- ✅ Main server structure
-
-### Remaining
-- ⏳ Complete score tools (configuration, pull, push, update)
-- ⏳ Complete report tools (last, configurations)
-- ⏳ Item management tools (last, info)
-- ⏳ Task management tools (last, info)
-- ⏳ Feedback analysis tools (summary, find, predict)
-
-## Benefits of This Structure
-
-1. **Maintainability**: Easier to find and modify specific functionality
-2. **Testability**: Individual tool modules can be tested in isolation
-3. **Scalability**: Easy to add new tool categories without bloating main file
-4. **Collaboration**: Multiple developers can work on different tool categories
-5. **Code Reuse**: Shared utilities prevent duplication
-6. **Clear Dependencies**: Import structure makes dependencies explicit
-
-## Backward Compatibility
-
-The refactored server provides the same MCP tool interface as the original monolithic file, ensuring existing clients continue to work without changes.
+- `MCP/tools/tactus_runtime/HANDLE_PROTOCOL.md`
+- `plexus/docs/overview.md`
+- `plexus/docs/discovery.md`
+- `plexus/docs/evaluation-and-feedback/`

--- a/dashboard/app/documentation/advanced/mcp-server/layout.tsx
+++ b/dashboard/app/documentation/advanced/mcp-server/layout.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Plexus MCP Server - Plexus Documentation",
-  description: "Learn how to use the Plexus MCP server to enable AI agents and tools to interact with Plexus functionality."
+  title: "Plexus MCP / Tactus Runtime - Plexus Documentation",
+  description: "Learn how Plexus exposes one programmable MCP tool backed by the host-provided Plexus Tactus runtime."
 };
 
 export default function McpServerLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
-} 
+}

--- a/dashboard/app/documentation/advanced/mcp-server/page.tsx
+++ b/dashboard/app/documentation/advanced/mcp-server/page.tsx
@@ -1,255 +1,263 @@
-'use client';
-
 import Link from "next/link";
+
+const clientConfig = `{
+  "mcpServers": {
+    "plexus": {
+      "command": "/path/to/python",
+      "args": [
+        "/path/to/Plexus/MCP/plexus_fastmcp_wrapper.py",
+        "--transport", "stdio",
+        "--target-cwd", "/path/to/Plexus"
+      ],
+      "env": {
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": "/path/to/Plexus"
+      }
+    }
+  }
+}`;
+
+const discoverSnippet = `return {
+  apis = plexus.api.list(),
+  docs = plexus.docs.list(),
+  overview = plexus.docs.get{ key = "overview" },
+}`;
+
+const scoreSnippet = `return plexus.score.info{
+  scorecard_identifier = "Quality Assurance",
+  score_identifier = "Compliance",
+}`;
+
+const feedbackSnippet = `local summary = plexus.feedback.alignment{
+  scorecard_name = "Quality Assurance",
+  score_name = "Compliance",
+  days = 30,
+  output_format = "json",
+}
+
+local false_negatives = plexus.feedback.find{
+  scorecard_name = "Quality Assurance",
+  score_name = "Compliance",
+  initial_value = "No",
+  final_value = "Yes",
+  limit = 5,
+  days = 30,
+}
+
+return {
+  summary = summary,
+  false_negatives = false_negatives,
+}`;
+
+const asyncSnippet = `local handle = plexus.evaluation.run{
+  scorecard_name = "Quality Assurance",
+  score_name = "Compliance",
+  n_samples = 200,
+  yaml = true,
+  async = true,
+  budget = {
+    usd = 1.0,
+    wallclock_seconds = 900,
+    depth = 1,
+    tool_calls = 20,
+  },
+}
+
+return {
+  handle_id = handle.id,
+  status = handle.status,
+}`;
+
+const handleSnippet = `return plexus.handle.await{
+  id = "<handle-id>",
+  timeout = "PT10M",
+}`;
+
+function CodeBlock({ children }: { children: string }) {
+  return (
+    <pre className="bg-muted rounded-lg mb-4 overflow-x-auto p-4 text-sm">
+      <code>{children}</code>
+    </pre>
+  );
+}
 
 export default function McpServerPage() {
   return (
     <div className="max-w-4xl mx-auto py-8 px-6">
-      <style jsx>{`
-        .code-container {
-          position: relative;
-          overflow-x: auto;
-          white-space: pre;
-          -webkit-overflow-scrolling: touch;
-        }
-        
-        .code-container::after {
-          content: '';
-          position: absolute;
-          right: 0;
-          top: 0;
-          bottom: 0;
-          width: 16px;
-          background: linear-gradient(to right, transparent, var(--background-muted));
-          opacity: 0;
-          transition: opacity 0.2s;
-          pointer-events: none;
-        }
-        
-        .code-container:hover::after {
-          opacity: 1;
-        }
-      `}</style>
-
-      <h1 className="text-4xl font-bold mb-4">Using the Plexus MCP Server</h1>
+      <h1 className="text-4xl font-bold mb-4">Plexus MCP / Tactus Runtime</h1>
       <p className="text-lg text-muted-foreground mb-8">
-        Connect AI assistants like Claude to your Plexus data and functionality using the Model Context Protocol (MCP) server.
+        Connect an MCP client to Plexus through one programmable tool:
+        <code> execute_tactus</code>. The tool runs sandboxed Tactus snippets
+        that call the host-provided <code>plexus</code> runtime module.
       </p>
 
       <div className="space-y-8">
         <section>
-          <h2 className="text-2xl font-semibold mb-4">What is MCP?</h2>
+          <h2 className="text-2xl font-semibold mb-4">Why one tool?</h2>
           <p className="text-muted-foreground mb-4">
-            The Model Context Protocol (MCP) is an open standard designed by Anthropic that allows AI models, such as Claude, 
-            to securely interact with external tools and data sources. For an AI assistant, an MCP server acts as a gateway, 
-            enabling it to access and use capabilities from other systems. In the context of Plexus, this means you can 
-            empower an AI to work with your scorecards, evaluations, and reports directly. This allows for more dynamic and 
-            powerful ways to interact with your Plexus instance. 
-            For a deeper dive into the protocol itself, see the official <Link href="https://www.anthropic.com/news/model-context-protocol" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Anthropic Model Context Protocol announcement</Link>.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl font-semibold mb-4">Plexus MCP Server Overview</h2>
-          <p className="text-muted-foreground mb-4">
-            The Plexus MCP server is a pre-built tool that you can run on your system. Once running, it allows AI assistants 
-            that support MCP (like the Claude desktop app) to connect to your Plexus environment. This connection lets the AI 
-            perform various actions within Plexus on your behalf, such as listing scorecards, retrieving report details, or 
-            even initiating new evaluations. The server is typically run via a wrapper script (<code>plexus_fastmcp_wrapper.py</code>) 
-            which handles environment setup and ensures smooth communication with the AI client.
-          </p>
-        </section>
-        
-        <section>
-          <h2 className="text-2xl font-semibold mb-4">Getting the Server Code</h2>
-          <p className="text-muted-foreground mb-4">
-            To run the Plexus MCP server, you'll first need to obtain the server code. This is available in the main Plexus GitHub repository. 
-            You can clone or download it from: <Link href="https://github.com/AnthusAI/Plexus" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">https://github.com/AnthusAI/Plexus</Link>.
-            The necessary scripts (<code>plexus_fastmcp_wrapper.py</code> and <code>plexus_fastmcp_server.py</code>) are typically located at <code>MCP/</code> within the repository.
-            You will primarily need these files and to ensure their dependencies can be met in your Python environment.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl font-semibold mb-4">Setting Up an MCP Client (e.g., Claude Desktop App)</h2>
-          <p className="text-muted-foreground mb-2">
-            To use the Plexus MCP server, you need an MCP client. For example, if you are using the Claude desktop application, 
-            you would configure it by creating or editing an <code>mcp.json</code> file. This file tells Claude (or another client) 
-            how to find and communicate with your running Plexus MCP server.
-          </p>
-          <p className="text-muted-foreground mb-2">
-            Here is an example configuration for your <code>mcp.json</code> file. You will need to replace the placeholder paths 
-            (<code>/path/to/...</code>) with the actual paths relevant to your system and where you have cloned the Plexus repository.
-          </p>
-          <pre className="bg-muted rounded-lg mb-4">
-            <div className="code-container p-4">
-{`{
-  "mcpServers": {
-    "plexus-mcp-service": {
-      "command": "/path/to/your/conda/envs/py311/bin/python",
-      "args": [
-        "/path/to/your/Plexus/MCP/plexus_fastmcp_wrapper.py",
-        "--host", "127.0.0.1",
-        "--port", "8002",
-        "--transport", "stdio",
-        "--env-file", "/path/to/your/Plexus/.env",
-        "--target-cwd", "/path/to/your/Plexus/"
-      ],
-      "env": {
-        "PYTHONUNBUFFERED": "1",
-        "PYTHONPATH": "/path/to/your/Plexus"
-      }
-    }
-  }
-}`}
-            </div>
-          </pre>
-          <p className="text-muted-foreground mb-1">Key parts of this configuration:</p>
-          <ul className="list-disc pl-6 space-y-1 text-muted-foreground mb-4">
-            <li><code>command</code>: The full path to the Python interpreter within your Plexus conda environment (e.g., <code>py311</code>).</li>
-            <li><code>args</code>: Specifies the wrapper script to run (<code>plexus_fastmcp_wrapper.py</code>) and its parameters. 
-                The <code>--host</code> and <code>--port</code> arguments configure the local server settings.
-                The <code>--transport stdio</code> argument is standard for client-server communication. 
-                The <code>--env-file</code> argument must point directly to your <code>.env</code> file (which contains API keys). 
-                The <code>--target-cwd</code> should point to your Plexus project root directory.</li>
-            <li><code>env.PYTHONPATH</code>: Should point to the root of your Plexus project directory to ensure the server can find all necessary Python modules.</li>
-          </ul>
-          <p className="text-muted-foreground mb-4">
-            The location of the <code>mcp.json</code> file can vary depending on the client. For the Claude desktop app, consult its documentation for the correct location (often in a configuration directory within your user profile).
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl font-semibold mb-4">Available Tools & Capabilities</h2>
-          <p className="text-muted-foreground mb-4">Once the Plexus MCP server is running (via the wrapper script) and your AI assistant is connected, you can instruct the assistant to use the following tools:</p>
-          
-          <div>
-            <h3 className="text-xl font-medium mb-2">Scorecard Management</h3>
-            <ul className="list-disc pl-6 space-y-3 text-muted-foreground">
-              <li>
-                <strong><code>list_plexus_scorecards</code></strong>: Ask the AI to list available scorecards in your Plexus Dashboard. 
-                You can optionally tell it to filter by an account name/key, a partial scorecard name, or a scorecard key. For example: "List Plexus scorecards for the 'Sales' account that include 'Q3' in the name."
-              </li>
-              <li>
-                <strong><code>get_plexus_scorecard_info</code></strong>: Request detailed information about a specific scorecard. 
-                Provide the AI with an identifier for the scorecard (like its name, key, or ID). It will return the scorecard's description, sections, and the scores within each section. For example: "Get info for the 'Customer Satisfaction Q3' scorecard."
-              </li>
-              <li>
-                <strong><code>get_plexus_score_details</code></strong>: Get specific details for a particular score within a scorecard, including its configuration and version history. 
-                You'll need to specify both the scorecard and the score. You can also ask for a specific version of the score. For example: "Show me the details for the 'Responsiveness' score in the 'Support Tickets' scorecard, especially its champion version."
-              </li>
-            </ul>
-          </div>
-
-          <div className="mt-6">
-            <h3 className="text-xl font-medium mb-2">Evaluation Tools</h3>
-            <ul className="list-disc pl-6 space-y-3 text-muted-foreground">
-              <li>
-                <strong><code>run_plexus_evaluation</code></strong>: Instruct the AI to start a new scorecard evaluation. 
-                You need to provide the scorecard name and optionally a specific score name and the number of samples. The server will dispatch this task to your Plexus backend. Note that the MCP server itself doesn't track the progress; you would monitor the evaluation in the Plexus Dashboard as usual. For example: "Run a Plexus evaluation for the 'Lead Quality' scorecard using 100 samples."
-              </li>
-            </ul>
-          </div>
-
-          <div className="mt-6">
-            <h3 className="text-xl font-medium mb-2">Reporting Tools</h3>
-            <ul className="list-disc pl-6 space-y-3 text-muted-foreground">
-              <li>
-                <strong><code>list_plexus_reports</code></strong>: Ask for a list of generated reports. You can filter by account or by a specific report configuration ID if you know it. 
-                The AI will return a list showing report names, IDs, and when they were created. For example: "List the latest Plexus reports for the main account."
-              </li>
-              <li>
-                <strong><code>get_plexus_report_details</code></strong>: Retrieve detailed information about a specific report by providing its ID. 
-                This includes the report's parameters, output, and any generated blocks. For example: "Get the details for Plexus report ID '123-abc-456'."
-              </li>
-              <li>
-                <strong><code>get_latest_plexus_report</code></strong>: A convenient way to get the details of the most recently generated report. 
-                You can optionally filter by account or report configuration ID. For example: "Show me the latest report generated from the 'Weekly Performance' configuration."
-              </li>
-              <li>
-                <strong><code>list_plexus_report_configurations</code></strong>: Get a list of all available report configurations for an account. 
-                This is useful for knowing what reports you *can* generate. For example: "What report configurations are available for the 'Marketing' account?"
-              </li>
-            </ul>
-          </div>
-
-          <div className="mt-6">
-            <h3 className="text-xl font-medium mb-2">Utility Tools</h3>
-            <ul className="list-disc pl-6 space-y-3 text-muted-foreground">
-              <li>
-                <strong><code>think</code></strong>: A planning tool used internally by the AI to structure reasoning before using other tools.
-                This helps the AI organize its approach to complex tasks that may require multiple steps or tool calls.
-              </li>
-            </ul>
-          </div>
-        </section>
-
-        <section>
-          <h2 className="text-2xl font-semibold mb-4">Environment Requirements for Running the Server</h2>
-          <div className="space-y-4">
-            <div>
-              <h3 className="text-xl font-medium mb-2">Software</h3>
-              <ul className="list-disc pl-6 space-y-1 text-muted-foreground">
-                <li>Python 3.11 or newer (required by the <code>fastmcp</code> library the server uses).</li>
-                <li>An existing Plexus installation and access to its dashboard credentials.</li>
-                <li>The <code>python-dotenv</code> Python package (used by the server to load your API keys from the <code>.env</code> file).</li>
-              </ul>
-            </div>
-            <div>
-              <h3 className="text-xl font-medium mb-2"><code>.env</code> File with Plexus Credentials</h3>
-              <p className="text-muted-foreground mb-2">
-                The server needs to access your Plexus API. Create a file named <code>.env</code>. The <code>--env-file</code> parameter in your <code>mcp.json</code> should point directly to this file.
-                It's typically located in your main Plexus project root directory (e.g., <code>Plexus/.env</code>).
-              </p>
-              <h4 className="text-lg font-medium mt-2 mb-1">Required Variables in <code>.env</code>:</h4>
-              <ul className="list-disc pl-6 space-y-1 text-muted-foreground">
-                <li><code>PLEXUS_API_URL</code>: The API endpoint URL for your Plexus instance.</li>
-                <li><code>PLEXUS_API_KEY</code>: Your API key for authenticating with Plexus.</li>
-                <li><code>PLEXUS_DASHBOARD_URL</code>: The main URL of your Plexus dashboard (used for generating links).</li>
-              </ul>
-              <h4 className="text-lg font-medium mt-2 mb-1">Optional Variables in <code>.env</code>:</h4>
-              <ul className="list-disc pl-6 space-y-1 text-muted-foreground">
-                <li><code>PLEXUS_ACCOUNT_KEY</code>: If you work with multiple accounts, you can set a default account key here.</li>
-                <li><code>LOG_LEVEL</code>: You can set this to <code>DEBUG</code>, <code>INFO</code>, <code>WARNING</code>, or <code>ERROR</code> to control the server's logging verbosity.</li>
-              </ul>
-            </div>
-          </div>
-        </section>
-
-        <section>
-          <h2 className="text-2xl font-semibold mb-4">Running the Server</h2>
-          <p className="text-muted-foreground mb-2">
-            Once you have the code and your <code>.env</code> file is set up, you should run the server using the <code>plexus_fastmcp_wrapper.py</code> script as configured in your <code>mcp.json</code> file. 
-            The MCP client (e.g., Claude Desktop App) will execute the command specified in <code>mcp.json</code> when it attempts to connect to the "plexus-mcp-service".
-          </p>
-          <p className="text-muted-foreground mb-2">
-            You typically don't run the <code>plexus_fastmcp_wrapper.py</code> script manually from the terminal for client use. Instead, ensure your <code>mcp.json</code> is correctly configured, and the client application will start the server process as needed.
+            Earlier MCP integrations often exposed every application operation
+            as a separate tool. That works for small systems, but Plexus has a
+            broad surface area: scorecards, scores, feedback, evaluations,
+            reports, datasets, procedures, documentation, budgets, and handles.
+            Loading all of that as individual tool schemas consumes model
+            context on every call, adding latency and cost while displacing the
+            user task and other useful context.
           </p>
           <p className="text-muted-foreground mb-4">
-            Make sure your Plexus Python environment (e.g., <code>conda activate py311</code>) is correctly referenced by the full path to python in the <code>command</code> field of your <code>mcp.json</code>. 
-            The wrapper script handles passing the necessary environment variables and paths to the underlying <code>plexus_fastmcp_server.py</code>.
+            Plexus now exposes a compact gateway instead. The MCP client calls
+            <code> execute_tactus</code>, and the submitted Tactus code composes
+            the <code>plexus</code> APIs it needs for the current task. The
+            assistant writes a small program instead of choosing from a long
+            menu of fine-grained tools.
+          </p>
+          <p className="text-muted-foreground mb-4">
+            The gateway also supports progressive disclosure. The base MCP
+            context only needs to describe <code>execute_tactus</code> and the
+            discovery path: use <code>plexus.api.list()</code> to inspect the
+            available API surface, then use <code>plexus.docs.list()</code> and{" "}
+            <code>plexus.docs.get{"{ ... }"}</code> to load focused docs and
+            examples for the workflow at hand.
+          </p>
+          <p className="text-muted-foreground">
+            This is the same pattern described on the Tactus site:{" "}
+            <Link
+              href="https://tactus.anth.us/use-cases/one-tool-programmable-api/"
+              className="text-primary hover:underline"
+            >
+              One Tool For Everything
+            </Link>
+            .
           </p>
         </section>
 
         <section>
-          <h2 className="text-2xl font-semibold mb-4">Troubleshooting Common Issues</h2>
+          <h2 className="text-2xl font-semibold mb-4">Runtime model</h2>
+          <p className="text-muted-foreground mb-4">
+            Inside <code>execute_tactus</code>, <code>plexus</code> is
+            available as an injected global host module. It delegates to Plexus
+            SDK code, services, documentation, task dispatch, and handle
+            storage. The Tactus runtime provides the controlled execution
+            boundary around those calls.
+          </p>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
-            <li><strong>Connection Errors:</strong> Double-check all paths in your <code>mcp.json</code> file (<code>command</code>, <code>args</code>, <code>env.PYTHONPATH</code>). Ensure they accurately point to your Python executable, the <code>plexus_fastmcp_wrapper.py</code> script, your <code>.env</code> file, and your project directory.</li>
-            <li><strong>Authentication Errors:</strong> Verify that the <code>--env-file</code> path in <code>mcp.json</code> correctly points to your <code>.env</code> file and that this file contains the correct <code>PLEXUS_API_URL</code> and <code>PLEXUS_API_KEY</code>.</li>
+            <li>
+              Use <code>plexus.api.list()</code> to discover namespaces and
+              methods.
+            </li>
+            <li>
+              Use <code>plexus.docs.list()</code> and{" "}
+              <code>plexus.docs.get{"{ ... }"}</code> to read focused docs
+              during the session.
+            </li>
+            <li>
+              Use explicit <code>return</code> values when you want a custom
+              result shape.
+            </li>
+            <li>
+              Long-running calls can return handles that are polled, awaited,
+              or cancelled later.
+            </li>
           </ul>
         </section>
 
         <section>
-          <h2 className="text-2xl font-semibold mb-4">Server Logs</h2>
-          <p className="text-muted-foreground mb-2">
-            The Plexus MCP server setup (via <code>plexus_fastmcp_wrapper.py</code>) directs operational logs and error messages to stderr. 
-            MCP clients like the Claude desktop app typically capture and display these stderr logs, or store them in a dedicated log file.
-          </p>
+          <h2 className="text-2xl font-semibold mb-4">Client setup</h2>
           <p className="text-muted-foreground mb-4">
-            For instance, Cursor often stores MCP interaction logs in <code>~/Library/Logs/Claude/mcp.log</code> on macOS. Monitoring this file is key for diagnosing issues if the client doesn't display them directly.
+            Configure your MCP client to launch the Plexus wrapper from your
+            local Plexus checkout. Replace the placeholder paths with your
+            Python environment and project path.
           </p>
+          <CodeBlock>{clientConfig}</CodeBlock>
+          <p className="text-muted-foreground">
+            Credentials are loaded from your Plexus environment and config
+            files. Keep API keys on the host side; they are not passed into the
+            Tactus snippet.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-4">Start with discovery</h2>
+          <p className="text-muted-foreground mb-4">
+            When unsure what the runtime supports, ask Plexus from inside the
+            runtime instead of guessing tool names.
+          </p>
+          <CodeBlock>{discoverSnippet}</CodeBlock>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-4">Common examples</h2>
+          <p className="text-muted-foreground mb-4">
+            Inspect a score by scorecard and score identifiers:
+          </p>
+          <CodeBlock>{scoreSnippet}</CodeBlock>
+
+          <p className="text-muted-foreground mb-4">
+            Combine feedback summary and item search in one call:
+          </p>
+          <CodeBlock>{feedbackSnippet}</CodeBlock>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-4">Async handles and budgets</h2>
+          <p className="text-muted-foreground mb-4">
+            Evaluations, reports, and procedures can be long-running. Use
+            <code> async = true</code> to dispatch the work and return a handle.
+            Include an explicit child budget so background work remains bounded.
+          </p>
+          <CodeBlock>{asyncSnippet}</CodeBlock>
+
+          <p className="text-muted-foreground mb-4">
+            Later, use the handle APIs from another <code>execute_tactus</code>
+            call:
+          </p>
+          <CodeBlock>{handleSnippet}</CodeBlock>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-4">Safety contract</h2>
+          <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+            <li>
+              The MCP surface stays small: clients only need to know{" "}
+              <code>execute_tactus</code>.
+            </li>
+            <li>
+              The runtime returns structured envelopes with success, value,
+              error, cost, trace, partial, and API-call data.
+            </li>
+            <li>
+              Destructive operations request human approval before committing
+              changes.
+            </li>
+            <li>
+              Traces and handles let operators inspect what happened and resume
+              long-running work.
+            </li>
+            <li>
+              Plexus keeps credentials, SDK implementation, policy, and
+              persistence on the trusted host side.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-4">Troubleshooting</h2>
+          <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+            <li>
+              If the MCP client cannot connect, verify the Python path, wrapper
+              path, <code>--target-cwd</code>, and <code>PYTHONPATH</code>.
+            </li>
+            <li>
+              If a Plexus call fails, inspect the returned structured error and
+              trace ID before retrying.
+            </li>
+            <li>
+              If a snippet needs a capability you cannot find, call{" "}
+              <code>plexus.api.list()</code> and then read the relevant docs
+              with <code>plexus.docs.get{"{ key = \"...\" }"}</code>.
+            </li>
+          </ul>
         </section>
       </div>
     </div>
-  )
-} 
+  );
+}

--- a/dashboard/app/documentation/advanced/page.tsx
+++ b/dashboard/app/documentation/advanced/page.tsx
@@ -70,17 +70,18 @@ export default function AdvancedPage() {
         </section>
 
         <section>
-          <h2 className="text-2xl font-semibold mb-4">Plexus MCP Server</h2>
+          <h2 className="text-2xl font-semibold mb-4">Plexus MCP / Tactus Runtime</h2>
           <div className="space-y-4">
             <p className="text-muted-foreground mb-4">
-              Enable AI agents and tools to interact with Plexus functionality using the Multi-Agent Cooperative Protocol (MCP).
+              Connect MCP clients to one programmable Tactus tool that can
+              compose Plexus APIs through a sandboxed host module.
             </p>
             <Link href="/documentation/advanced/mcp-server">
-              <DocButton>Explore MCP Server</DocButton>
+              <DocButton>Explore MCP / Tactus Runtime</DocButton>
             </Link>
           </div>
         </section>
       </div>
     </div>
   )
-} 
+}

--- a/dashboard/app/documentation/components/documentation-layout.tsx
+++ b/dashboard/app/documentation/components/documentation-layout.tsx
@@ -175,7 +175,7 @@ const docSections: DocSidebarItem[] = [
       { name: "Worker Nodes", href: "/documentation/advanced/worker-nodes" },
       { name: "Python SDK Reference", href: "/documentation/advanced/sdk" },
       { name: "Universal Code Snippets", href: "/documentation/advanced/universal-code" },
-      { name: "MCP Server", href: "/documentation/advanced/mcp-server" },
+      { name: "MCP / Tactus Runtime", href: "/documentation/advanced/mcp-server" },
     ],
   },
 ]

--- a/plexus/docs/overview.md
+++ b/plexus/docs/overview.md
@@ -6,8 +6,7 @@ returns a structured envelope. Use this as the only Plexus tool.
 
 ## Runtime ground rules
 
-- `plexus` is a global. You do **not** need
-  `local plexus = require("plexus")`.
+- `plexus` is a global. You do **not** need to import it yourself.
 - The runtime captures the result of the **last** Plexus operation your
   snippet calls and returns it as the value of this tool call. You only
   need to write an explicit `return` when you want a custom output shape.


### PR DESCRIPTION
## Summary

Updates the public Plexus MCP documentation to describe the current one-tool Tactus runtime model instead of the older catalog-of-tools model. The docs now present `execute_tactus` as the single MCP tool, explain the injected global `plexus` host module, and show discovery through `plexus.api.list()`, `plexus.docs.list()`, and `plexus.docs.get{...}`.

## What changed

- Rewrites `MCP/README.md` around `execute_tactus`, discovery, async handles, budgets, structured envelopes, and adding capabilities through the Tactus runtime rather than new MCP tools.
- Replaces the public Dashboard MCP Server page with current docs for the Plexus MCP / Tactus Runtime, including client setup, common snippets, feedback/evaluation workflows, async handles, safety controls, and the link to the Tactus “One Tool For Everything” pattern page.
- Updates advanced docs navigation, page metadata, and sidebar labeling from “MCP Server” to “MCP / Tactus Runtime”.
- Clarifies `plexus/docs/overview.md` so Plexus-specific snippets use the injected global `plexus` and do not require `local plexus = require("plexus")`.

## Validation

- `git diff --check` passed in the clean PR worktree.
- Static stale-copy search passed for public docs: no `local plexus = require("plexus")`, `Plexus execute_tactus`, or old many-tool catalog labels remain in the touched public docs.
- `cd dashboard && npm run typecheck` passed in the dependency-installed Plexus checkout.

## Scope

This PR targets documentation and public navigation only. It does not change the Tactus runtime implementation, MCP server behavior, or protected `main` branch.