### PR TITLE
Show timestamps for unnamed chat sessions

### DIFF
--- a/dashboard/components/ui/__tests__/conversation-viewer-session-routing.test.tsx
+++ b/dashboard/components/ui/__tests__/conversation-viewer-session-routing.test.tsx
@@ -148,6 +148,22 @@ jest.mock("@/components/ui/dropdown-menu", () => ({
   ),
 }))
 
+jest.mock("@/components/ui/timestamp", () => ({
+  Timestamp: ({
+    time,
+    variant,
+    className,
+  }: {
+    time: string | Date
+    variant: string
+    className?: string
+  }) => (
+    <span data-testid="timestamp" data-variant={variant} className={className}>
+      {typeof time === "string" ? time : time.toISOString()}
+    </span>
+  ),
+}))
+
 if (typeof window !== "undefined" && !("ResizeObserver" in window)) {
   ;(window as any).ResizeObserver = class {
     observe() {}
@@ -320,14 +336,39 @@ describe("ConversationViewer session-routing states", () => {
             messageCount: 0,
           },
         ]}
-        messages={[]}
+        messages={[
+          {
+            id: "msg-unnamed-1",
+            sessionId: "sess-optimize-1234",
+            accountId: "acct-1",
+            procedureId: "builtin:console/chat",
+            role: "USER",
+            messageType: "MESSAGE",
+            humanInteraction: "CHAT",
+            content: "hello",
+            createdAt: "2026-03-27T00:05:00.000Z",
+          },
+          {
+            id: "msg-unnamed-2",
+            sessionId: "sess-optimize-1234",
+            accountId: "acct-1",
+            procedureId: "builtin:console/chat",
+            role: "ASSISTANT",
+            messageType: "MESSAGE",
+            humanInteraction: "CHAT_ASSISTANT",
+            content: "reply",
+            createdAt: "2026-03-27T00:08:00.000Z",
+          },
+        ]}
         selectedSessionId="sess-optimize-1234"
         defaultSidebarCollapsed={false}
       />
     )
 
     expect(screen.queryByText("Optimize")).not.toBeInTheDocument()
-    expect(screen.getAllByText("Session sess-opt")).not.toHaveLength(0)
+    expect(screen.queryByText("Session sess-opt")).not.toBeInTheDocument()
+    expect(screen.getAllByTestId("timestamp")).toHaveLength(2)
+    expect(screen.getAllByText("2026-03-27T00:08:00.000Z")).toHaveLength(2)
   })
 
   it("hides unnamed sessions that are marked hidden-until-named", () => {
@@ -375,14 +416,27 @@ describe("ConversationViewer session-routing states", () => {
             messageCount: 0,
           },
         ]}
-        messages={[]}
+        messages={[
+          {
+            id: "msg-legacy-unnamed",
+            sessionId: "legacy-unnamed-1",
+            accountId: "acct-1",
+            procedureId: "builtin:console/chat",
+            role: "USER",
+            messageType: "MESSAGE",
+            humanInteraction: "CHAT",
+            content: "hello",
+            createdAt: "2026-03-27T00:09:00.000Z",
+          },
+        ]}
         selectedSessionId="legacy-unnamed-1"
         defaultSidebarCollapsed={false}
       />
     )
 
     expect(screen.getByText("Chat Sessions (1)")).toBeInTheDocument()
-    expect(screen.getAllByText("Session legacy-u").length).toBeGreaterThan(0)
+    expect(screen.queryByText("Session legacy-u")).not.toBeInTheDocument()
+    expect(screen.getAllByText("2026-03-27T00:09:00.000Z")).toHaveLength(2)
   })
 
   it("renames a session from the action menu and marks title source manual", async () => {

--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -33,6 +33,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Textarea } from "@/components/ui/textarea"
+import { Timestamp } from "@/components/ui/timestamp"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -369,31 +370,35 @@ const serializeSessionMetadata = (value: unknown): string | undefined => {
   return undefined
 }
 
-const getSessionDisplayName = (session: Pick<ChatSession, "id" | "name">): string => {
+const getSessionExplicitName = (session: Pick<ChatSession, "name">): string => {
   const explicitName = String(session.name || "").trim()
-  if (explicitName) {
-    return explicitName
-  }
-  const sessionId = String(session.id || "").trim()
-  if (!sessionId) {
-    return "New Chat"
-  }
-  return `Session ${sessionId.slice(0, 8)}`
+  return explicitName
 }
 
-const getSessionHeaderTitle = (session: Pick<ChatSession, "id" | "name" | "metadata">): string => {
-  const explicitName = String(session.name || "").trim()
+const getSessionTitleAttribute = (session: Pick<ChatSession, "name">): string | undefined => {
+  const explicitName = getSessionExplicitName(session)
+  return explicitName || undefined
+}
+
+const SessionLabel = ({
+  session,
+  latestMessageAt,
+  timestampClassName,
+}: {
+  session: Pick<ChatSession, "name" | "metadata">
+  latestMessageAt?: string
+  timestampClassName?: string
+}) => {
+  const explicitName = getSessionExplicitName(session)
   if (explicitName) {
-    return explicitName
+    return <span className="truncate">{explicitName}</span>
   }
   if (isHiddenUntilNamedSession(session)) {
-    return "New Chat"
+    return <span className="truncate">New Chat</span>
   }
-  const sessionId = String(session.id || "").trim()
-  if (!sessionId) {
-    return "New Chat"
-  }
-  return `Session ${sessionId.slice(0, 8)}`
+  return latestMessageAt
+    ? <Timestamp time={latestMessageAt} variant="relative" className={timestampClassName} />
+    : null
 }
 
 const isHiddenUntilNamedSession = (session: Pick<ChatSession, "name" | "metadata">): boolean => {
@@ -1531,6 +1536,26 @@ function ConversationViewer({
   const messages = propMessages || internalMessages  
   const selectedSessionId = propSelectedSessionId || internalSelectedSessionId
   const isExternallyControlledSession = Boolean(propSelectedSessionId?.trim())
+  const latestMessageAtBySession = React.useMemo(() => {
+    const latestBySession = new Map<string, string>()
+
+    for (const message of messages) {
+      if (!message.sessionId || !message.createdAt) {
+        continue
+      }
+      const messageTime = new Date(message.createdAt).getTime()
+      if (Number.isNaN(messageTime)) {
+        continue
+      }
+
+      const existing = latestBySession.get(message.sessionId)
+      if (!existing || messageTime > new Date(existing).getTime()) {
+        latestBySession.set(message.sessionId, message.createdAt)
+      }
+    }
+
+    return latestBySession
+  }, [messages])
 
   useEffect(() => {
     selectedSessionIdRef.current = selectedSessionId
@@ -2949,10 +2974,16 @@ function ConversationViewer({
                 className="w-full justify-start text-left p-2 h-auto"
               >
                 <div className="flex items-center gap-2 min-w-0 flex-1">
-                  <MessageSquare className="h-4 w-4 flex-shrink-0" />
+                  {getSessionExplicitName(session) && (
+                    <MessageSquare className="h-4 w-4 flex-shrink-0" />
+                  )}
                   <div className="min-w-0 flex-1">
                     <div className="text-xs font-medium truncate">
-                      {getSessionDisplayName(session)}
+                      <SessionLabel
+                        session={session}
+                        latestMessageAt={latestMessageAtBySession.get(session.id)}
+                        timestampClassName="text-xs font-medium"
+                      />
                     </div>
                   <div className="text-xs text-muted-foreground">
                       {session.messageCount ? `${session.messageCount} messages` : 'No messages'}
@@ -2974,7 +3005,7 @@ function ConversationViewer({
                 size="sm"
                 onClick={() => handleSessionSelect(session.id)}
                 className="w-full h-8 p-0"
-                title={getSessionDisplayName(session)}
+                title={getSessionTitleAttribute(session)}
               >
                 <MessageSquare className="h-4 w-4" />
               </Button>
@@ -2999,11 +3030,17 @@ function ConversationViewer({
           <div data-testid="conversation-main-header" className="h-12 border-b border-border px-3 pt-0.5">
             <div className="flex h-full items-center justify-between">
               <div className="flex min-w-0 items-center gap-2">
-                <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
+                {getSessionExplicitName(selectedSession) && (
+                  <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
+                )}
                 <div className="min-w-0 flex items-center gap-2">
-                  <h3 className="font-medium text-sm truncate">
-                    {getSessionHeaderTitle(selectedSession)}
-                  </h3>
+                  <div className="font-medium text-sm truncate">
+                    <SessionLabel
+                      session={selectedSession}
+                      latestMessageAt={latestMessageAtBySession.get(selectedSession.id)}
+                      timestampClassName="font-medium text-sm"
+                    />
+                  </div>
                   <span className="text-xs text-muted-foreground truncate">
                     {selectedSession.messageCount ? `${selectedSession.messageCount} messages` : 'No messages'}
                   </span>

--- a/project/events/2026-05-03T17:32:46.255Z__5bf838f1-7e3d-4a25-a0f9-17b884172354.json
+++ b/project/events/2026-05-03T17:32:46.255Z__5bf838f1-7e3d-4a25-a0f9-17b884172354.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "5bf838f1-7e3d-4a25-a0f9-17b884172354",
+  "issue_id": "plx-433556f9-4e56-4008-9f53-bbb019ccbb3a",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-03T17:32:46.255Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-b13120eb-5b86-4098-94e6-422ffc0412a3",
+    "priority": 1,
+    "status": "open",
+    "title": "Show latest chat message timestamp for unnamed sessions"
+  }
+}

--- a/project/events/2026-05-03T17:32:50.149Z__9bce1112-0d87-4513-aa37-8b444cc075ae.json
+++ b/project/events/2026-05-03T17:32:50.149Z__9bce1112-0d87-4513-aa37-8b444cc075ae.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9bce1112-0d87-4513-aa37-8b444cc075ae",
+  "issue_id": "plx-433556f9-4e56-4008-9f53-bbb019ccbb3a",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-03T17:32:50.149Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "0739fe56-5556-43e2-af94-01dd198afdd1"
+  }
+}

--- a/project/events/2026-05-03T17:32:50.166Z__9d6c7fe9-38bf-405c-b37f-ab7cb901fe49.json
+++ b/project/events/2026-05-03T17:32:50.166Z__9d6c7fe9-38bf-405c-b37f-ab7cb901fe49.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9d6c7fe9-38bf-405c-b37f-ab7cb901fe49",
+  "issue_id": "plx-433556f9-4e56-4008-9f53-bbb019ccbb3a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-03T17:32:50.166Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-03T17:41:04.151Z__9be2c88d-a113-4ef9-b75e-cb0c58c68d1b.json
+++ b/project/events/2026-05-03T17:41:04.151Z__9be2c88d-a113-4ef9-b75e-cb0c58c68d1b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9be2c88d-a113-4ef9-b75e-cb0c58c68d1b",
+  "issue_id": "plx-433556f9-4e56-4008-9f53-bbb019ccbb3a",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-03T17:41:04.151Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "66133251-2d9c-4ef6-9a70-3c3c97dc6818"
+  }
+}

--- a/project/events/2026-05-03T17:41:04.165Z__8f962fd3-fe8b-4483-8665-cedd54892cce.json
+++ b/project/events/2026-05-03T17:41:04.165Z__8f962fd3-fe8b-4483-8665-cedd54892cce.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8f962fd3-fe8b-4483-8665-cedd54892cce",
+  "issue_id": "plx-433556f9-4e56-4008-9f53-bbb019ccbb3a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-03T17:41:04.165Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-433556f9-4e56-4008-9f53-bbb019ccbb3a.json
+++ b/project/issues/plx-433556f9-4e56-4008-9f53-bbb019ccbb3a.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-433556f9-4e56-4008-9f53-bbb019ccbb3a",
+  "title": "Show latest chat message timestamp for unnamed sessions",
+  "description": "",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b13120eb-5b86-4098-94e6-422ffc0412a3",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "0739fe56-5556-43e2-af94-01dd198afdd1",
+      "author": "ryan",
+      "text": "Behavior spec:\n\nFeature: Unnamed chat session labels\nScenario: An unnamed chat session has a recent message\nGiven a chat session has no explicit name\nAnd the session has a most-recent message timestamp\nWhen the session appears in the console chat session list or ProcedureTask detail chat UI\nThen the UI shows the standard Timestamp component for that most-recent message instead of a generated Session <id> fallback\n\nScenario: A named chat session is shown\nGiven a chat session has an explicit name\nWhen the session appears in either UI\nThen the name remains the session label.",
+      "created_at": "2026-05-03T17:32:50.149092Z"
+    },
+    {
+      "id": "66133251-2d9c-4ef6-9a70-3c3c97dc6818",
+      "author": "ryan",
+      "text": "Implemented unnamed chat session labels with the standard Timestamp component sourced from the session's most recent loaded message. Removed the square message icon for unnamed timestamp labels, while preserving explicit session names.",
+      "created_at": "2026-05-03T17:41:04.151066Z"
+    }
+  ],
+  "created_at": "2026-05-03T17:32:46.255175Z",
+  "updated_at": "2026-05-03T17:41:04.165453Z",
+  "closed_at": "2026-05-03T17:41:04.165453Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Replace generated `Session <id>` labels for unnamed visible chat sessions with the standard `Timestamp` component.
- Source the timestamp from the most recent loaded message in that session.
- Remove the square message icon when an unnamed session is represented by a timestamp, while preserving explicit session names and their existing icon treatment.

## Kanbus
- Closed `plx-433556`: Show latest chat message timestamp for unnamed sessions.

## Verification
- `cd dashboard && node ./node_modules/jest/bin/jest.js conversation-viewer-session-routing.test.tsx`
- `git diff --check`
- Typecheck was run before the final icon-only adjustment and completed successfully; it was not rerun to completion after the user requested commit/merge without waiting.