### PR TITLE
Stabilize procedure grid accuracy bar

### DIFF
--- a/dashboard/components/EvaluationListAccuracyBar.tsx
+++ b/dashboard/components/EvaluationListAccuracyBar.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils"
 interface EvaluationListAccuracyBarProps {
   progress: number
   accuracy: number
+  variant?: 'default' | 'blank'
   isFocused?: boolean
   isSelected?: boolean
   baselineAccuracy?: number
@@ -13,6 +14,7 @@ interface EvaluationListAccuracyBarProps {
 export function EvaluationListAccuracyBar({
   progress,
   accuracy,
+  variant = 'default',
   isFocused = false,
   isSelected = false,
   baselineAccuracy,
@@ -41,8 +43,10 @@ export function EvaluationListAccuracyBar({
     <div className={cn(
       "relative w-full h-8 rounded-md",
       isSelected ? "bg-progress-background-selected" : "bg-progress-background"
-    )}>
-      {clampedProgress > 0 && (
+    )}
+      data-testid="evaluation-list-accuracy-bar"
+    >
+      {variant !== 'blank' && clampedProgress > 0 && (
         <>
           <div
             className={cn(

--- a/dashboard/components/ProcedureTask.tsx
+++ b/dashboard/components/ProcedureTask.tsx
@@ -1290,13 +1290,14 @@ export default function ProcedureTask({
             </div>
           )}
           {renderProcedureStatus('grid')}
-          {feedbackEvaluationSummary && (
-            <EvaluationListAccuracyBar
-              progress={feedbackProgress}
-              accuracy={feedbackEvaluationSummary.accuracy ?? 0}
-              isSelected={isSelected}
-            />
-          )}
+          <EvaluationListAccuracyBar
+            variant={feedbackEvaluationSummary ? 'default' : 'blank'}
+            progress={feedbackProgress}
+            accuracy={feedbackEvaluationSummary?.accuracy ?? 0}
+            isSelected={isSelected}
+            baselineAccuracy={feedbackEvaluationSummary?.baselineAccuracy ?? undefined}
+            currentBaselineAccuracy={feedbackEvaluationSummary?.currentBaselineAccuracy ?? undefined}
+          />
         </div>
       ) : (
         <div className="p-3">

--- a/dashboard/components/__tests__/EvaluationListAccuracyBar.test.tsx
+++ b/dashboard/components/__tests__/EvaluationListAccuracyBar.test.tsx
@@ -3,6 +3,24 @@ import { render, screen } from '@testing-library/react'
 import { EvaluationListAccuracyBar } from '@/components/EvaluationListAccuracyBar'
 
 describe('EvaluationListAccuracyBar', () => {
+  it('renders a blank slot with the same bar footprint', () => {
+    render(
+      <EvaluationListAccuracyBar
+        variant="blank"
+        progress={100}
+        accuracy={80}
+        baselineAccuracy={70}
+        currentBaselineAccuracy={75}
+      />
+    )
+
+    const bar = screen.getByTestId('evaluation-list-accuracy-bar')
+    expect(bar).toHaveClass('w-full', 'h-8', 'rounded-md')
+    expect(screen.queryByText('80%')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Original baseline marker')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Current best baseline marker')).not.toBeInTheDocument()
+  })
+
   it('renders visibly separate original and current baseline markers when accuracies overlap', () => {
     render(
       <EvaluationListAccuracyBar

--- a/dashboard/components/__tests__/ProcedureTask.optimizer-auth.test.tsx
+++ b/dashboard/components/__tests__/ProcedureTask.optimizer-auth.test.tsx
@@ -281,6 +281,50 @@ describe('ProcedureTask optimizer auth flow', () => {
     expect(screen.getByText(/^Optimization Procedure$/)).toBeInTheDocument()
   })
 
+  it('reserves a blank accuracy bar slot in grid mode before feedback summary is loaded', () => {
+    render(
+      <ProcedureTask
+        variant="grid"
+        procedure={{
+          ...baseProcedure,
+          feedbackEvaluationSummary: null,
+        } as any}
+      />
+    )
+
+    const bar = screen.getByTestId('evaluation-list-accuracy-bar')
+    expect(bar).toHaveClass('w-full', 'h-8', 'rounded-md')
+    expect(screen.queryByText('0%')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Original baseline marker')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Current best baseline marker')).not.toBeInTheDocument()
+  })
+
+  it('renders feedback accuracy with baseline markers in grid mode', () => {
+    render(
+      <ProcedureTask
+        variant="grid"
+        procedure={{
+          ...baseProcedure,
+          feedbackEvaluationSummary: {
+            id: 'eval-feedback-1',
+            status: 'COMPLETED',
+            accuracy: 87,
+            processedItems: 87,
+            totalItems: 100,
+            baselineEvaluationId: 'baseline-eval-1',
+            currentBaselineEvaluationId: 'current-baseline-eval-1',
+            baselineAccuracy: 72,
+            currentBaselineAccuracy: 81,
+          },
+        } as any}
+      />
+    )
+
+    expect(screen.getAllByText('87%').length).toBeGreaterThan(0)
+    expect(screen.getByLabelText('Original baseline marker')).toBeInTheDocument()
+    expect(screen.getByLabelText('Current best baseline marker')).toBeInTheDocument()
+  })
+
   it('keeps local procedure runs labeled Local even when a worker node id is present', () => {
     render(
       <ProcedureTask

--- a/dashboard/components/ui/__tests__/optimizer-results-utils.test.ts
+++ b/dashboard/components/ui/__tests__/optimizer-results-utils.test.ts
@@ -1,0 +1,168 @@
+import { hydrateProcedureRunsFeedbackEvaluations } from '../optimizer-results-utils'
+
+const mockGraphql = jest.fn()
+
+jest.mock('aws-amplify/api', () => ({
+  generateClient: () => ({
+    graphql: mockGraphql,
+  }),
+}))
+
+jest.mock('aws-amplify/storage', () => ({
+  downloadData: jest.fn(),
+}))
+
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+describe('optimizer-results-utils procedure feedback hydration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('attaches original and current baseline accuracies to feedback summaries', async () => {
+    mockGraphql.mockImplementation(({ variables }: { variables: { id: string } }) => ({
+      data: {
+        getEvaluation: {
+          id: variables.id,
+          status: 'COMPLETED',
+          createdAt: '2026-04-25T00:00:00Z',
+          updatedAt: '2026-04-25T00:00:00Z',
+          parameters:
+            variables.id === 'eval-feedback-1'
+              ? JSON.stringify({
+                  metadata: {
+                    baseline_evaluation_id: 'baseline-eval-1',
+                    current_baseline_evaluation_id: 'current-baseline-eval-1',
+                  },
+                })
+              : JSON.stringify({ metadata: {} }),
+          accuracy:
+            variables.id === 'baseline-eval-1'
+              ? 72
+              : variables.id === 'current-baseline-eval-1'
+                ? 81
+                : 87,
+          processedItems: 87,
+          totalItems: 100,
+          metrics: JSON.stringify({ accuracy: 87 }),
+          task: null,
+        },
+      },
+    }))
+
+    const [hydrated] = await hydrateProcedureRunsFeedbackEvaluations([
+      {
+        procedureId: 'proc-1',
+        indexed: true,
+        manifest: {
+          best: {
+            best_feedback_evaluation_id: 'eval-feedback-1',
+          },
+        },
+      } as any,
+    ])
+
+    expect(hydrated.feedbackEvaluationSummary).toMatchObject({
+      id: 'eval-feedback-1',
+      accuracy: 87,
+      baselineEvaluationId: 'baseline-eval-1',
+      currentBaselineEvaluationId: 'current-baseline-eval-1',
+      baselineAccuracy: 72,
+      currentBaselineAccuracy: 81,
+    })
+  })
+
+  it('keeps the selected feedback summary when baseline evaluations are unavailable', async () => {
+    mockGraphql.mockImplementation(({ variables }: { variables: { id: string } }) => ({
+      data: {
+        getEvaluation:
+          variables.id === 'eval-feedback-1'
+            ? {
+                id: variables.id,
+                status: 'COMPLETED',
+                createdAt: '2026-04-25T00:00:00Z',
+                updatedAt: '2026-04-25T00:00:00Z',
+                parameters: JSON.stringify({
+                  metadata: {
+                    baseline_evaluation_id: 'missing-baseline-eval',
+                    current_baseline_evaluation_id: 'missing-current-baseline-eval',
+                  },
+                }),
+                accuracy: 87,
+                processedItems: 87,
+                totalItems: 100,
+                metrics: JSON.stringify({ accuracy: 87 }),
+                task: null,
+              }
+            : null,
+      },
+    }))
+
+    const [hydrated] = await hydrateProcedureRunsFeedbackEvaluations([
+      {
+        procedureId: 'proc-1',
+        indexed: true,
+        manifest: {
+          best: {
+            best_feedback_evaluation_id: 'eval-feedback-1',
+          },
+        },
+      } as any,
+    ])
+
+    expect(hydrated.feedbackEvaluationSummary).toMatchObject({
+      id: 'eval-feedback-1',
+      accuracy: 87,
+      baselineEvaluationId: 'missing-baseline-eval',
+      currentBaselineEvaluationId: 'missing-current-baseline-eval',
+      baselineAccuracy: null,
+      currentBaselineAccuracy: null,
+    })
+  })
+
+  it('uses procedure manifest baseline associations when the selected evaluation has none', async () => {
+    mockGraphql.mockImplementation(({ variables }: { variables: { id: string } }) => ({
+      data: {
+        getEvaluation: {
+          id: variables.id,
+          status: 'COMPLETED',
+          createdAt: '2026-05-03T13:35:00Z',
+          updatedAt: '2026-05-03T13:35:00Z',
+          parameters: JSON.stringify({ metadata: {} }),
+          accuracy: 80,
+          processedItems: 40,
+          totalItems: 50,
+          metrics: JSON.stringify({ accuracy: 80 }),
+          task: null,
+        },
+      },
+    }))
+
+    const [hydrated] = await hydrateProcedureRunsFeedbackEvaluations([
+      {
+        procedureId: 'proc-1',
+        indexed: true,
+        manifest: {
+          baseline: {
+            original_feedback_evaluation_id: 'original-baseline-eval',
+            current_feedback_evaluation_id: null,
+          },
+        },
+      } as any,
+    ])
+
+    expect(hydrated.feedbackEvaluationSummary).toMatchObject({
+      id: 'original-baseline-eval',
+      accuracy: 80,
+      baselineEvaluationId: 'original-baseline-eval',
+      currentBaselineEvaluationId: null,
+      baselineAccuracy: 80,
+      currentBaselineAccuracy: null,
+    })
+  })
+})

--- a/dashboard/components/ui/optimizer-results-utils.ts
+++ b/dashboard/components/ui/optimizer-results-utils.ts
@@ -207,6 +207,8 @@ export type ProcedureFeedbackEvaluationSummary = {
   totalItems?: number | null
   baselineEvaluationId?: string | null
   currentBaselineEvaluationId?: string | null
+  baselineAccuracy?: number | null
+  currentBaselineAccuracy?: number | null
   updatedAt?: string | null
 }
 
@@ -610,7 +612,61 @@ export function feedbackEvaluationSummaryFromView(
     totalItems: evaluation.totalItems ?? null,
     baselineEvaluationId: evaluation.baselineEvaluationId ?? null,
     currentBaselineEvaluationId: evaluation.currentBaselineEvaluationId ?? null,
+    baselineAccuracy: null,
+    currentBaselineAccuracy: null,
     updatedAt: evaluation.updatedAt ?? evaluation.createdAt ?? null,
+  }
+}
+
+async function loadEvaluationAccuraciesById(
+  evaluationIds: Array<string | null | undefined>
+): Promise<Map<string, number | null>> {
+  const uniqueIds = [...new Set(evaluationIds.filter((id): id is string => typeof id === 'string' && id.length > 0))]
+  const entries = await Promise.all(
+    uniqueIds.map(async (evaluationId) => {
+      try {
+        const evaluation = await loadScoreEvaluationById(evaluationId)
+        return [evaluationId, evaluation?.accuracy ?? null] as const
+      } catch (error) {
+        console.error('Failed to load procedure baseline evaluation accuracy', evaluationId, error)
+        return [evaluationId, null] as const
+      }
+    })
+  )
+  return new Map(entries)
+}
+
+function applyBaselineAccuraciesToSummary(
+  summary: ProcedureFeedbackEvaluationSummary | null,
+  accuraciesByEvaluationId: Map<string, number | null>
+): ProcedureFeedbackEvaluationSummary | null {
+  if (!summary) return null
+  return {
+    ...summary,
+    baselineAccuracy: summary.baselineEvaluationId
+      ? accuraciesByEvaluationId.get(summary.baselineEvaluationId) ?? null
+      : null,
+    currentBaselineAccuracy: summary.currentBaselineEvaluationId
+      ? accuraciesByEvaluationId.get(summary.currentBaselineEvaluationId) ?? null
+      : null,
+  }
+}
+
+function applyProcedureBaselineAssociations(
+  summary: ProcedureFeedbackEvaluationSummary | null,
+  manifest: OptimizerManifest | null | undefined
+): ProcedureFeedbackEvaluationSummary | null {
+  if (!summary) return null
+  return {
+    ...summary,
+    baselineEvaluationId:
+      summary.baselineEvaluationId ??
+      manifest?.baseline?.original_feedback_evaluation_id ??
+      null,
+    currentBaselineEvaluationId:
+      summary.currentBaselineEvaluationId ??
+      manifest?.baseline?.current_feedback_evaluation_id ??
+      null,
   }
 }
 
@@ -658,9 +714,17 @@ export async function hydrateProcedureRunFeedbackEvaluation(
 
   try {
     const evaluation = await loadScoreEvaluationById(evaluationId)
+    const summary = applyProcedureBaselineAssociations(
+      feedbackEvaluationSummaryFromView(evaluation),
+      run.manifest
+    )
+    const accuraciesByEvaluationId = await loadEvaluationAccuraciesById([
+      summary?.baselineEvaluationId,
+      summary?.currentBaselineEvaluationId,
+    ])
     return {
       ...run,
-      feedbackEvaluationSummary: feedbackEvaluationSummaryFromView(evaluation),
+      feedbackEvaluationSummary: applyBaselineAccuraciesToSummary(summary, accuraciesByEvaluationId),
     }
   } catch (error) {
     console.error('Failed to load procedure feedback evaluation', evaluationId, error)
@@ -694,13 +758,25 @@ export async function hydrateProcedureRunsFeedbackEvaluations(
       .filter((evaluation): evaluation is ScoreEvaluationView => Boolean(evaluation?.id))
       .map((evaluation) => [evaluation.id, evaluation])
   )
-
-  return runs.map((run) => {
+  const summariesByRun = runs.map((run) => {
     const evaluationId = currentProcedureFeedbackEvaluationId(run.manifest)
     const evaluation = evaluationId ? evaluationsById.get(evaluationId) : null
+    return applyProcedureBaselineAssociations(
+      feedbackEvaluationSummaryFromView(evaluation),
+      run.manifest
+    )
+  })
+  const baselineEvaluationIds = summariesByRun.flatMap((summary) => [
+    summary?.baselineEvaluationId,
+    summary?.currentBaselineEvaluationId,
+  ])
+  const baselineAccuraciesByEvaluationId = await loadEvaluationAccuraciesById(baselineEvaluationIds)
+
+  return runs.map((run, index) => {
+    const summary = summariesByRun[index] ?? null
     return {
       ...run,
-      feedbackEvaluationSummary: feedbackEvaluationSummaryFromView(evaluation),
+      feedbackEvaluationSummary: applyBaselineAccuraciesToSummary(summary, baselineAccuraciesByEvaluationId),
     }
   })
 }

--- a/project/events/2026-05-03T14:07:42.464Z__d7e7eaba-0156-4aed-b855-814df8e6ee32.json
+++ b/project/events/2026-05-03T14:07:42.464Z__d7e7eaba-0156-4aed-b855-814df8e6ee32.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "d7e7eaba-0156-4aed-b855-814df8e6ee32",
+  "issue_id": "plx-609e170e-a2b9-4f5b-82f9-2549797062c7",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-03T14:07:42.464Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Stabilize procedure grid accuracy bar slot"
+  }
+}

--- a/project/events/2026-05-03T14:07:46.588Z__3386a6cd-ccd5-4bbd-bf8c-9428c6de1b5c.json
+++ b/project/events/2026-05-03T14:07:46.588Z__3386a6cd-ccd5-4bbd-bf8c-9428c6de1b5c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3386a6cd-ccd5-4bbd-bf8c-9428c6de1b5c",
+  "issue_id": "plx-609e170e-a2b9-4f5b-82f9-2549797062c7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-03T14:07:46.588Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "902f310b-263e-4b12-8adb-41d0cb921482"
+  }
+}

--- a/project/events/2026-05-03T14:07:46.603Z__7bcec805-bb7e-4d3d-a54c-6c3da3590213.json
+++ b/project/events/2026-05-03T14:07:46.603Z__7bcec805-bb7e-4d3d-a54c-6c3da3590213.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7bcec805-bb7e-4d3d-a54c-6c3da3590213",
+  "issue_id": "plx-609e170e-a2b9-4f5b-82f9-2549797062c7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-03T14:07:46.603Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-03T14:14:57.250Z__bca10f15-2179-4b4e-bf43-8321e33a6b2d.json
+++ b/project/events/2026-05-03T14:14:57.250Z__bca10f15-2179-4b4e-bf43-8321e33a6b2d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bca10f15-2179-4b4e-bf43-8321e33a6b2d",
+  "issue_id": "plx-6ba6fd03-f9d7-4e95-ab64-1f8372f680c0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-03T14:14:57.250Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "f5a76820-9f3a-412e-b53b-f306a253c778"
+  }
+}

--- a/project/events/2026-05-03T14:19:08.709Z__e8c5a2e3-9196-43d8-bdb3-bc3713accc84.json
+++ b/project/events/2026-05-03T14:19:08.709Z__e8c5a2e3-9196-43d8-bdb3-bc3713accc84.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e8c5a2e3-9196-43d8-bdb3-bc3713accc84",
+  "issue_id": "plx-609e170e-a2b9-4f5b-82f9-2549797062c7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-03T14:19:08.709Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-609e170e-a2b9-4f5b-82f9-2549797062c7.json
+++ b/project/issues/plx-609e170e-a2b9-4f5b-82f9-2549797062c7.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-609e170e-a2b9-4f5b-82f9-2549797062c7",
+  "title": "Stabilize procedure grid accuracy bar slot",
+  "description": "",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "902f310b-263e-4b12-8adb-41d0cb921482",
+      "author": "ryan",
+      "text": "Behavior spec: procedure grid cards always reserve the bottom accuracy-bar slot; when feedback evaluation data is present, the grid bar includes original/current baseline markers from the selected evaluation's baseline associations.",
+      "created_at": "2026-05-03T14:07:46.588452Z"
+    },
+    {
+      "id": "d41b8df0-408b-4f39-b371-43de4f844dc1",
+      "author": "ryan",
+      "text": "Implemented locally: procedure grid now always renders a same-size accuracy bar slot, blank until feedback summary data is available. Summary hydration now attaches baseline/current baseline accuracies from evaluation parameters and uses optimizer manifest baseline associations when selected evaluations do not carry those IDs. Verified focused Jest tests and dashboard typecheck.",
+      "created_at": "2026-05-03T14:15:27.829537Z"
+    }
+  ],
+  "created_at": "2026-05-03T14:07:42.464098Z",
+  "updated_at": "2026-05-03T14:19:08.708265Z",
+  "closed_at": "2026-05-03T14:19:08.708265Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Keep the procedure grid card accuracy-bar slot mounted even before the feedback evaluation summary is available.
- Add a blank `EvaluationListAccuracyBar` variant with the same footprint and no visible labels or markers.
- Hydrate procedure feedback evaluation summaries with original/current baseline accuracies from the selected feedback evaluation associations.
- Use optimizer manifest baseline associations when the selected feedback evaluation itself does not carry baseline IDs, preserving the existing selected evaluation logic.

## Kanbus
- Closed `plx-609e17`: Stabilize procedure grid accuracy bar slot.

## Verification
- `cd dashboard && npm test -- EvaluationListAccuracyBar.test.tsx ProcedureTask.optimizer-auth.test.tsx optimizer-results-utils.test.ts score-procedure-list.test.tsx`
- `cd dashboard && npm run typecheck`
- `git diff --cached --check`