### PR TITLE
Fix CodeQL unused import finding

### DIFF
--- a/dashboard/__tests__/items-dashboard.test.tsx
+++ b/dashboard/__tests__/items-dashboard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import ItemsDashboard, {
+import {
   ITEM_IDENTIFIER_SEARCH_QUERY,
   buildItemIdentifierSearchVariables,
   firstItemIdFromIdentifierSearchResponse,

--- a/project/events/2026-05-02T19:41:02.497Z__2ad4b18f-869b-4ac4-a5ca-b9e3eb52788c.json
+++ b/project/events/2026-05-02T19:41:02.497Z__2ad4b18f-869b-4ac4-a5ca-b9e3eb52788c.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "2ad4b18f-869b-4ac4-a5ca-b9e3eb52788c",
+  "issue_id": "plx-93975eb9-1e2d-48e0-b584-75420d90d1f3",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-02T19:41:02.497Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Prepare develop to main release PR"
+  }
+}

--- a/project/events/2026-05-02T19:41:07.613Z__aeea741b-e8cd-4d7c-91d2-cf02ecf3dac4.json
+++ b/project/events/2026-05-02T19:41:07.613Z__aeea741b-e8cd-4d7c-91d2-cf02ecf3dac4.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "aeea741b-e8cd-4d7c-91d2-cf02ecf3dac4",
+  "issue_id": "plx-93975eb9-1e2d-48e0-b584-75420d90d1f3",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-02T19:41:07.613Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-02T19:41:07.631Z__41f912b8-adb8-4a8f-bcf5-8062c88cd2d4.json
+++ b/project/events/2026-05-02T19:41:07.631Z__41f912b8-adb8-4a8f-bcf5-8062c88cd2d4.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "41f912b8-adb8-4a8f-bcf5-8062c88cd2d4",
+  "issue_id": "plx-93975eb9-1e2d-48e0-b584-75420d90d1f3",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-02T19:41:07.631Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "9ca724a9-853b-4f6d-ada5-93e0e03d3716"
+  }
+}

--- a/project/events/2026-05-02T19:51:21.251Z__f09452aa-adf5-409d-9aef-ce0a3c0a2e07.json
+++ b/project/events/2026-05-02T19:51:21.251Z__f09452aa-adf5-409d-9aef-ce0a3c0a2e07.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f09452aa-adf5-409d-9aef-ce0a3c0a2e07",
+  "issue_id": "plx-93975eb9-1e2d-48e0-b584-75420d90d1f3",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-02T19:51:21.251Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a4b101b3-d45f-4499-98e4-88d2eb4a9612"
+  }
+}

--- a/project/events/2026-05-02T19:51:21.650Z__c2b5952d-881a-4002-8334-48f7c1bc6e57.json
+++ b/project/events/2026-05-02T19:51:21.650Z__c2b5952d-881a-4002-8334-48f7c1bc6e57.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c2b5952d-881a-4002-8334-48f7c1bc6e57",
+  "issue_id": "plx-93975eb9-1e2d-48e0-b584-75420d90d1f3",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-02T19:51:21.650Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-02T19:54:12.546Z__464e6457-a669-456f-9325-794724d6dadc.json
+++ b/project/events/2026-05-02T19:54:12.546Z__464e6457-a669-456f-9325-794724d6dadc.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "464e6457-a669-456f-9325-794724d6dadc",
+  "issue_id": "plx-49e6647b-d577-44b3-89ee-df73373cf09f",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-02T19:54:12.546Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Accept CodeQL unused import suggestion for release PR"
+  }
+}

--- a/project/events/2026-05-02T19:55:13.715Z__f4eaa819-a848-4b86-a63f-7206fbfdee1b.json
+++ b/project/events/2026-05-02T19:55:13.715Z__f4eaa819-a848-4b86-a63f-7206fbfdee1b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f4eaa819-a848-4b86-a63f-7206fbfdee1b",
+  "issue_id": "plx-49e6647b-d577-44b3-89ee-df73373cf09f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-02T19:55:13.715Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "80be8167-8140-4528-8803-d390eba6d9a5"
+  }
+}

--- a/project/events/2026-05-02T19:55:48.649Z__77928c16-1b5e-4163-b4a3-0cbd29418dcf.json
+++ b/project/events/2026-05-02T19:55:48.649Z__77928c16-1b5e-4163-b4a3-0cbd29418dcf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "77928c16-1b5e-4163-b4a3-0cbd29418dcf",
+  "issue_id": "plx-49e6647b-d577-44b3-89ee-df73373cf09f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-02T19:55:48.649Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-02T19:56:24.847Z__ed9798ca-4a4e-490d-9131-60b494701fca.json
+++ b/project/events/2026-05-02T19:56:24.847Z__ed9798ca-4a4e-490d-9131-60b494701fca.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ed9798ca-4a4e-490d-9131-60b494701fca",
+  "issue_id": "plx-49e6647b-d577-44b3-89ee-df73373cf09f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-02T19:56:24.847Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "237f5b29-1db0-4131-b817-c788c9e830de"
+  }
+}

--- a/project/events/2026-05-02T19:56:24.860Z__bc24ec96-f5ad-49e3-9e82-ced0a09e56df.json
+++ b/project/events/2026-05-02T19:56:24.860Z__bc24ec96-f5ad-49e3-9e82-ced0a09e56df.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bc24ec96-f5ad-49e3-9e82-ced0a09e56df",
+  "issue_id": "plx-49e6647b-d577-44b3-89ee-df73373cf09f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-02T19:56:24.860Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-49e6647b-d577-44b3-89ee-df73373cf09f.json
+++ b/project/issues/plx-49e6647b-d577-44b3-89ee-df73373cf09f.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-49e6647b-d577-44b3-89ee-df73373cf09f",
+  "title": "Accept CodeQL unused import suggestion for release PR",
+  "description": "",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "80be8167-8140-4528-8803-d390eba6d9a5",
+      "author": "ryan",
+      "text": "Behavior spec: the release PR should not carry the CodeQL unused default import finding in dashboard/__tests__/items-dashboard.test.tsx; keep only the named imports used by the identifier-search helper tests.",
+      "created_at": "2026-05-02T19:55:13.170121Z"
+    },
+    {
+      "id": "237f5b29-1db0-4131-b817-c788c9e830de",
+      "author": "ryan",
+      "text": "Accepted CodeQL suggestion by removing the unused default ItemsDashboard import while keeping the named identifier-search helper imports. Verified with: cd dashboard && npm test -- items-dashboard.test.tsx.",
+      "created_at": "2026-05-02T19:56:24.847094Z"
+    }
+  ],
+  "created_at": "2026-05-02T19:54:12.543391Z",
+  "updated_at": "2026-05-02T19:56:24.860134Z",
+  "closed_at": "2026-05-02T19:56:24.860134Z",
+  "custom": {}
+}

--- a/project/issues/plx-93975eb9-1e2d-48e0-b584-75420d90d1f3.json
+++ b/project/issues/plx-93975eb9-1e2d-48e0-b584-75420d90d1f3.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-93975eb9-1e2d-48e0-b584-75420d90d1f3",
+  "title": "Prepare develop to main release PR",
+  "description": "",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "9ca724a9-853b-4f6d-ada5-93e0e03d3716",
+      "author": "ryan",
+      "text": "Preparing develop-to-main release PR. Waiting for develop CI on 236e799f to pass before opening PR.",
+      "created_at": "2026-05-02T19:41:07.631304Z"
+    },
+    {
+      "id": "a4b101b3-d45f-4499-98e4-88d2eb4a9612",
+      "author": "ryan",
+      "text": "Created develop-to-main release PR #277: https://github.com/AnthusAI/Plexus/pull/277. Description covers procedure/execute_tactus runtime changes, dashboard task UI refinements, score champion timeline reporting, score-version procedure indexing, item search fixes, docs, and included develop PRs #268-#276.",
+      "created_at": "2026-05-02T19:51:21.249324Z"
+    }
+  ],
+  "created_at": "2026-05-02T19:41:02.496998Z",
+  "updated_at": "2026-05-02T19:51:21.643609Z",
+  "closed_at": "2026-05-02T19:51:21.643609Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary

Accepts the CodeQL PR suggestion from release PR #277 by removing the unused default `ItemsDashboard` import in the identifier-search test file while preserving the named helper imports that the tests use.

## Validation

- `cd dashboard && npm test -- items-dashboard.test.tsx`

## Kanbus

- Closes `plx-49e664`
