### PR TITLE
Console chat deep-link tail follow + streaming flicker guard

### DIFF
--- a/dashboard/components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx
+++ b/dashboard/components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx
@@ -350,6 +350,68 @@ describe("ConversationViewer streaming updates", () => {
     expect(container.querySelectorAll('[data-message-id="msg-assistant-1"]')).toHaveLength(1)
   })
 
+  it("ignores regressive assistant streaming updates that arrive out of order", async () => {
+    render(
+      <ConversationViewer
+        experimentId="proc-1"
+        defaultSidebarCollapsed={false}
+      />
+    )
+
+    await screen.findByText("Hel")
+
+    await act(async () => {
+      subscriptions.messageUpdate?.next({
+        data: {
+          id: "msg-assistant-1",
+          accountId: "acct-1",
+          procedureId: "proc-1",
+          sessionId: "sess-1",
+          role: "ASSISTANT",
+          messageType: "MESSAGE",
+          humanInteraction: "CHAT_ASSISTANT",
+          content: "Hello streaming world",
+          createdAt: "2026-03-27T00:00:01.000Z",
+          sequenceNumber: 1,
+          metadata: JSON.stringify({
+            streaming: {
+              state: "streaming",
+            },
+          }),
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello streaming world")).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      subscriptions.messageUpdate?.next({
+        data: {
+          id: "msg-assistant-1",
+          accountId: "acct-1",
+          procedureId: "proc-1",
+          sessionId: "sess-1",
+          role: "ASSISTANT",
+          messageType: "MESSAGE",
+          humanInteraction: "CHAT_ASSISTANT",
+          content: "Hello",
+          createdAt: "2026-03-27T00:00:01.000Z",
+          sequenceNumber: 1,
+          metadata: JSON.stringify({
+            streaming: {
+              state: "streaming",
+            },
+          }),
+        },
+      })
+    })
+
+    expect(screen.getByText("Hello streaming world")).toBeInTheDocument()
+    expect(screen.queryByText("Hello")).not.toBeInTheDocument()
+  })
+
   it("auto-follows conversation when streaming updates arrive", async () => {
     render(
       <ConversationViewer

--- a/dashboard/components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx
+++ b/dashboard/components/ui/__tests__/conversation-viewer-streaming-updates.test.tsx
@@ -73,6 +73,10 @@ jest.mock("@/utils/data-operations", () => ({
   getClient: () => mockClient,
 }))
 
+jest.mock("@/utils/user-profile", () => ({
+  getCurrentUserAttribution: jest.fn().mockResolvedValue({ createdByUserId: "user-1" }),
+}))
+
 jest.mock("@/components/ai-elements/conversation", () => ({
   Conversation: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   ConversationContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -516,6 +520,7 @@ describe("ConversationViewer streaming updates", () => {
     })
 
     const createdMessage = mockChatMessageCreate.mock.calls[0]?.[0]
+    expect(createdMessage.createdByUserId).toBe("user-1")
     expect(createdMessage.responseTarget).toBe("local:ryan")
     expect(createdMessage.responseStatus).toBe("PENDING")
     const metadata = JSON.parse(createdMessage.metadata)
@@ -735,6 +740,53 @@ describe("ConversationViewer streaming updates", () => {
       expect(screen.getByText("plexus_search input-available")).toBeInTheDocument()
       expect(screen.getByText("plexus_search output-available")).toBeInTheDocument()
       expect(screen.getAllByTestId("tool")).toHaveLength(2)
+    })
+  })
+
+  it("jumps to latest message when opening a deep-linked session", async () => {
+    mockChatMessageList.mockResolvedValue({
+      data: [
+        {
+          id: "msg-older",
+          accountId: "acct-1",
+          procedureId: "proc-1",
+          sessionId: "sess-1",
+          role: "USER",
+          messageType: "MESSAGE",
+          humanInteraction: "CHAT",
+          content: "older",
+          createdAt: "2026-03-27T00:00:01.000Z",
+          sequenceNumber: 1,
+        },
+        {
+          id: "msg-latest",
+          accountId: "acct-1",
+          procedureId: "proc-1",
+          sessionId: "sess-1",
+          role: "ASSISTANT",
+          messageType: "MESSAGE",
+          humanInteraction: "CHAT_ASSISTANT",
+          content: "latest",
+          createdAt: "2026-03-27T00:00:02.000Z",
+          sequenceNumber: 2,
+        },
+      ],
+      nextToken: null,
+    })
+
+    render(
+      <ConversationViewer
+        experimentId="proc-1"
+        defaultSidebarCollapsed={false}
+        selectedSessionId="sess-1"
+      />
+    )
+
+    await screen.findByText("latest")
+    await waitFor(() => {
+      expect(mockScrollToIndex).toHaveBeenCalledWith(
+        expect.objectContaining({ index: "LAST", align: "end", behavior: "auto" })
+      )
     })
   })
 

--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -684,6 +684,33 @@ const isAssistantChatMessage = (message: ChatMessage): boolean => (
   )
 )
 
+const getStreamingState = (metadata: unknown): string | null => {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null
+  }
+  const streaming = (metadata as Record<string, unknown>).streaming
+  if (!streaming || typeof streaming !== 'object' || Array.isArray(streaming)) {
+    return null
+  }
+  const state = (streaming as Record<string, unknown>).state
+  return typeof state === 'string' ? state.toLowerCase() : null
+}
+
+const shouldIgnoreRegressiveAssistantUpdate = (previous: ChatMessage, incoming: ChatMessage): boolean => {
+  if (!isAssistantChatMessage(previous) || !isAssistantChatMessage(incoming)) {
+    return false
+  }
+
+  const previousState = getStreamingState(previous.metadata)
+  if (previousState === 'complete') {
+    return false
+  }
+
+  const previousContentLength = (previous.content || '').length
+  const incomingContentLength = (incoming.content || '').length
+  return incomingContentLength < previousContentLength
+}
+
 const CLIENT_HISTORY_SNAPSHOT_LIMIT = 24
 const CLIENT_HISTORY_SNAPSHOT_MAX_CHARS = 600
 
@@ -2181,6 +2208,9 @@ function ConversationViewer({
 
       const previous = prevMessages[existingIndex]
       if (areMessagesEquivalent(previous, parsed)) {
+        return prevMessages
+      }
+      if (shouldIgnoreRegressiveAssistantUpdate(previous, parsed)) {
         return prevMessages
       }
 

--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from "react"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import { getClient } from '@/utils/data-operations'
 import { formatAmplifyError } from '@/utils/amplify-client'
+import { getCurrentUserAttribution } from '@/utils/user-profile'
 import {
   Conversation,
   ConversationEmptyState,
@@ -1751,6 +1752,7 @@ function ConversationViewer({
       })
       const respondedAt = new Date().toISOString()
       const responseTarget = getConsoleResponseTarget()
+      const attribution = await getCurrentUserAttribution()
       const responseMetadata = {
         control: {
           request_id: control.request_id,
@@ -1777,6 +1779,7 @@ function ConversationViewer({
         responseTarget,
         responseStatus: 'PENDING',
         createdAt: respondedAt,
+        ...attribution,
       })
       const responseMessageId = created?.data?.id
       if (!responseMessageId) {
@@ -2606,6 +2609,28 @@ function ConversationViewer({
   }, [latestConversationRenderSignature, selectedSessionId, shouldForceFollow])
 
   const previousThinkingStateRef = React.useRef(false)
+  const pendingInitialTailJumpSessionRef = React.useRef<string | null>(null)
+
+  useEffect(() => {
+    pendingInitialTailJumpSessionRef.current = selectedSessionId || null
+  }, [selectedSessionId])
+
+  useEffect(() => {
+    const pendingSessionId = pendingInitialTailJumpSessionRef.current
+    if (!pendingSessionId || pendingSessionId !== selectedSessionId || renderRows.length === 0) {
+      return
+    }
+
+    const rafId = window.requestAnimationFrame(() => {
+      virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior: "auto" })
+      pendingInitialTailJumpSessionRef.current = null
+    })
+
+    return () => {
+      window.cancelAnimationFrame(rafId)
+    }
+  }, [renderRows.length, selectedSessionId])
+
   useEffect(() => {
     const transitionedFromThinkingToMessage = previousThinkingStateRef.current && !showThinkingPlaceholder
     previousThinkingStateRef.current = showThinkingPlaceholder
@@ -2799,6 +2824,7 @@ function ConversationViewer({
         let messagePersisted = false
         try {
           const client = getClient()
+          const attribution = await getCurrentUserAttribution()
           const metadata = enableProcedureSteering
             ? {
                 source: 'procedure-steering-input',
@@ -2836,6 +2862,7 @@ function ConversationViewer({
             metadata: JSON.stringify(metadata),
             responseTarget,
             responseStatus: enableProcedureSteering ? 'COMPLETED' : 'PENDING',
+            ...attribution,
           })
 
           const createdMessageId = created?.data?.id


### PR DESCRIPTION
## Summary
- keep console sessions deep-linkable by session id and ensure deep-linked loads jump to the latest message
- add a one-time tail jump on selected session load when rows are present
- reduce streaming text flicker by ignoring regressive assistant chunk updates that arrive out of order

## Testing
- npm test -- conversation-viewer-streaming-updates.test.tsx
- npm test -- console-dashboard.test.tsx
