### PR TITLE
Add scorecard history report gauges

### DIFF
--- a/dashboard/components/blocks/ScorecardHistory.tsx
+++ b/dashboard/components/blocks/ScorecardHistory.tsx
@@ -1,0 +1,594 @@
+"use client";
+
+import React from "react";
+import { downloadData } from "aws-amplify/storage";
+import { DiffEditor, type Monaco } from "@monaco-editor/react";
+import Link from "next/link";
+import { ChevronDown, ChevronRight, Link as LinkIcon } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
+import type { PluggableList } from "unified";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { parseOutputString } from "@/lib/utils";
+import {
+  applyMonacoTheme,
+  configureYamlLanguage,
+  defineCustomMonacoThemes,
+  getCommonMonacoOptions,
+  setupMonacoThemeWatcher,
+} from "@/lib/monaco-theme";
+
+import ReportBlock, { ReportBlockProps, type BlockComponent } from "./ReportBlock";
+
+const markdownPlugins: PluggableList = [remarkGfm, remarkBreaks];
+
+interface ScorecardHistoryDiff {
+  original_version_id?: string | null;
+  modified_version_id?: string | null;
+  original_label?: string | null;
+  modified_label?: string | null;
+  original?: string | null;
+  modified?: string | null;
+  unified_diff?: string | null;
+  has_changes?: boolean;
+}
+
+interface ChampionPromotion {
+  entered_at?: string | null;
+  exited_at?: string | null;
+  previous_champion_version_id?: string | null;
+  next_champion_version_id?: string | null;
+  transition_id?: string | null;
+}
+
+interface ScorecardHistoryVersion {
+  version_id: string;
+  score_id?: string | null;
+  note?: string | null;
+  branch?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  parent_version_id?: string | null;
+  champion_status?: {
+    is_current_champion?: boolean;
+    is_champion_related?: boolean;
+    promotions_in_window?: ChampionPromotion[];
+  };
+  diffs?: {
+    code?: ScorecardHistoryDiff | null;
+    guidelines?: ScorecardHistoryDiff | null;
+  };
+}
+
+interface ScorecardHistoryScore {
+  score_id: string;
+  score_name: string;
+  summary?: string | null;
+  featured_version_count?: number;
+  champion_version_count?: number;
+  versions?: ScorecardHistoryVersion[];
+}
+
+interface ScorecardHistoryData {
+  report_type?: string;
+  block_title?: string;
+  block_description?: string;
+  scope?: "single_score" | "scorecard_all_scores";
+  scorecard_id?: string | null;
+  scorecard_name?: string | null;
+  score_id?: string | null;
+  score_name?: string | null;
+  date_range?: {
+    start: string;
+    end: string;
+  };
+  summary?: {
+    text?: string | null;
+    champion_coverage?: "all" | "none" | "some" | string;
+    featured_version_count?: number;
+    champion_version_count?: number;
+    scores_changed_count?: number;
+  };
+  scores?: ScorecardHistoryScore[];
+  message?: string;
+  warning?: string;
+  error?: string;
+  output_compacted?: boolean;
+  output_attachment?: string;
+}
+
+const shortId = (value?: string | null): string => {
+  if (!value) return "N/A";
+  return value.length > 12 ? value.slice(0, 8) : value;
+};
+
+const formatInteger = (value: number | null | undefined): string => {
+  if (value === null || value === undefined || Number.isNaN(value)) return "0";
+  return Math.round(value).toLocaleString();
+};
+
+const formatDateTime = (value?: string | null): string => {
+  if (!value) return "N/A";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+};
+
+const scoreHref = (scorecardId?: string | null, scoreId?: string | null): string | null => {
+  if (!scorecardId || !scoreId) return null;
+  return `/lab/scorecards/${encodeURIComponent(scorecardId)}/scores/${encodeURIComponent(scoreId)}`;
+};
+
+const scoreVersionHref = (
+  scorecardId?: string | null,
+  scoreId?: string | null,
+  scoreVersionId?: string | null
+): string | null => {
+  if (!scorecardId || !scoreId || !scoreVersionId) return null;
+  return `${scoreHref(scorecardId, scoreId)}/versions/${encodeURIComponent(scoreVersionId)}`;
+};
+
+const RecordLink: React.FC<{ href?: string | null; label: string }> = ({ href, label }) => {
+  if (!href) return null;
+  return (
+    <Link
+      href={href}
+      aria-label={label}
+      title={label}
+      className="inline-flex shrink-0 rounded-sm text-foreground transition-colors hover:bg-card"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <LinkIcon className="h-3.5 w-3.5" />
+    </Link>
+  );
+};
+
+const LinkedShortId: React.FC<{
+  id?: string | null;
+  href?: string | null;
+  label: string;
+}> = ({ id, href, label }) => (
+  <span className="inline-flex min-w-0 items-center gap-1.5">
+    <span className="truncate font-mono">{shortId(id)}</span>
+    {id ? <RecordLink href={href} label={label} /> : null}
+  </span>
+);
+
+const MarkdownText: React.FC<{ children?: string | null; testId?: string }> = ({ children, testId }) => {
+  const text = children?.trim();
+  if (!text) return null;
+  return (
+    <div className="prose prose-sm max-w-none text-foreground dark:prose-invert" data-testid={testId}>
+      <ReactMarkdown remarkPlugins={markdownPlugins}>{text}</ReactMarkdown>
+    </div>
+  );
+};
+
+const handleDiffEditorMount = (_editor: unknown, monaco: Monaco) => {
+  defineCustomMonacoThemes(monaco);
+  applyMonacoTheme(monaco);
+  setupMonacoThemeWatcher(monaco);
+  configureYamlLanguage(monaco);
+};
+
+const coverageLabel = (value?: string | null): string => {
+  if (value === "all") return "All promoted";
+  if (value === "some") return "Some promoted";
+  if (value === "none") return "None promoted";
+  return value || "N/A";
+};
+
+const ChampionBadges: React.FC<{ version: ScorecardHistoryVersion }> = ({ version }) => {
+  const status = version.champion_status || {};
+  const promotionCount = status.promotions_in_window?.length || 0;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      <Badge variant="secondary" className="border-0 bg-card">
+        Starred
+      </Badge>
+      {status.is_current_champion ? (
+        <Badge variant="secondary" className="border-0 bg-green-500/15 text-green-700 dark:text-green-400">
+          Current Champion
+        </Badge>
+      ) : null}
+      {promotionCount > 0 ? (
+        <Badge variant="secondary" className="border-0 bg-blue-500/15 text-blue-700 dark:text-blue-400">
+          Promoted {promotionCount}x
+        </Badge>
+      ) : null}
+    </div>
+  );
+};
+
+const DiffViewer: React.FC<{
+  diff?: ScorecardHistoryDiff | null;
+  language: "yaml" | "markdown";
+  label: string;
+  testId: string;
+}> = ({ diff, language, label, testId }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const original = diff?.original || "";
+  const modified = diff?.modified || "";
+  const hasText = Boolean(original || modified);
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-auto w-full justify-between rounded-lg bg-card px-3 py-2 text-left"
+          aria-expanded={isOpen}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            {isOpen ? (
+              <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+            )}
+            <span className="truncate text-sm font-medium">{label}</span>
+          </span>
+          <span className="ml-3 shrink-0 text-xs text-muted-foreground">
+            {diff?.has_changes ? "Changed" : "No changes"}
+          </span>
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-2 rounded-lg bg-background p-2" data-testid={testId}>
+          <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span>{diff?.original_label || "Parent"}</span>
+            <LinkedShortId id={diff?.original_version_id} label="Open original score version" />
+            <span>to</span>
+            <span>{diff?.modified_label || "Version"}</span>
+            <LinkedShortId id={diff?.modified_version_id} label="Open modified score version" />
+          </div>
+          {isOpen && hasText ? (
+            <div className="h-[420px] overflow-hidden rounded-lg bg-background">
+              <DiffEditor
+                height="100%"
+                language={language}
+                original={original}
+                modified={modified}
+                onMount={handleDiffEditorMount}
+                options={{
+                  ...getCommonMonacoOptions(),
+                  readOnly: true,
+                  renderSideBySide: true,
+                  automaticLayout: true,
+                  minimap: { enabled: false },
+                  scrollBeyondLastLine: false,
+                }}
+              />
+            </div>
+          ) : (
+            <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-lg bg-card p-3 text-xs text-foreground">
+              {diff?.unified_diff || "No diff content available."}
+            </pre>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+const VersionDetails: React.FC<{
+  version: ScorecardHistoryVersion;
+  scorecardId?: string | null;
+  scoreId?: string | null;
+}> = ({ version, scorecardId, scoreId }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const promotions = version.champion_status?.promotions_in_window || [];
+  const versionLink = scoreVersionHref(scorecardId, scoreId, version.version_id);
+  const parentLink = scoreVersionHref(scorecardId, scoreId, version.parent_version_id);
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="rounded-lg bg-background">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-start justify-between gap-3 rounded-lg px-3 py-3 text-left transition-colors hover:bg-card"
+            aria-expanded={isOpen}
+            data-testid={`version-trigger-${version.version_id}`}
+          >
+            <div className="min-w-0 space-y-1">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                {isOpen ? (
+                  <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <span className="font-mono text-xs text-muted-foreground">{shortId(version.version_id)}</span>
+                <span className="text-sm font-medium">{formatDateTime(version.created_at)}</span>
+              </div>
+              {version.note ? (
+                <div className="line-clamp-2 text-sm text-foreground">{version.note}</div>
+              ) : null}
+            </div>
+            <ChampionBadges version={version} />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="space-y-3 px-3 pb-3" data-testid={`version-details-${version.version_id}`}>
+            <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
+              <div>
+                <div className="font-medium text-foreground">Version</div>
+                <LinkedShortId id={version.version_id} href={versionLink} label="Open score version" />
+              </div>
+              <div>
+                <div className="font-medium text-foreground">Parent</div>
+                <LinkedShortId id={version.parent_version_id} href={parentLink} label="Open parent score version" />
+              </div>
+              <div>
+                <div className="font-medium text-foreground">Created</div>
+                <div>{formatDateTime(version.created_at)}</div>
+              </div>
+              <div>
+                <div className="font-medium text-foreground">Branch</div>
+                <div>{version.branch || "N/A"}</div>
+              </div>
+            </div>
+
+            {version.note ? (
+              <div className="rounded-lg bg-card p-3">
+                <div className="mb-1 text-xs font-medium text-muted-foreground">Version Note</div>
+                <MarkdownText>{version.note}</MarkdownText>
+              </div>
+            ) : null}
+
+            {promotions.length > 0 ? (
+              <div className="rounded-lg bg-card p-3">
+                <div className="mb-2 text-xs font-medium text-muted-foreground">Champion Promotions In Window</div>
+                <div className="space-y-1 text-xs text-foreground">
+                  {promotions.map((promotion, index) => (
+                    <div
+                      key={`${version.version_id}-${promotion.entered_at || index}`}
+                      className="grid gap-1 rounded bg-background px-2 py-1 sm:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1fr)]"
+                    >
+                      <div>{formatDateTime(promotion.entered_at)}</div>
+                      <div>Previous: {shortId(promotion.previous_champion_version_id)}</div>
+                      <div>Next: {shortId(promotion.next_champion_version_id)}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="space-y-2">
+              <DiffViewer
+                diff={version.diffs?.code}
+                language="yaml"
+                label="Code Diff"
+                testId={`code-diff-${version.version_id}`}
+              />
+              <DiffViewer
+                diff={version.diffs?.guidelines}
+                language="markdown"
+                label="Guidelines Diff"
+                testId={`guidelines-diff-${version.version_id}`}
+              />
+            </div>
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+};
+
+const ScoreHistorySection: React.FC<{
+  score: ScorecardHistoryScore;
+  scorecardId?: string | null;
+}> = ({ score, scorecardId }) => {
+  const [versionsOpen, setVersionsOpen] = React.useState(false);
+  const versions = Array.isArray(score.versions) ? score.versions : [];
+
+  return (
+    <section className="rounded-lg bg-muted px-3 py-4" data-testid={`score-history-${score.score_id}`}>
+      <div className="space-y-2">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div role="heading" aria-level={3} className="text-lg font-semibold leading-none">
+              {score.score_name}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              {formatInteger(score.featured_version_count)} starred version
+              {score.featured_version_count === 1 ? "" : "s"}
+              {" | "}
+              {formatInteger(score.champion_version_count)} champion-related
+            </div>
+          </div>
+          <LinkedShortId id={score.score_id} href={scoreHref(scorecardId, score.score_id)} label="Open score" />
+        </div>
+        <MarkdownText testId={`score-summary-${score.score_id}`}>
+          {score.summary || "No summary returned for this score."}
+        </MarkdownText>
+      </div>
+
+      <Collapsible open={versionsOpen} onOpenChange={setVersionsOpen}>
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            className="mt-3 h-auto w-full justify-between rounded-lg bg-card px-3 py-2 text-left"
+            aria-expanded={versionsOpen}
+          >
+            <span className="flex items-center gap-2">
+              {versionsOpen ? (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              )}
+              <span className="text-sm font-medium">Score Versions</span>
+            </span>
+            <span className="text-xs text-muted-foreground">{formatInteger(versions.length)}</span>
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-2 space-y-2" data-testid={`version-list-${score.score_id}`}>
+            {versions.map((version) => (
+              <VersionDetails
+                key={version.version_id}
+                version={version}
+                scorecardId={scorecardId}
+                scoreId={score.score_id}
+              />
+            ))}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </section>
+  );
+};
+
+const ScorecardHistory: React.FC<ReportBlockProps> = (props) => {
+  const [loadedOutput, setLoadedOutput] = React.useState<ScorecardHistoryData | null>(null);
+  const [attachmentLoadError, setAttachmentLoadError] = React.useState<string | null>(null);
+  const isProcessing = Boolean((props.config as any)?.isProcessing);
+
+  let parsedOutput: ScorecardHistoryData = {};
+  try {
+    parsedOutput =
+      typeof props.output === "string"
+        ? (parseOutputString(props.output) as ScorecardHistoryData)
+        : ((props.output || {}) as ScorecardHistoryData);
+  } catch {
+    parsedOutput = {};
+  }
+
+  React.useEffect(() => {
+    if (!parsedOutput.output_compacted || !parsedOutput.output_attachment || loadedOutput) return;
+
+    let cancelled = false;
+    setAttachmentLoadError(null);
+
+    (async () => {
+      try {
+        const result = await downloadData({
+          path: parsedOutput.output_attachment!,
+          options: { bucket: "reportBlockDetails" as any },
+        }).result;
+        const text = await result.body.text();
+        if (!cancelled) setLoadedOutput(parseOutputString(text) as ScorecardHistoryData);
+      } catch (error) {
+        if (!cancelled) {
+          setAttachmentLoadError(
+            error instanceof Error ? error.message : "Failed to load compacted output attachment."
+          );
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadedOutput, parsedOutput.output_attachment, parsedOutput.output_compacted]);
+
+  const output = loadedOutput ?? parsedOutput;
+  const scores = React.useMemo(
+    () => (Array.isArray(output.scores) ? output.scores : []),
+    [output.scores]
+  );
+  const isLoadingCompactedOutput =
+    Boolean(parsedOutput.output_compacted) && !loadedOutput && !attachmentLoadError;
+  const hasResolvedData =
+    scores.length > 0 ||
+    Boolean(output.summary) ||
+    Boolean(output.message) ||
+    Boolean(output.error) ||
+    Boolean(output.warning);
+  const title =
+    props.name && !props.name.startsWith("block_")
+      ? props.name
+      : output.block_title || "Scorecard History";
+  const subtitle = output.score_name
+    ? `${output.scorecard_name || "Scorecard"} / ${output.score_name}`
+    : output.scorecard_name || output.block_description;
+
+  if ((isProcessing || isLoadingCompactedOutput) && !hasResolvedData) {
+    return (
+      <ReportBlock
+        {...props}
+        output={output as any}
+        title={title}
+        subtitle={subtitle}
+        subtitleClassName="mt-1 text-lg font-semibold text-foreground"
+        error={attachmentLoadError || output.error}
+        warning={output.warning}
+        dateRange={output.date_range}
+      >
+        <div className="rounded-lg bg-card p-4 text-sm text-foreground">
+          Report block is processing. Scorecard history will appear when computation completes.
+        </div>
+      </ReportBlock>
+    );
+  }
+
+  return (
+    <ReportBlock
+      {...props}
+      output={output as any}
+      title={title}
+      subtitle={subtitle}
+      subtitleClassName="mt-1 text-lg font-semibold text-foreground"
+      error={attachmentLoadError || output.error}
+      warning={output.warning}
+      dateRange={output.date_range}
+    >
+      <div className="space-y-4">
+        <div className="rounded-lg bg-card p-4">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-semibold">History Summary</div>
+            <Badge variant="secondary" className="border-0 bg-background">
+              {coverageLabel(output.summary?.champion_coverage)}
+            </Badge>
+          </div>
+          <MarkdownText testId="scorecard-history-summary">
+            {output.summary?.text || output.message || "No featured score versions were created in the requested time window."}
+          </MarkdownText>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-lg bg-card p-3">
+            <div className="text-xs text-muted-foreground">Scores Changed</div>
+            <div className="text-xl font-semibold">
+              {formatInteger(output.summary?.scores_changed_count ?? scores.length)}
+            </div>
+          </div>
+          <div className="rounded-lg bg-card p-3">
+            <div className="text-xs text-muted-foreground">Starred Versions</div>
+            <div className="text-xl font-semibold">{formatInteger(output.summary?.featured_version_count)}</div>
+          </div>
+          <div className="rounded-lg bg-card p-3">
+            <div className="text-xs text-muted-foreground">Champion Related</div>
+            <div className="text-xl font-semibold">{formatInteger(output.summary?.champion_version_count)}</div>
+          </div>
+          <div className="rounded-lg bg-card p-3">
+            <div className="text-xs text-muted-foreground">Champion Coverage</div>
+            <div className="text-xl font-semibold">{coverageLabel(output.summary?.champion_coverage)}</div>
+          </div>
+        </div>
+
+        {scores.length > 0 ? (
+          <div className="space-y-4">
+            {scores.map((score) => (
+              <ScoreHistorySection key={score.score_id} score={score} scorecardId={output.scorecard_id} />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg bg-card p-4 text-sm text-foreground">
+            {output.message || "No featured score versions found in the requested time window."}
+          </div>
+        )}
+      </div>
+    </ReportBlock>
+  );
+};
+
+(ScorecardHistory as BlockComponent).blockClass = "ScorecardHistory";
+
+export default ScorecardHistory;

--- a/dashboard/components/blocks/ScorecardHistory.tsx
+++ b/dashboard/components/blocks/ScorecardHistory.tsx
@@ -13,6 +13,10 @@ import type { PluggableList } from "unified";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Gauge } from "@/components/gauge";
+import { ac1GaugeSegments } from "@/components/ui/scorecard-evaluation";
+import { GaugeThresholdComputer } from "@/utils/gauge-thresholds";
 import { parseOutputString } from "@/lib/utils";
 import {
   applyMonacoTheme,
@@ -25,6 +29,12 @@ import {
 import ReportBlock, { ReportBlockProps, type BlockComponent } from "./ReportBlock";
 
 const markdownPlugins: PluggableList = [remarkGfm, remarkBreaks];
+
+const accuracyGaugeSegments = GaugeThresholdComputer.createSegments(
+  GaugeThresholdComputer.computeThresholds({})
+);
+
+type MetricName = "alignment" | "accuracy" | "precision" | "recall";
 
 interface ScorecardHistoryDiff {
   original_version_id?: string | null;
@@ -71,6 +81,47 @@ interface ScorecardHistoryScore {
   featured_version_count?: number;
   champion_version_count?: number;
   versions?: ScorecardHistoryVersion[];
+  performance?: ScorecardHistoryPerformance | null;
+  window_diff?: ScorecardHistoryWindowDiff | null;
+}
+
+interface ScorecardHistoryWindowDiff {
+  baseline_version_id?: string | null;
+  latest_version_id?: string | null;
+  baseline_created_at?: string | null;
+  latest_created_at?: string | null;
+  code?: ScorecardHistoryDiff | null;
+  guidelines?: ScorecardHistoryDiff | null;
+}
+
+interface EvaluationMetricValues {
+  alignment?: number | null;
+  accuracy?: number | null;
+  precision?: number | null;
+  recall?: number | null;
+}
+
+interface EvaluationMetricPayload {
+  evaluation_id?: string | null;
+  evaluation_type?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  processed_items?: number | null;
+  total_items?: number | null;
+  dataset_id?: string | null;
+  metrics?: EvaluationMetricValues | null;
+}
+
+interface PerformanceDatasetPayload {
+  current?: EvaluationMetricPayload | null;
+  baseline?: EvaluationMetricPayload | null;
+}
+
+interface ScorecardHistoryPerformance {
+  current_version_id?: string | null;
+  baseline_version_id?: string | null;
+  recent_feedback?: PerformanceDatasetPayload | null;
+  regression?: PerformanceDatasetPayload | null;
 }
 
 interface ScorecardHistoryData {
@@ -116,6 +167,16 @@ const formatDateTime = (value?: string | null): string => {
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
   return parsed.toLocaleString();
+};
+
+const finiteNumber = (value?: number | null): number | undefined => {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+};
+
+const formatMetricValue = (value: number | undefined, metric: MetricName): string => {
+  if (value === undefined) return "N/A";
+  if (metric === "alignment") return value.toFixed(2);
+  return `${value.toFixed(1)}%`;
 };
 
 const scoreHref = (scorecardId?: string | null, scoreId?: string | null): string | null => {
@@ -180,6 +241,23 @@ const coverageLabel = (value?: string | null): string => {
   if (value === "some") return "Some promoted";
   if (value === "none") return "None promoted";
   return value || "N/A";
+};
+
+const diffChanged = (version: ScorecardHistoryVersion, kind: "code" | "guidelines"): boolean => {
+  return Boolean(version.diffs?.[kind]?.has_changes);
+};
+
+const notePreview = (note?: string | null): string => {
+  const cleaned = (note || "").replace(/\s+/g, " ").trim();
+  if (!cleaned) return "No version note provided.";
+  return cleaned.length > 260 ? `${cleaned.slice(0, 257).trim()}...` : cleaned;
+};
+
+const scorePerformanceKinds = (performance?: ScorecardHistoryPerformance | null): string[] => {
+  const kinds = [];
+  if (performance?.recent_feedback?.current) kinds.push("recent feedback");
+  if (performance?.regression?.current) kinds.push("regression");
+  return kinds;
 };
 
 const ChampionBadges: React.FC<{ version: ScorecardHistoryVersion }> = ({ version }) => {
@@ -380,34 +458,328 @@ const VersionDetails: React.FC<{
   );
 };
 
+const metricConfigs: Array<{
+  key: MetricName;
+  title: string;
+  min: number;
+  max: number;
+  unit: string;
+  decimalPlaces: number;
+}> = [
+  { key: "alignment", title: "Alignment", min: -1, max: 1, unit: "", decimalPlaces: 2 },
+  { key: "accuracy", title: "Accuracy", min: 0, max: 100, unit: "%", decimalPlaces: 1 },
+  { key: "precision", title: "Precision", min: 0, max: 100, unit: "%", decimalPlaces: 1 },
+  { key: "recall", title: "Recall", min: 0, max: 100, unit: "%", decimalPlaces: 1 },
+];
+
+const PerformanceGaugeCard: React.FC<{
+  metric: MetricName;
+  title: string;
+  current?: number;
+  baseline?: number;
+  min: number;
+  max: number;
+  unit: string;
+  decimalPlaces: number;
+}> = ({ metric, title, current, baseline, min, max, unit, decimalPlaces }) => {
+  if (current === undefined) return null;
+  const hasBaseline = baseline !== undefined;
+  const segments = metric === "alignment" ? ac1GaugeSegments : accuracyGaugeSegments;
+
+  return (
+    <div className="rounded-lg bg-background p-2" data-testid={`history-gauge-${metric}`}>
+      <div className="mb-1 flex items-baseline justify-between gap-2 text-xs">
+        <div className="font-medium text-foreground">{title}</div>
+        <div className="text-muted-foreground">{formatMetricValue(current, metric)}</div>
+      </div>
+      <div className="mx-auto w-[145px]">
+        <Gauge
+          value={current}
+          beforeValue={baseline}
+          showComparisonLabel={hasBaseline}
+          title={title}
+          min={min}
+          max={max}
+          valueUnit={unit}
+          decimalPlaces={decimalPlaces}
+          segments={segments}
+          showOnlyEssentialTicks
+        />
+      </div>
+      {hasBaseline ? (
+        <div className="mt-1 text-center text-[11px] text-muted-foreground" data-testid={`history-baseline-${metric}`}>
+          Baseline {formatMetricValue(baseline, metric)}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const PerformanceGaugeGrid: React.FC<{
+  payload: PerformanceDatasetPayload;
+  label: string;
+}> = ({ payload, label }) => {
+  const currentMetrics = payload.current?.metrics || {};
+  const baselineMetrics = payload.baseline?.metrics || {};
+
+  return (
+    <div className="space-y-2" data-testid={`performance-gauges-${label.toLowerCase().replace(/\s+/g, "-")}`}>
+      <div className="grid grid-cols-2 gap-2">
+        {metricConfigs.map((config) => (
+          <PerformanceGaugeCard
+            key={config.key}
+            metric={config.key}
+            title={config.title}
+            current={finiteNumber(currentMetrics[config.key])}
+            baseline={finiteNumber(baselineMetrics[config.key])}
+            min={config.min}
+            max={config.max}
+            unit={config.unit}
+            decimalPlaces={config.decimalPlaces}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const PerformancePanel: React.FC<{ performance?: ScorecardHistoryPerformance | null }> = ({ performance }) => {
+  const datasets = [
+    performance?.recent_feedback?.current ? {
+      key: "recent-feedback",
+      label: "Recent Feedback",
+      payload: performance.recent_feedback,
+    } : null,
+    performance?.regression?.current ? {
+      key: "regression",
+      label: "Regression",
+      payload: performance.regression,
+    } : null,
+  ].filter(Boolean) as Array<{ key: string; label: string; payload: PerformanceDatasetPayload }>;
+
+  if (datasets.length === 0) return null;
+
+  return (
+    <aside className="rounded-lg bg-card p-3" data-testid="score-performance-panel">
+      <div className="mb-2 text-sm font-semibold">Evaluation Metrics</div>
+      {datasets.length === 1 ? (
+        <PerformanceGaugeGrid payload={datasets[0].payload} label={datasets[0].label} />
+      ) : (
+        <Tabs defaultValue={datasets[0].key}>
+          <TabsList className="mb-3 h-auto justify-start bg-transparent p-0">
+            {datasets.map((dataset) => (
+              <TabsTrigger
+                key={dataset.key}
+                value={dataset.key}
+                className="rounded-none border-b-2 border-transparent bg-transparent px-3 py-2 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+              >
+                {dataset.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {datasets.map((dataset) => (
+            <TabsContent key={dataset.key} value={dataset.key} className="mt-0">
+              <PerformanceGaugeGrid payload={dataset.payload} label={dataset.label} />
+            </TabsContent>
+          ))}
+        </Tabs>
+      )}
+    </aside>
+  );
+};
+
+const InterventionSummary: React.FC<{
+  score: ScorecardHistoryScore;
+  versions: ScorecardHistoryVersion[];
+}> = ({ score, versions }) => {
+  const codeChangeCount = versions.filter((version) => diffChanged(version, "code")).length;
+  const guidelineChangeCount = versions.filter((version) => diffChanged(version, "guidelines")).length;
+  const championRelatedCount = versions.filter((version) => version.champion_status?.is_champion_related).length;
+  const currentChampion = versions.find((version) => version.champion_status?.is_current_champion);
+  const performanceKinds = scorePerformanceKinds(score.performance);
+
+  const items = [
+    {
+      label: "Guidelines",
+      value: guidelineChangeCount,
+      detail: guidelineChangeCount > 0
+        ? `${guidelineChangeCount} starred version${guidelineChangeCount === 1 ? "" : "s"} changed rubric guidance.`
+        : "No guideline diff was detected in the included versions.",
+    },
+    {
+      label: "Code",
+      value: codeChangeCount,
+      detail: codeChangeCount > 0
+        ? `${codeChangeCount} starred version${codeChangeCount === 1 ? "" : "s"} changed score configuration.`
+        : "No code/config diff was detected in the included versions.",
+    },
+    {
+      label: "Champion",
+      value: championRelatedCount,
+      detail: currentChampion
+        ? `${championRelatedCount} champion-related; latest current champion is ${shortId(currentChampion.version_id)}.`
+        : `${championRelatedCount} champion-related version${championRelatedCount === 1 ? "" : "s"} in this window.`,
+    },
+    {
+      label: "Evaluations",
+      value: performanceKinds.length,
+      detail: performanceKinds.length > 0
+        ? `Gauge data available for ${performanceKinds.join(" and ")}.`
+        : "No completed evaluation gauges were found for the latest included version.",
+    },
+  ];
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4" data-testid={`intervention-summary-${score.score_id}`}>
+      {items.map((item) => (
+        <div key={item.label} className="rounded-lg bg-card p-3">
+          <div className="mb-1 flex items-baseline justify-between gap-2">
+            <div className="text-xs font-medium text-muted-foreground">{item.label}</div>
+            <div className="text-lg font-semibold text-foreground">{formatInteger(item.value)}</div>
+          </div>
+          <div className="text-xs leading-snug text-foreground">{item.detail}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const ChangeNotesBrief: React.FC<{ versions: ScorecardHistoryVersion[] }> = ({ versions }) => {
+  const notes = versions
+    .filter((version) => (version.note || "").trim())
+    .slice(0, 6);
+  const remainingCount = Math.max(0, versions.filter((version) => (version.note || "").trim()).length - notes.length);
+
+  if (notes.length === 0) return null;
+
+  return (
+    <div className="rounded-lg bg-card p-3" data-testid="change-notes-brief">
+      <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">Change Notes</div>
+      <ul className="space-y-2">
+        {notes.map((version) => (
+          <li key={version.version_id} className="grid gap-1 text-sm leading-snug sm:grid-cols-[7.5rem_minmax(0,1fr)]">
+            <span className="font-mono text-xs text-muted-foreground">{formatDateTime(version.created_at)}</span>
+            <span className="text-foreground">{notePreview(version.note)}</span>
+          </li>
+        ))}
+      </ul>
+      {remainingCount > 0 ? (
+        <div className="mt-2 text-xs text-muted-foreground">
+          {remainingCount} more note{remainingCount === 1 ? "" : "s"} available in Score Versions.
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const WindowDiffSection: React.FC<{
+  windowDiff?: ScorecardHistoryWindowDiff | null;
+}> = ({ windowDiff }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  if (!windowDiff) return null;
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          className="mt-3 h-auto w-full justify-between rounded-lg bg-card px-3 py-2 text-left"
+          aria-expanded={isOpen}
+          data-testid="window-diff-trigger"
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            {isOpen ? (
+              <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+            )}
+            <span className="truncate text-sm font-medium">Full Window Diff</span>
+          </span>
+          <span className="ml-3 shrink-0 text-xs text-muted-foreground">
+            {shortId(windowDiff.baseline_version_id)} to {shortId(windowDiff.latest_version_id)}
+          </span>
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-2 space-y-2 rounded-lg bg-background p-3" data-testid="window-diff-content">
+          <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+            <div>
+              <div className="font-medium text-foreground">Pre-window version</div>
+              <div className="font-mono">{shortId(windowDiff.baseline_version_id)}</div>
+              <div>{formatDateTime(windowDiff.baseline_created_at)}</div>
+            </div>
+            <div>
+              <div className="font-medium text-foreground">Latest included version</div>
+              <div className="font-mono">{shortId(windowDiff.latest_version_id)}</div>
+              <div>{formatDateTime(windowDiff.latest_created_at)}</div>
+            </div>
+          </div>
+          <DiffViewer
+            diff={windowDiff.code}
+            language="yaml"
+            label="Full Code Diff"
+            testId="window-code-diff"
+          />
+          <DiffViewer
+            diff={windowDiff.guidelines}
+            language="markdown"
+            label="Full Guidelines Diff"
+            testId="window-guidelines-diff"
+          />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
 const ScoreHistorySection: React.FC<{
   score: ScorecardHistoryScore;
   scorecardId?: string | null;
 }> = ({ score, scorecardId }) => {
   const [versionsOpen, setVersionsOpen] = React.useState(false);
   const versions = Array.isArray(score.versions) ? score.versions : [];
+  const hasPerformance =
+    Boolean(score.performance?.recent_feedback?.current) ||
+    Boolean(score.performance?.regression?.current);
 
   return (
     <section className="rounded-lg bg-muted px-3 py-4" data-testid={`score-history-${score.score_id}`}>
-      <div className="space-y-2">
-        <div className="flex min-w-0 items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div role="heading" aria-level={3} className="text-lg font-semibold leading-none">
-              {score.score_name}
+      <div className="flex flex-wrap gap-4">
+        <div className="min-w-[min(100%,30rem)] flex-[999_1_30rem] space-y-3">
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div role="heading" aria-level={3} className="text-lg font-semibold leading-none">
+                {score.score_name}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {formatInteger(score.featured_version_count)} starred version
+                {score.featured_version_count === 1 ? "" : "s"}
+                {" | "}
+                {formatInteger(score.champion_version_count)} champion-related
+              </div>
             </div>
-            <div className="mt-1 text-xs text-muted-foreground">
-              {formatInteger(score.featured_version_count)} starred version
-              {score.featured_version_count === 1 ? "" : "s"}
-              {" | "}
-              {formatInteger(score.champion_version_count)} champion-related
-            </div>
+            <LinkedShortId id={score.score_id} href={scoreHref(scorecardId, score.score_id)} label="Open score" />
           </div>
-          <LinkedShortId id={score.score_id} href={scoreHref(scorecardId, score.score_id)} label="Open score" />
+          <div className="rounded-lg bg-card p-3">
+            <div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">Overview</div>
+            <MarkdownText testId={`score-summary-${score.score_id}`}>
+              {score.summary || "No summary returned for this score."}
+            </MarkdownText>
+          </div>
+          <InterventionSummary score={score} versions={versions} />
         </div>
-        <MarkdownText testId={`score-summary-${score.score_id}`}>
-          {score.summary || "No summary returned for this score."}
-        </MarkdownText>
+        {hasPerformance ? (
+          <div className="min-w-[min(100%,20rem)] flex-[1_1_20rem]">
+            <PerformancePanel performance={score.performance} />
+          </div>
+        ) : null}
+        <div className="min-w-0 basis-full">
+          <ChangeNotesBrief versions={versions} />
+        </div>
       </div>
+
+      <WindowDiffSection windowDiff={score.window_diff} />
 
       <Collapsible open={versionsOpen} onOpenChange={setVersionsOpen}>
         <CollapsibleTrigger asChild>

--- a/dashboard/components/blocks/__tests__/ScorecardHistory.test.tsx
+++ b/dashboard/components/blocks/__tests__/ScorecardHistory.test.tsx
@@ -1,0 +1,181 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ScorecardHistory from "@/components/blocks/ScorecardHistory";
+
+const mockDownloadData = jest.fn();
+
+jest.mock("aws-amplify/storage", () => ({
+  downloadData: (...args: any[]) => mockDownloadData(...args),
+}));
+
+jest.mock("@monaco-editor/react", () => ({
+  DiffEditor: ({ language, original, modified }: any) => (
+    <div data-testid={`diff-editor-${language}`} data-original={original} data-modified={modified} />
+  ),
+}));
+
+jest.mock("@/components/blocks/ReportBlock", () => {
+  const MockReportBlock = ({ title, subtitle, subtitleClassName, children }: any) => (
+    <div>
+      <div>{title}</div>
+      {subtitle ? <div data-testid="report-subtitle" className={subtitleClassName}>{subtitle}</div> : null}
+      {children}
+    </div>
+  );
+  return {
+    __esModule: true,
+    default: MockReportBlock,
+  };
+});
+
+describe("ScorecardHistory", () => {
+  beforeEach(() => {
+    mockDownloadData.mockReset();
+  });
+
+  const output = {
+    report_type: "scorecard_history",
+    block_title: "Scorecard History",
+    block_description: "Featured score-version changes and champion promotion status",
+    scope: "scorecard_all_scores",
+    scorecard_id: "scorecard-1",
+    scorecard_name: "Select Quote HCS Medium Risk",
+    date_range: {
+      start: "2026-04-25T00:00:00+00:00",
+      end: "2026-05-05T00:00:00+00:00",
+    },
+    summary: {
+      text: "Overall history summary. Some included changes were promoted to champion.",
+      champion_coverage: "some",
+      featured_version_count: 1,
+      champion_version_count: 1,
+      scores_changed_count: 1,
+    },
+    scores: [
+      {
+        score_id: "score-1",
+        score_name: "Agent Misrepresentation",
+        summary: "The score tightened its routing criteria.",
+        featured_version_count: 1,
+        champion_version_count: 1,
+        versions: [
+          {
+            version_id: "version-1",
+            score_id: "score-1",
+            note: "Tightened routing criteria for transfer cases.",
+            branch: "optimizer",
+            created_at: "2026-05-01T12:00:00+00:00",
+            updated_at: "2026-05-01T12:00:00+00:00",
+            parent_version_id: "version-0",
+            champion_status: {
+              is_current_champion: true,
+              is_champion_related: true,
+              promotions_in_window: [
+                {
+                  entered_at: "2026-05-02T12:00:00+00:00",
+                  previous_champion_version_id: "version-0",
+                  next_champion_version_id: null,
+                },
+              ],
+            },
+            diffs: {
+              code: {
+                original_version_id: "version-0",
+                modified_version_id: "version-1",
+                original_label: "Parent Code",
+                modified_label: "Version Code",
+                original: "name: old\n",
+                modified: "name: new\n",
+                unified_diff: "--- version-0/configuration\n+++ version-1/configuration\n-name: old\n+name: new",
+                has_changes: true,
+              },
+              guidelines: {
+                original_version_id: "version-0",
+                modified_version_id: "version-1",
+                original_label: "Parent Guidelines",
+                modified_label: "Version Guidelines",
+                original: "# Old\n",
+                modified: "# New\n",
+                unified_diff: "--- version-0/guidelines\n+++ version-1/guidelines\n-# Old\n+# New",
+                has_changes: true,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const baseProps = {
+    id: "block-1",
+    config: {},
+    output,
+    log: undefined,
+    name: "Scorecard History",
+    position: 1,
+    type: "ScorecardHistory",
+    attachedFiles: [],
+  };
+
+  it("shows top and score summaries while keeping versions and diffs collapsed by default", () => {
+    render(<ScorecardHistory {...baseProps} />);
+
+    expect(screen.getByText("Scorecard History")).toBeInTheDocument();
+    expect(screen.getByTestId("report-subtitle")).toHaveTextContent("Select Quote HCS Medium Risk");
+    expect(screen.getByTestId("scorecard-history-summary")).toHaveTextContent("Overall history summary");
+    expect(screen.getByTestId("score-summary-score-1")).toHaveTextContent("tightened its routing criteria");
+    expect(screen.queryByTestId("version-list-score-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("version-details-version-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("diff-editor-yaml")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("diff-editor-markdown")).not.toBeInTheDocument();
+  });
+
+  it("renders Monaco diffs only after expanding the score, version, and diff", () => {
+    render(<ScorecardHistory {...baseProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Score Versions/i }));
+    expect(screen.getByTestId("version-list-score-1")).toBeInTheDocument();
+    expect(screen.getByTestId("version-trigger-version-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("version-details-version-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("diff-editor-yaml")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("version-trigger-version-1"));
+    expect(screen.getByTestId("version-details-version-1")).toBeInTheDocument();
+    expect(screen.getByText("Version Note")).toBeInTheDocument();
+    expect(screen.queryByTestId("diff-editor-yaml")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Code Diff/i }));
+    expect(screen.getByTestId("code-diff-version-1")).toBeInTheDocument();
+    expect(screen.getByTestId("diff-editor-yaml")).toHaveAttribute("data-original", "name: old\n");
+    expect(screen.getByTestId("diff-editor-yaml")).toHaveAttribute("data-modified", "name: new\n");
+  });
+
+  it("loads compacted output from the report block details attachment", async () => {
+    mockDownloadData.mockReturnValue({
+      result: Promise.resolve({
+        body: {
+          text: () => Promise.resolve(JSON.stringify(output)),
+        },
+      }),
+    });
+
+    render(
+      <ScorecardHistory
+        {...baseProps}
+        output={{
+          output_compacted: true,
+          output_attachment: "reportblocks/block-1/output-block-1.json",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scorecard-history-summary")).toHaveTextContent("Overall history summary");
+    });
+    expect(mockDownloadData).toHaveBeenCalledWith({
+      path: "reportblocks/block-1/output-block-1.json",
+      options: { bucket: "reportBlockDetails" },
+    });
+  });
+});

--- a/dashboard/components/blocks/__tests__/ScorecardHistory.test.tsx
+++ b/dashboard/components/blocks/__tests__/ScorecardHistory.test.tsx
@@ -15,6 +15,24 @@ jest.mock("@monaco-editor/react", () => ({
   ),
 }));
 
+jest.mock("@/components/gauge", () => ({
+  Gauge: ({ title, value, beforeValue, showComparisonLabel }: any) => (
+    <div
+      data-testid={`gauge-${String(title).toLowerCase()}`}
+      data-value={value}
+      data-before-value={beforeValue}
+      data-show-comparison={String(Boolean(showComparisonLabel))}
+    />
+  ),
+}));
+
+jest.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: any) => <div>{children}</div>,
+  TabsContent: ({ children }: any) => <div>{children}</div>,
+  TabsList: ({ children }: any) => <div>{children}</div>,
+  TabsTrigger: ({ children, ...props }: any) => <button type="button" {...props}>{children}</button>,
+}));
+
 jest.mock("@/components/blocks/ReportBlock", () => {
   const MockReportBlock = ({ title, subtitle, subtitleClassName, children }: any) => (
     <div>
@@ -59,6 +77,32 @@ describe("ScorecardHistory", () => {
         summary: "The score tightened its routing criteria.",
         featured_version_count: 1,
         champion_version_count: 1,
+        window_diff: {
+          baseline_version_id: "version-0",
+          latest_version_id: "version-1",
+          baseline_created_at: "2026-04-24T12:00:00+00:00",
+          latest_created_at: "2026-05-01T12:00:00+00:00",
+          code: {
+            original_version_id: "version-0",
+            modified_version_id: "version-1",
+            original_label: "Pre-window Code",
+            modified_label: "Latest Code",
+            original: "name: old\n",
+            modified: "name: new\n",
+            unified_diff: "--- version-0/configuration\n+++ version-1/configuration\n-name: old\n+name: new",
+            has_changes: true,
+          },
+          guidelines: {
+            original_version_id: "version-0",
+            modified_version_id: "version-1",
+            original_label: "Pre-window Guidelines",
+            modified_label: "Latest Guidelines",
+            original: "# Old\n",
+            modified: "# New\n",
+            unified_diff: "--- version-0/guidelines\n+++ version-1/guidelines\n-# Old\n+# New",
+            has_changes: true,
+          },
+        },
         versions: [
           {
             version_id: "version-1",
@@ -118,6 +162,12 @@ describe("ScorecardHistory", () => {
     attachedFiles: [],
   };
 
+  const withPerformance = (performance: any) => {
+    const cloned = JSON.parse(JSON.stringify(output));
+    cloned.scores[0].performance = performance;
+    return cloned;
+  };
+
   it("shows top and score summaries while keeping versions and diffs collapsed by default", () => {
     render(<ScorecardHistory {...baseProps} />);
 
@@ -125,10 +175,17 @@ describe("ScorecardHistory", () => {
     expect(screen.getByTestId("report-subtitle")).toHaveTextContent("Select Quote HCS Medium Risk");
     expect(screen.getByTestId("scorecard-history-summary")).toHaveTextContent("Overall history summary");
     expect(screen.getByTestId("score-summary-score-1")).toHaveTextContent("tightened its routing criteria");
+    expect(screen.getByTestId("intervention-summary-score-1")).toHaveTextContent("Guidelines");
+    expect(screen.getByTestId("intervention-summary-score-1")).toHaveTextContent("Code");
+    expect(screen.getByTestId("intervention-summary-score-1")).toHaveTextContent("Champion");
+    expect(screen.getByTestId("intervention-summary-score-1")).toHaveTextContent("Evaluations");
+    expect(screen.getByTestId("change-notes-brief")).toHaveTextContent("Tightened routing criteria for transfer cases.");
     expect(screen.queryByTestId("version-list-score-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("window-diff-content")).not.toBeInTheDocument();
     expect(screen.queryByTestId("version-details-version-1")).not.toBeInTheDocument();
     expect(screen.queryByTestId("diff-editor-yaml")).not.toBeInTheDocument();
     expect(screen.queryByTestId("diff-editor-markdown")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("score-performance-panel")).not.toBeInTheDocument();
   });
 
   it("renders Monaco diffs only after expanding the score, version, and diff", () => {
@@ -147,6 +204,19 @@ describe("ScorecardHistory", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Code Diff/i }));
     expect(screen.getByTestId("code-diff-version-1")).toBeInTheDocument();
+    expect(screen.getByTestId("diff-editor-yaml")).toHaveAttribute("data-original", "name: old\n");
+    expect(screen.getByTestId("diff-editor-yaml")).toHaveAttribute("data-modified", "name: new\n");
+  });
+
+  it("renders full window diffs only after expanding the window diff and diff panel", () => {
+    render(<ScorecardHistory {...baseProps} />);
+
+    fireEvent.click(screen.getByTestId("window-diff-trigger"));
+    expect(screen.getByTestId("window-diff-content")).toBeInTheDocument();
+    expect(screen.queryByTestId("diff-editor-yaml")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Full Code Diff/i }));
+    expect(screen.getByTestId("window-code-diff")).toBeInTheDocument();
     expect(screen.getByTestId("diff-editor-yaml")).toHaveAttribute("data-original", "name: old\n");
     expect(screen.getByTestId("diff-editor-yaml")).toHaveAttribute("data-modified", "name: new\n");
   });
@@ -177,5 +247,107 @@ describe("ScorecardHistory", () => {
       path: "reportblocks/block-1/output-block-1.json",
       options: { bucket: "reportBlockDetails" },
     });
+  });
+
+  it("renders one evaluation kind as gauges without tabs", () => {
+    render(
+      <ScorecardHistory
+        {...baseProps}
+        output={withPerformance({
+          current_version_id: "version-1",
+          baseline_version_id: "version-0",
+          recent_feedback: {
+            current: {
+              evaluation_id: "eval-current",
+              metrics: {
+                alignment: 0.74,
+                accuracy: 88.2,
+                precision: 91.1,
+                recall: 84.4,
+              },
+            },
+            baseline: {
+              evaluation_id: "eval-baseline",
+              metrics: {
+                alignment: 0.61,
+                accuracy: 80.1,
+                precision: 86.3,
+                recall: 70.5,
+              },
+            },
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId("score-performance-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("performance-gauges-recent-feedback")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Recent Feedback" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("gauge-alignment")).toHaveAttribute("data-value", "0.74");
+    expect(screen.getByTestId("gauge-alignment")).toHaveAttribute("data-before-value", "0.61");
+    expect(screen.getByTestId("gauge-alignment")).toHaveAttribute("data-show-comparison", "true");
+    expect(screen.getByTestId("gauge-accuracy")).toHaveAttribute("data-value", "88.2");
+    expect(screen.getByTestId("gauge-precision")).toHaveAttribute("data-value", "91.1");
+    expect(screen.getByTestId("gauge-recall")).toHaveAttribute("data-value", "84.4");
+  });
+
+  it("renders tabs when recent feedback and regression metrics both exist", () => {
+    render(
+      <ScorecardHistory
+        {...baseProps}
+        output={withPerformance({
+          current_version_id: "version-1",
+          baseline_version_id: "version-0",
+          recent_feedback: {
+            current: {
+              evaluation_id: "eval-feedback-current",
+              metrics: { alignment: 0.74, accuracy: 88.2, precision: 91.1, recall: 84.4 },
+            },
+          },
+          regression: {
+            current: {
+              evaluation_id: "eval-regression-current",
+              dataset_id: "dataset-1",
+              metrics: { alignment: 0.7, accuracy: 85.4, precision: 90.2, recall: 79.1 },
+            },
+            baseline: {
+              evaluation_id: "eval-regression-baseline",
+              dataset_id: "dataset-1",
+              metrics: { alignment: 0.6, accuracy: 81.4, precision: 88.2, recall: 71.1 },
+            },
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Recent Feedback" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Regression" })).toBeInTheDocument();
+    expect(screen.getByTestId("performance-gauges-recent-feedback")).toBeInTheDocument();
+    expect(screen.getByTestId("performance-gauges-regression")).toBeInTheDocument();
+    expect(screen.getAllByTestId("gauge-alignment")[1]).toHaveAttribute("data-before-value", "0.6");
+  });
+
+  it("does not show baseline needles when baseline metrics are absent", () => {
+    render(
+      <ScorecardHistory
+        {...baseProps}
+        output={withPerformance({
+          current_version_id: "version-1",
+          baseline_version_id: "version-0",
+          regression: {
+            current: {
+              evaluation_id: "eval-regression-current",
+              dataset_id: "dataset-1",
+              metrics: { alignment: 0.7, accuracy: 85.4, precision: 90.2, recall: 79.1 },
+            },
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByTestId("performance-gauges-regression")).toBeInTheDocument();
+    expect(screen.getByTestId("gauge-alignment")).not.toHaveAttribute("data-before-value");
+    expect(screen.getByTestId("gauge-alignment")).toHaveAttribute("data-show-comparison", "false");
+    expect(screen.queryByTestId("history-baseline-alignment")).not.toBeInTheDocument();
   });
 });

--- a/dashboard/components/blocks/index.ts
+++ b/dashboard/components/blocks/index.ts
@@ -20,6 +20,7 @@ export { default as AcceptanceRate } from './AcceptanceRate';
 export { default as AcceptanceRateTimeline } from './AcceptanceRateTimeline';
 export { default as RecentFeedback } from './RecentFeedback';
 export { default as ScoreChampionVersionTimeline } from './ScoreChampionVersionTimeline';
+export { default as ScorecardHistory } from './ScorecardHistory';
 export { BlockRenderer } from './BlockRegistry';
 export type { BlockRendererProps } from './BlockRegistry';
 export { getBlock, hasBlock, getRegisteredBlockTypes } from './BlockRegistry';

--- a/dashboard/components/blocks/registrySetup.ts
+++ b/dashboard/components/blocks/registrySetup.ts
@@ -25,6 +25,7 @@ import AcceptanceRate from './AcceptanceRate';
 import AcceptanceRateTimeline from './AcceptanceRateTimeline';
 import RecentFeedback from './RecentFeedback';
 import ScoreChampionVersionTimeline from './ScoreChampionVersionTimeline';
+import ScorecardHistory from './ScorecardHistory';
 
 // Register all block components
 // Register the default block handler first
@@ -49,3 +50,4 @@ registerBlock('AcceptanceRate', AcceptanceRate as BlockComponent);
 registerBlock('AcceptanceRateTimeline', AcceptanceRateTimeline as BlockComponent);
 registerBlock('RecentFeedback', RecentFeedback as BlockComponent);
 registerBlock('ScoreChampionVersionTimeline', ScoreChampionVersionTimeline as BlockComponent);
+registerBlock('ScorecardHistory', ScorecardHistory as BlockComponent);

--- a/plexus/cli/feedback/feedback_report.py
+++ b/plexus/cli/feedback/feedback_report.py
@@ -700,6 +700,66 @@ def score_champion_version_timeline(
     )
 
 
+@report.command(name="scorecard-history")
+@click.option("--scorecard", required=True, help="Scorecard identifier (id, external id, key, or name).")
+@click.option("--score", required=False, help="Optional score identifier (id, external id, key, or name).")
+@click.option("--days", type=int, required=False, help="Trailing window in days.")
+@click.option("--start-date", required=False, help="Inclusive start date in YYYY-MM-DD.")
+@click.option("--end-date", required=False, help="Inclusive end date in YYYY-MM-DD.")
+@click.option("--summary-llm-provider", required=False, help="LLM provider for the history summary.")
+@click.option("--summary-llm-model", required=False, help="LLM model for the history summary.")
+@click.option("--cache-key", required=False, help="Deterministic cache key for repeated runs.")
+@click.option("--ttl-hours", type=float, default=24.0, show_default=True, help="Cache TTL in hours.")
+@click.option("--fresh", is_flag=True, help="Ignore cached results and rerun.")
+@click.option("--background", is_flag=True, help="Queue as a durable task for dispatcher execution and return immediately.")
+@click.option("--account", "account_identifier", default=None, help="Optional account key or id.")
+@click.option("--format", "output_format", type=click.Choice(["json", "yaml"]), default="json", show_default=True)
+@click.option("--include-log", is_flag=True, help="Include report block log output.")
+def scorecard_history(
+    scorecard: str,
+    score: Optional[str],
+    days: Optional[int],
+    start_date: Optional[str],
+    end_date: Optional[str],
+    summary_llm_provider: Optional[str],
+    summary_llm_model: Optional[str],
+    cache_key: Optional[str],
+    ttl_hours: float,
+    fresh: bool,
+    background: bool,
+    account_identifier: Optional[str],
+    output_format: str,
+    include_log: bool,
+) -> None:
+    """Run the ScorecardHistory report block."""
+    extra_config: Dict[str, Any] = {}
+    if summary_llm_provider:
+        extra_config["summary_llm_provider"] = summary_llm_provider
+    if summary_llm_model:
+        extra_config["summary_llm_model"] = summary_llm_model
+
+    result = run_feedback_report_block(
+        block_class="ScorecardHistory",
+        scorecard=scorecard,
+        score=score,
+        days=_coerce_optional_int(days, "days"),
+        start_date=start_date,
+        end_date=end_date,
+        account_identifier=account_identifier,
+        cache_key=cache_key,
+        ttl_hours=ttl_hours,
+        fresh=fresh,
+        background=background,
+        extra_config=extra_config,
+    )
+    _print_result(
+        title="ScorecardHistory",
+        result=result,
+        output_format=output_format,
+        include_log=include_log,
+    )
+
+
 @report.command(name="acceptance-rate-timeline")
 @click.option("--scorecard", required=True, help="Scorecard identifier (id, external id, or key).")
 @click.option("--score", required=False, help="Optional score identifier (id or external id).")

--- a/plexus/cli/feedback/feedback_report_test.py
+++ b/plexus/cli/feedback/feedback_report_test.py
@@ -274,6 +274,69 @@ def test_score_champion_version_timeline_supports_single_score_explicit_window(m
     assert kwargs["fresh"] is True
 
 
+@patch("plexus.cli.feedback.feedback_report.run_feedback_report_block")
+def test_scorecard_history_uses_dedicated_block(mock_run_feedback_report_block):
+    runner = CliRunner()
+    mock_run_feedback_report_block.return_value = {"status": "success", "output": {"scores": []}}
+
+    result = runner.invoke(
+        report,
+        [
+            "scorecard-history",
+            "--scorecard",
+            "Select Quote HCS Medium Risk",
+            "--days",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_run_feedback_report_block.call_args
+    assert kwargs["block_class"] == "ScorecardHistory"
+    assert kwargs["scorecard"] == "Select Quote HCS Medium Risk"
+    assert kwargs["score"] is None
+    assert kwargs["days"] == 10
+    assert kwargs["extra_config"] == {}
+
+
+@patch("plexus.cli.feedback.feedback_report.run_feedback_report_block")
+def test_scorecard_history_supports_single_score_explicit_window_and_summary_model(mock_run_feedback_report_block):
+    runner = CliRunner()
+    mock_run_feedback_report_block.return_value = {"status": "success", "output": {"scores": []}}
+
+    result = runner.invoke(
+        report,
+        [
+            "scorecard-history",
+            "--scorecard",
+            "1438",
+            "--score",
+            "48059",
+            "--start-date",
+            "2026-04-01",
+            "--end-date",
+            "2026-05-01",
+            "--summary-llm-provider",
+            "openai",
+            "--summary-llm-model",
+            "gpt-5-mini",
+            "--fresh",
+        ],
+    )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_run_feedback_report_block.call_args
+    assert kwargs["block_class"] == "ScorecardHistory"
+    assert kwargs["score"] == "48059"
+    assert kwargs["start_date"] == "2026-04-01"
+    assert kwargs["end_date"] == "2026-05-01"
+    assert kwargs["extra_config"] == {
+        "summary_llm_provider": "openai",
+        "summary_llm_model": "gpt-5-mini",
+    }
+    assert kwargs["fresh"] is True
+
+
 @patch("plexus.cli.feedback.feedback_report.resolve_account_id_for_command")
 @patch("plexus.cli.feedback.feedback_report.enrich_parameters_with_names")
 @patch("plexus.cli.feedback.feedback_report.memoized_resolve_score_identifier")

--- a/plexus/reports/blocks/__init__.py
+++ b/plexus/reports/blocks/__init__.py
@@ -17,6 +17,7 @@ from .acceptance_rate import AcceptanceRate
 from .acceptance_rate_timeline import AcceptanceRateTimeline
 from .recent_feedback import RecentFeedback
 from .score_champion_version_timeline import ScoreChampionVersionTimeline
+from .scorecard_history import ScorecardHistory
 
 __all__ = [
     "BaseReportBlock",
@@ -36,4 +37,5 @@ __all__ = [
     "AcceptanceRateTimeline",
     "RecentFeedback",
     "ScoreChampionVersionTimeline",
+    "ScorecardHistory",
 ]

--- a/plexus/reports/blocks/scorecard_history.py
+++ b/plexus/reports/blocks/scorecard_history.py
@@ -1,0 +1,704 @@
+from __future__ import annotations
+
+import asyncio
+import difflib
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base import BaseReportBlock
+from .feedback_scope_resolver import (
+    list_scores_for_scorecard,
+    resolve_score_for_scorecard,
+    resolve_scorecard,
+)
+
+
+@dataclass(frozen=True)
+class _ResolvedScoreHistoryScope:
+    score_id: str
+    score_name: str
+    champion_version_id: Optional[str]
+
+
+class ScorecardHistory(BaseReportBlock):
+    """
+    Report block summarizing featured ScoreVersion changes over a date window.
+
+    Scope:
+    - scorecard only: all scores on the scorecard
+    - scorecard + score/score_id: a single score on the scorecard
+    """
+
+    DEFAULT_NAME = "Scorecard History"
+    DEFAULT_DESCRIPTION = "Featured score-version changes and champion promotion status"
+    DEFAULT_DAYS = 30
+    SUMMARY_DIFF_CHAR_LIMIT = 1500
+
+    async def generate(self) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        self.log_messages = []
+
+        try:
+            scorecard_identifier = self._get_param("scorecard")
+            if not scorecard_identifier:
+                raise ValueError("'scorecard' is required.")
+
+            score_identifier = self._get_param("score") or self._get_param("score_id")
+            if score_identifier is not None:
+                score_identifier = str(score_identifier).strip() or None
+
+            window_start, window_end = self._resolve_window_utc()
+            scorecard = await self._resolve_scorecard(str(scorecard_identifier))
+            scores_to_analyze = await self._resolve_scores_for_mode(
+                scorecard_id=scorecard.id,
+                score_identifier=score_identifier,
+            )
+
+            self._log(
+                f"Running ScorecardHistory for scorecard '{scorecard.name}' "
+                f"with {len(scores_to_analyze)} score(s), "
+                f"start={window_start.isoformat()}, end={window_end.isoformat()}"
+            )
+
+            score_outputs: List[Dict[str, Any]] = []
+            summary_inputs: List[Dict[str, Any]] = []
+
+            for score_scope in scores_to_analyze:
+                versions = await self._fetch_versions_for_score(score_scope.score_id)
+                versions_by_id = {
+                    str(version.get("id")): version
+                    for version in versions
+                    if version.get("id")
+                }
+                included_versions = self._select_featured_versions(
+                    versions=versions,
+                    start_date=window_start,
+                    end_date=window_end,
+                )
+
+                if not included_versions:
+                    continue
+
+                version_entries: List[Dict[str, Any]] = []
+                for version in included_versions:
+                    entry = await self._build_version_entry(
+                        score_scope=score_scope,
+                        version=version,
+                        versions_by_id=versions_by_id,
+                        start_date=window_start,
+                        end_date=window_end,
+                    )
+                    version_entries.append(entry)
+
+                champion_version_count = sum(
+                    1 for entry in version_entries if entry["champion_status"]["is_champion_related"]
+                )
+                score_output = {
+                    "score_id": score_scope.score_id,
+                    "score_name": score_scope.score_name,
+                    "featured_version_count": len(version_entries),
+                    "champion_version_count": champion_version_count,
+                    "versions": version_entries,
+                }
+                score_output["summary"] = self._build_score_summary_text(score_output)
+                score_outputs.append(score_output)
+                summary_inputs.append(self._build_score_summary_input(score_output))
+
+            mode = "single_score" if score_identifier else "scorecard_all_scores"
+            summary_payload = self._empty_summary() if not score_outputs else await self._generate_summary_payload(
+                scorecard_name=scorecard.name,
+                mode=mode,
+                start_date=window_start,
+                end_date=window_end,
+                score_summaries=summary_inputs,
+            )
+
+            featured_version_count = sum(score["featured_version_count"] for score in score_outputs)
+            champion_version_count = sum(score["champion_version_count"] for score in score_outputs)
+            champion_coverage = self._champion_coverage(
+                featured_version_count=featured_version_count,
+                champion_version_count=champion_version_count,
+            )
+
+            output: Dict[str, Any] = {
+                "report_type": "scorecard_history",
+                "block_title": self.DEFAULT_NAME,
+                "block_description": self.DEFAULT_DESCRIPTION,
+                "scope": mode,
+                "scorecard_id": scorecard.id,
+                "scorecard_name": scorecard.name,
+                "score_id": scores_to_analyze[0].score_id if mode == "single_score" and scores_to_analyze else None,
+                "score_name": scores_to_analyze[0].score_name if mode == "single_score" and scores_to_analyze else None,
+                "date_range": {
+                    "start": window_start.isoformat(),
+                    "end": window_end.isoformat(),
+                },
+                "summary": {
+                    "text": str(summary_payload.get("overall_summary") or "").strip(),
+                    "champion_coverage": champion_coverage,
+                    "featured_version_count": featured_version_count,
+                    "champion_version_count": champion_version_count,
+                    "scores_changed_count": len(score_outputs),
+                },
+                "scores": score_outputs,
+            }
+
+            return output, self._get_log_string()
+        except Exception as exc:
+            self._log(f"ERROR generating ScorecardHistory: {exc}", level="ERROR")
+            return {
+                "report_type": "scorecard_history",
+                "block_title": self.DEFAULT_NAME,
+                "block_description": self.DEFAULT_DESCRIPTION,
+                "error": str(exc),
+                "scores": [],
+            }, self._get_log_string()
+
+    def _get_param(self, name: str) -> Any:
+        if name in self.config and self.config.get(name) is not None:
+            return self.config.get(name)
+        if name in self.params and self.params.get(name) is not None:
+            return self.params.get(name)
+        param_name = f"param_{name}"
+        if param_name in self.params and self.params.get(param_name) is not None:
+            return self.params.get(param_name)
+        return None
+
+    def _now_utc(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _parse_dt(self, value: Any, *, is_end: bool) -> datetime:
+        value_str = str(value).strip()
+        date_only = len(value_str) == 10 and value_str[4] == "-" and value_str[7] == "-"
+        try:
+            dt = datetime.fromisoformat(value_str.replace("Z", "+00:00"))
+            if date_only:
+                if is_end:
+                    dt = dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+                else:
+                    dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        except Exception:
+            dt = datetime.strptime(value_str, "%Y-%m-%d")
+            if is_end:
+                dt = dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+            else:
+                dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    def _resolve_window_utc(self) -> Tuple[datetime, datetime]:
+        start_date_raw = self._get_param("start_date")
+        end_date_raw = self._get_param("end_date")
+        days_raw = self._get_param("days")
+
+        if (start_date_raw and not end_date_raw) or (end_date_raw and not start_date_raw):
+            raise ValueError("Both 'start_date' and 'end_date' are required when specifying explicit date windows.")
+        if days_raw is not None and start_date_raw and end_date_raw:
+            raise ValueError("Use either 'days' or 'start_date'+'end_date', not both.")
+
+        if start_date_raw and end_date_raw:
+            start_date = self._parse_dt(start_date_raw, is_end=False)
+            end_date = self._parse_dt(end_date_raw, is_end=True)
+        else:
+            days = int(days_raw) if days_raw is not None else self.DEFAULT_DAYS
+            if days <= 0:
+                raise ValueError("'days' must be a positive integer.")
+            end_date = self._now_utc()
+            start_date = end_date - timedelta(days=days)
+
+        if end_date <= start_date:
+            raise ValueError("'end_date' must be after 'start_date'.")
+        return start_date, end_date
+
+    async def _resolve_scorecard(self, scorecard_identifier: str) -> Any:
+        return await resolve_scorecard(self.api_client, scorecard_identifier)
+
+    async def _resolve_scores_for_mode(
+        self,
+        *,
+        scorecard_id: str,
+        score_identifier: Optional[str],
+    ) -> List[_ResolvedScoreHistoryScope]:
+        if score_identifier:
+            score = await resolve_score_for_scorecard(
+                self.api_client,
+                scorecard_id,
+                score_identifier,
+            )
+            champion_version_id = await self._fetch_champion_version_id(score.id)
+            return [
+                _ResolvedScoreHistoryScope(
+                    score_id=score.id,
+                    score_name=score.name,
+                    champion_version_id=champion_version_id,
+                )
+            ]
+
+        scores = await list_scores_for_scorecard(self.api_client, scorecard_id)
+        scopes: List[_ResolvedScoreHistoryScope] = []
+        for score in scores:
+            scopes.append(
+                _ResolvedScoreHistoryScope(
+                    score_id=score.id,
+                    score_name=score.name,
+                    champion_version_id=await self._fetch_champion_version_id(score.id),
+                )
+            )
+        return scopes
+
+    async def _fetch_champion_version_id(self, score_id: str) -> Optional[str]:
+        query = """
+        query GetScoreChampionVersionForHistory($id: ID!) {
+            getScore(id: $id) {
+                id
+                championVersionId
+            }
+        }
+        """
+        result = await asyncio.to_thread(self.api_client.execute, query, {"id": score_id})
+        score_data = (result or {}).get("getScore") or {}
+        value = score_data.get("championVersionId")
+        return str(value).strip() if value else None
+
+    async def _fetch_versions_for_score(self, score_id: str) -> List[Dict[str, Any]]:
+        query = """
+        query ListScoreVersionsForScorecardHistory($scoreId: String!, $nextToken: String) {
+            listScoreVersionByScoreIdAndCreatedAt(
+                scoreId: $scoreId,
+                sortDirection: ASC,
+                limit: 100,
+                nextToken: $nextToken
+            ) {
+                items {
+                    id
+                    scoreId
+                    configuration
+                    guidelines
+                    isFeatured
+                    note
+                    branch
+                    parentVersionId
+                    metadata
+                    createdAt
+                    updatedAt
+                }
+                nextToken
+            }
+        }
+        """
+
+        versions: List[Dict[str, Any]] = []
+        next_token: Optional[str] = None
+        while True:
+            result = await asyncio.to_thread(
+                self.api_client.execute,
+                query,
+                {"scoreId": score_id, "nextToken": next_token},
+            )
+            page = (result or {}).get("listScoreVersionByScoreIdAndCreatedAt") or {}
+            versions.extend(item for item in page.get("items") or [] if isinstance(item, dict))
+            next_token = page.get("nextToken")
+            if not next_token:
+                break
+        return versions
+
+    async def _fetch_score_version_by_id(self, version_id: str) -> Optional[Dict[str, Any]]:
+        query = """
+        query GetScoreVersionForScorecardHistory($id: ID!) {
+            getScoreVersion(id: $id) {
+                id
+                scoreId
+                configuration
+                guidelines
+                isFeatured
+                note
+                branch
+                parentVersionId
+                metadata
+                createdAt
+                updatedAt
+            }
+        }
+        """
+        result = await asyncio.to_thread(self.api_client.execute, query, {"id": version_id})
+        version = (result or {}).get("getScoreVersion")
+        return version if isinstance(version, dict) else None
+
+    def _select_featured_versions(
+        self,
+        *,
+        versions: List[Dict[str, Any]],
+        start_date: datetime,
+        end_date: datetime,
+    ) -> List[Dict[str, Any]]:
+        selected = [
+            version for version in versions
+            if self._is_featured(version) and self._in_window(version.get("createdAt"), start_date, end_date)
+        ]
+        selected.sort(key=lambda version: self._to_dt(version.get("createdAt")).timestamp())
+        return selected
+
+    def _is_featured(self, version: Dict[str, Any]) -> bool:
+        return str(version.get("isFeatured") or "").strip().lower() == "true"
+
+    def _in_window(self, value: Any, start_date: datetime, end_date: datetime) -> bool:
+        dt = self._to_dt(value)
+        return start_date <= dt <= end_date
+
+    def _to_dt(self, value: Any) -> datetime:
+        if isinstance(value, datetime):
+            dt = value
+        elif isinstance(value, str):
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        else:
+            raise ValueError(f"Expected datetime-compatible value, got {type(value).__name__}.")
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    async def _build_version_entry(
+        self,
+        *,
+        score_scope: _ResolvedScoreHistoryScope,
+        version: Dict[str, Any],
+        versions_by_id: Dict[str, Dict[str, Any]],
+        start_date: datetime,
+        end_date: datetime,
+    ) -> Dict[str, Any]:
+        version_id = str(version.get("id") or "").strip()
+        parent_version_id = str(version.get("parentVersionId") or "").strip() or None
+        parent_version = versions_by_id.get(parent_version_id or "")
+        if parent_version_id and not parent_version:
+            parent_version = await self._fetch_score_version_by_id(parent_version_id)
+
+        champion_promotions = self._champion_promotions_in_window(
+            version=version,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        is_current_champion = version_id == score_scope.champion_version_id
+        is_champion_related = is_current_champion or bool(champion_promotions)
+
+        return {
+            "version_id": version_id,
+            "score_id": score_scope.score_id,
+            "note": version.get("note") or "",
+            "branch": version.get("branch"),
+            "created_at": version.get("createdAt"),
+            "updated_at": version.get("updatedAt"),
+            "parent_version_id": parent_version_id,
+            "champion_status": {
+                "is_current_champion": is_current_champion,
+                "is_champion_related": is_champion_related,
+                "promotions_in_window": champion_promotions,
+            },
+            "diffs": {
+                "code": self._build_diff_payload(
+                    parent_version=parent_version,
+                    version=version,
+                    field="configuration",
+                    original_label="Parent Code",
+                    modified_label="Version Code",
+                ),
+                "guidelines": self._build_diff_payload(
+                    parent_version=parent_version,
+                    version=version,
+                    field="guidelines",
+                    original_label="Parent Guidelines",
+                    modified_label="Version Guidelines",
+                ),
+            },
+        }
+
+    def _champion_promotions_in_window(
+        self,
+        *,
+        version: Dict[str, Any],
+        start_date: datetime,
+        end_date: datetime,
+    ) -> List[Dict[str, Any]]:
+        metadata = self._parse_json_object(version.get("metadata"))
+        history = metadata.get("championHistory")
+        if not isinstance(history, list):
+            return []
+
+        promotions = []
+        for entry in history:
+            if not isinstance(entry, dict):
+                continue
+            entered_at = entry.get("enteredAt")
+            if not entered_at or not self._in_window(entered_at, start_date, end_date):
+                continue
+            promotions.append({
+                "entered_at": entered_at,
+                "exited_at": entry.get("exitedAt"),
+                "previous_champion_version_id": entry.get("previousChampionVersionId"),
+                "next_champion_version_id": entry.get("nextChampionVersionId"),
+                "transition_id": entry.get("transitionId"),
+            })
+        promotions.sort(key=lambda entry: self._to_dt(entry["entered_at"]).timestamp())
+        return promotions
+
+    def _build_diff_payload(
+        self,
+        *,
+        parent_version: Optional[Dict[str, Any]],
+        version: Dict[str, Any],
+        field: str,
+        original_label: str,
+        modified_label: str,
+    ) -> Dict[str, Any]:
+        original = str((parent_version or {}).get(field) or "")
+        modified = str(version.get(field) or "")
+        return {
+            "original_version_id": (parent_version or {}).get("id"),
+            "modified_version_id": version.get("id"),
+            "original_label": original_label,
+            "modified_label": modified_label,
+            "original": original,
+            "modified": modified,
+            "unified_diff": self._build_unified_diff(
+                original,
+                modified,
+                fromfile=f"{(parent_version or {}).get('id') or 'none'}/{field}",
+                tofile=f"{version.get('id')}/{field}",
+            ),
+            "has_changes": original != modified,
+        }
+
+    def _build_unified_diff(self, original: str, modified: str, *, fromfile: str, tofile: str) -> str:
+        return "".join(
+            difflib.unified_diff(
+                original.splitlines(keepends=True),
+                modified.splitlines(keepends=True),
+                fromfile=fromfile,
+                tofile=tofile,
+            )
+        )
+
+    def _build_score_summary_input(self, score_output: Dict[str, Any]) -> Dict[str, Any]:
+        versions = []
+        for version in score_output["versions"]:
+            code_diff = str(version["diffs"]["code"]["unified_diff"] or "")
+            guidelines_diff = str(version["diffs"]["guidelines"]["unified_diff"] or "")
+            versions.append({
+                "version_id": version["version_id"],
+                "created_at": version["created_at"],
+                "note": version["note"],
+                "is_current_champion": version["champion_status"]["is_current_champion"],
+                "promotions_in_window": version["champion_status"]["promotions_in_window"],
+                "code_diff": self._limit_text(code_diff),
+                "guidelines_diff": self._limit_text(guidelines_diff),
+            })
+        return {
+            "score_id": score_output["score_id"],
+            "score_name": score_output["score_name"],
+            "featured_version_count": score_output["featured_version_count"],
+            "champion_version_count": score_output["champion_version_count"],
+            "versions": versions,
+        }
+
+    def _build_score_summary_text(self, score_output: Dict[str, Any]) -> str:
+        featured_count = int(score_output.get("featured_version_count") or 0)
+        champion_count = int(score_output.get("champion_version_count") or 0)
+        coverage = self._champion_coverage(
+            featured_version_count=featured_count,
+            champion_version_count=champion_count,
+        )
+        if coverage == "all":
+            champion_text = "all were champion-related"
+        elif coverage == "some":
+            champion_text = f"{champion_count} were champion-related"
+        else:
+            champion_text = "none were champion-related"
+
+        note_fragments = []
+        for version in score_output.get("versions") or []:
+            note = str(version.get("note") or "").strip()
+            if note:
+                note_fragments.append(note)
+            else:
+                note_fragments.append(f"Version {version.get('version_id')}")
+
+        notes_text = "; ".join(note_fragments)
+        if len(notes_text) > 900:
+            notes_text = notes_text[:900].rstrip() + "..."
+        return (
+            f"{featured_count} starred version{' was' if featured_count == 1 else 's were'} "
+            f"created in the window; {champion_text}. {notes_text}"
+        ).strip()
+
+    def _limit_text(self, text: str) -> str:
+        if len(text) <= self.SUMMARY_DIFF_CHAR_LIMIT:
+            return text
+        return text[: self.SUMMARY_DIFF_CHAR_LIMIT] + "\n[diff truncated for summary prompt]"
+
+    async def _generate_summary_payload(
+        self,
+        *,
+        scorecard_name: str,
+        mode: str,
+        start_date: datetime,
+        end_date: datetime,
+        score_summaries: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        prompt_payload = {
+            "scorecard_name": scorecard_name,
+            "scope": mode,
+            "date_range": {
+                "start": start_date.isoformat(),
+                "end": end_date.isoformat(),
+            },
+            "scores": score_summaries,
+        }
+        prompt = (
+            "Summarize the featured score-version history below for a report audience.\n"
+            "Explain what changed over the time period in chronological order.\n"
+            "Explicitly state whether all, none, or some included changes were promoted to champion.\n"
+            "Use version notes as the source of per-version descriptions and use diffs only to clarify what changed.\n"
+            "Keep overall_summary to one concise paragraph.\n"
+            "The response must be valid JSON, not Python dict syntax. Use double quotes for every key and string.\n"
+            "The first character of the response must be { and the last character must be }.\n"
+            "Return only strict JSON with this shape:\n"
+            "{\n"
+            '  "overall_summary": "string"\n'
+            "}\n\n"
+            f"History data:\n{json.dumps(prompt_payload, indent=2, sort_keys=False)}"
+        )
+        system_prompt = (
+            "You write concise operational report summaries. "
+            "Do not invent score versions, dates, promotions, or outcomes not present in the data."
+        )
+        raw_response = await self._run_tac_inference(prompt, system_prompt=system_prompt)
+        return self._parse_summary_response(raw_response)
+
+    def _parse_summary_response(self, raw_response: Optional[str]) -> Dict[str, Any]:
+        if not raw_response or not raw_response.strip():
+            raise ValueError("LLM summary response was empty.")
+
+        text = raw_response.strip()
+        fenced_match = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", text, flags=re.DOTALL)
+        if fenced_match:
+            text = fenced_match.group(1).strip()
+
+        parsed = json.loads(text)
+        if not isinstance(parsed, dict):
+            raise ValueError("LLM summary response must be a JSON object.")
+        if not isinstance(parsed.get("overall_summary"), str):
+            raise ValueError("LLM summary response missing 'overall_summary'.")
+        return parsed
+
+    def _parse_json_object(self, value: Any) -> Dict[str, Any]:
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str) and value.strip():
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        return {}
+
+    async def _run_tac_inference(self, user_message: str, system_prompt: str = "") -> Optional[str]:
+        try:
+            provider = str(self._get_param("summary_llm_provider") or "openai")
+            model = str(self._get_param("summary_llm_model") or "gpt-4o-mini")
+            if provider.lower() == "openai":
+                return await self._run_openai_json_inference(
+                    user_message=user_message,
+                    system_prompt=system_prompt,
+                    model=model,
+                )
+
+            from tactus.adapters.memory import MemoryStorage
+            from tactus.core.runtime import TactusRuntime
+
+            model_lower = model.lower()
+            is_reasoning = any(token in model_lower for token in ("gpt-5", "o3", "o4"))
+            tac_name = "single_turn_inference_reasoning.tac" if is_reasoning else "single_turn_inference.tac"
+            tac_path = os.path.join(os.path.dirname(__file__), "..", "procedures", tac_name)
+
+            with open(tac_path) as tac_file:
+                tac_source = (
+                    tac_file.read()
+                    .replace("{{PROVIDER}}", provider)
+                    .replace("{{MODEL}}", model)
+                )
+
+            runtime = TactusRuntime(
+                procedure_id="scorecard_history_summary_inference",
+                storage_backend=MemoryStorage(),
+                openai_api_key=os.environ.get("OPENAI_API_KEY"),
+            )
+            result = await runtime.execute(
+                tac_source,
+                context={"user_message": user_message, "system_prompt": system_prompt},
+                format="lua",
+            )
+
+            procedure_output = result.get("result", result) if isinstance(result, dict) else result
+            text = self._extract_tactus_text(procedure_output)
+            return text.strip() or None
+        except Exception as exc:
+            raise RuntimeError(f"LLM summary generation failed: {exc}") from exc
+
+    async def _run_openai_json_inference(self, *, user_message: str, system_prompt: str, model: str) -> Optional[str]:
+        def _invoke() -> str:
+            from openai import OpenAI
+
+            client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+            response = client.chat.completions.create(
+                model=model,
+                temperature=0,
+                max_tokens=4096,
+                response_format={"type": "json_object"},
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_message},
+                ],
+            )
+            content = response.choices[0].message.content if response.choices else ""
+            return str(content or "").strip()
+
+        return await asyncio.to_thread(_invoke)
+
+    def _extract_tactus_text(self, value: Any, *, depth: int = 0) -> str:
+        if value is None or depth > 8:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (int, float, bool)):
+            return str(value)
+        if isinstance(value, dict):
+            if isinstance(value.get("overall_summary"), str):
+                return json.dumps(value)
+            for key in ("reason", "text", "output", "content", "message", "response", "result"):
+                extracted = self._extract_tactus_text(value.get(key), depth=depth + 1)
+                if extracted:
+                    return extracted
+            for nested in value.values():
+                extracted = self._extract_tactus_text(nested, depth=depth + 1)
+                if extracted:
+                    return extracted
+            return ""
+        if isinstance(value, list):
+            for item in value:
+                extracted = self._extract_tactus_text(item, depth=depth + 1)
+                if extracted:
+                    return extracted
+            return ""
+        return ""
+
+    def _empty_summary(self) -> Dict[str, Any]:
+        return {
+            "overall_summary": "No featured score versions were created in the requested time window.",
+        }
+
+    def _champion_coverage(self, *, featured_version_count: int, champion_version_count: int) -> str:
+        if featured_version_count == 0 or champion_version_count == 0:
+            return "none"
+        if featured_version_count == champion_version_count:
+            return "all"
+        return "some"

--- a/plexus/reports/blocks/scorecard_history.py
+++ b/plexus/reports/blocks/scorecard_history.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import difflib
 import json
+import math
 import os
 import re
 from dataclasses import dataclass
@@ -103,6 +104,18 @@ class ScorecardHistory(BaseReportBlock):
                     "champion_version_count": champion_version_count,
                     "versions": version_entries,
                 }
+                window_diff = self._build_score_window_diff(
+                    versions=versions,
+                    included_versions=included_versions,
+                )
+                if window_diff:
+                    score_output["window_diff"] = window_diff
+                performance = await self._build_score_performance(
+                    versions=versions,
+                    included_versions=included_versions,
+                )
+                if performance:
+                    score_output["performance"] = performance
                 score_output["summary"] = self._build_score_summary_text(score_output)
                 score_outputs.append(score_output)
                 summary_inputs.append(self._build_score_summary_input(score_output))
@@ -328,6 +341,60 @@ class ScorecardHistory(BaseReportBlock):
         version = (result or {}).get("getScoreVersion")
         return version if isinstance(version, dict) else None
 
+    async def _fetch_evaluations_for_version(self, score_version_id: str) -> List[Dict[str, Any]]:
+        query = """
+        query ListEvaluationsForScorecardHistory(
+            $scoreVersionId: String!
+            $sortDirection: ModelSortDirection
+            $limit: Int
+            $nextToken: String
+        ) {
+            listEvaluationByScoreVersionIdAndCreatedAt(
+                scoreVersionId: $scoreVersionId
+                sortDirection: $sortDirection
+                limit: $limit
+                nextToken: $nextToken
+            ) {
+                items {
+                    id
+                    type
+                    status
+                    createdAt
+                    updatedAt
+                    parameters
+                    scoreId
+                    scoreVersionId
+                    accuracy
+                    processedItems
+                    totalItems
+                    metrics
+                    cost
+                    taskId
+                }
+                nextToken
+            }
+        }
+        """
+        evaluations: List[Dict[str, Any]] = []
+        next_token: Optional[str] = None
+        while True:
+            result = await asyncio.to_thread(
+                self.api_client.execute,
+                query,
+                {
+                    "scoreVersionId": score_version_id,
+                    "sortDirection": "DESC",
+                    "limit": 100,
+                    "nextToken": next_token,
+                },
+            )
+            payload = (result or {}).get("listEvaluationByScoreVersionIdAndCreatedAt") or {}
+            evaluations.extend(item for item in payload.get("items") or [] if isinstance(item, dict))
+            next_token = payload.get("nextToken")
+            if not next_token:
+                break
+        return evaluations
+
     def _select_featured_versions(
         self,
         *,
@@ -341,6 +408,23 @@ class ScorecardHistory(BaseReportBlock):
         ]
         selected.sort(key=lambda version: self._to_dt(version.get("createdAt")).timestamp())
         return selected
+
+    def _select_predecessor_version(
+        self,
+        *,
+        versions: List[Dict[str, Any]],
+        first_included_version: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        first_created_at = self._to_dt(first_included_version.get("createdAt"))
+        predecessors = [
+            version
+            for version in versions
+            if version.get("id") != first_included_version.get("id")
+            and self._to_dt(version.get("createdAt")) < first_created_at
+        ]
+        if not predecessors:
+            return None
+        return max(predecessors, key=lambda version: self._to_dt(version.get("createdAt")).timestamp())
 
     def _is_featured(self, version: Dict[str, Any]) -> bool:
         return str(version.get("isFeatured") or "").strip().lower() == "true"
@@ -480,6 +564,247 @@ class ScorecardHistory(BaseReportBlock):
             )
         )
 
+    def _build_score_window_diff(
+        self,
+        *,
+        versions: List[Dict[str, Any]],
+        included_versions: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        if not included_versions:
+            return None
+
+        baseline_version = self._select_predecessor_version(
+            versions=versions,
+            first_included_version=included_versions[0],
+        )
+        latest_version = included_versions[-1]
+        if not baseline_version:
+            return None
+
+        return {
+            "baseline_version_id": baseline_version.get("id"),
+            "latest_version_id": latest_version.get("id"),
+            "baseline_created_at": baseline_version.get("createdAt"),
+            "latest_created_at": latest_version.get("createdAt"),
+            "code": self._build_diff_payload(
+                parent_version=baseline_version,
+                version=latest_version,
+                field="configuration",
+                original_label="Pre-window Code",
+                modified_label="Latest Code",
+            ),
+            "guidelines": self._build_diff_payload(
+                parent_version=baseline_version,
+                version=latest_version,
+                field="guidelines",
+                original_label="Pre-window Guidelines",
+                modified_label="Latest Guidelines",
+            ),
+        }
+
+    async def _build_score_performance(
+        self,
+        *,
+        versions: List[Dict[str, Any]],
+        included_versions: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        if not included_versions:
+            return None
+
+        current_version = included_versions[-1]
+        current_version_id = str(current_version.get("id") or "").strip()
+        if not current_version_id:
+            return None
+
+        baseline_version = self._select_predecessor_version(
+            versions=versions,
+            first_included_version=included_versions[0],
+        )
+        baseline_version_id = str((baseline_version or {}).get("id") or "").strip() or None
+
+        current_evaluations = await self._fetch_evaluations_for_version(current_version_id)
+        baseline_evaluations = (
+            await self._fetch_evaluations_for_version(baseline_version_id)
+            if baseline_version_id
+            else []
+        )
+
+        feedback_eval = self._select_best_evaluation(current_evaluations, "feedback")
+        feedback_baseline_eval = self._select_best_evaluation(baseline_evaluations, "feedback")
+        regression_eval = self._select_best_evaluation(
+            current_evaluations,
+            "accuracy",
+            require_dataset=True,
+        )
+        regression_dataset_id = self._evaluation_dataset_id(regression_eval)
+        regression_baseline_eval = (
+            self._select_best_evaluation(
+                baseline_evaluations,
+                "accuracy",
+                require_dataset=True,
+                dataset_id=regression_dataset_id,
+            )
+            if regression_dataset_id
+            else None
+        )
+
+        performance: Dict[str, Any] = {
+            "current_version_id": current_version_id,
+            "baseline_version_id": baseline_version_id,
+        }
+        feedback_payload = self._performance_kind_payload(
+            current_eval=feedback_eval,
+            baseline_eval=feedback_baseline_eval,
+        )
+        if feedback_payload:
+            performance["recent_feedback"] = feedback_payload
+
+        regression_payload = self._performance_kind_payload(
+            current_eval=regression_eval,
+            baseline_eval=regression_baseline_eval,
+        )
+        if regression_payload:
+            performance["regression"] = regression_payload
+
+        return performance if any(key in performance for key in ("recent_feedback", "regression")) else None
+
+    def _performance_kind_payload(
+        self,
+        *,
+        current_eval: Optional[Dict[str, Any]],
+        baseline_eval: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        current = self._metrics_payload(current_eval)
+        if not current:
+            return None
+        payload = {"current": current}
+        baseline = self._metrics_payload(baseline_eval)
+        if baseline:
+            payload["baseline"] = baseline
+        return payload
+
+    def _select_best_evaluation(
+        self,
+        evaluations: List[Dict[str, Any]],
+        evaluation_type: str,
+        *,
+        require_dataset: bool = False,
+        dataset_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        candidates: List[Dict[str, Any]] = []
+        for evaluation in evaluations:
+            if str(evaluation.get("type") or "").lower() != evaluation_type:
+                continue
+            if str(evaluation.get("status") or "").upper() != "COMPLETED":
+                continue
+            evaluation_dataset_id = self._evaluation_dataset_id(evaluation)
+            if require_dataset and not evaluation_dataset_id:
+                continue
+            if dataset_id and evaluation_dataset_id != dataset_id:
+                continue
+            candidates.append(evaluation)
+
+        if not candidates:
+            return None
+
+        def sort_key(evaluation: Dict[str, Any]) -> Tuple[float, datetime]:
+            metrics = self._parse_metrics(evaluation)
+            alignment = metrics.get("alignment")
+            return (
+                float(alignment) if isinstance(alignment, (int, float)) else float("-inf"),
+                self._parse_datetime(evaluation.get("createdAt")) or datetime.min.replace(tzinfo=timezone.utc),
+            )
+
+        return max(candidates, key=sort_key)
+
+    def _metrics_payload(self, evaluation: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        if not evaluation:
+            return None
+
+        metrics = {
+            key: value
+            for key, value in self._parse_metrics(evaluation).items()
+            if key in ("alignment", "accuracy", "precision", "recall") and value is not None
+        }
+        if not metrics:
+            return None
+
+        payload: Dict[str, Any] = {
+            "evaluation_id": evaluation.get("id"),
+            "evaluation_type": evaluation.get("type"),
+            "created_at": evaluation.get("createdAt"),
+            "updated_at": evaluation.get("updatedAt"),
+            "processed_items": evaluation.get("processedItems"),
+            "total_items": evaluation.get("totalItems"),
+            "metrics": metrics,
+        }
+        dataset_id = self._evaluation_dataset_id(evaluation)
+        if dataset_id:
+            payload["dataset_id"] = dataset_id
+        return payload
+
+    def _evaluation_dataset_id(self, evaluation: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not evaluation:
+            return None
+
+        for value in (evaluation.get("dataSetId"), evaluation.get("datasetId")):
+            if value:
+                return str(value).strip()
+
+        parameters = self._parse_json_object(evaluation.get("parameters"))
+        for key in ("dataset_id", "dataSetId", "datasetId"):
+            value = parameters.get(key)
+            if value:
+                return str(value).strip()
+        return None
+
+    def _parse_metrics(self, evaluation: Dict[str, Any]) -> Dict[str, Optional[float]]:
+        parsed = self._parse_json_value(evaluation.get("metrics"))
+        accuracy_value = self._finite_number(evaluation.get("accuracy"))
+
+        if isinstance(parsed, list):
+            values: Dict[str, Optional[float]] = {
+                "accuracy": accuracy_value,
+                "alignment": None,
+                "precision": None,
+                "recall": None,
+            }
+            for metric in parsed:
+                if not isinstance(metric, dict):
+                    continue
+                name = str(metric.get("name") or metric.get("label") or "").lower()
+                number = self._finite_number(metric.get("value"))
+                if number is None:
+                    continue
+                if values["accuracy"] is None and "accuracy" in name:
+                    values["accuracy"] = number
+                if values["alignment"] is None and ("alignment" in name or "ac1" in name):
+                    values["alignment"] = number
+                if values["precision"] is None and "precision" in name:
+                    values["precision"] = number
+                if values["recall"] is None and "recall" in name:
+                    values["recall"] = number
+            return values
+
+        if isinstance(parsed, dict):
+            return {
+                "accuracy": accuracy_value if accuracy_value is not None else self._finite_number(parsed.get("accuracy")),
+                "alignment": self._first_finite(
+                    parsed.get("alignment"),
+                    parsed.get("ac1"),
+                    parsed.get("agreement"),
+                ),
+                "precision": self._finite_number(parsed.get("precision")),
+                "recall": self._finite_number(parsed.get("recall")),
+            }
+
+        return {
+            "accuracy": accuracy_value,
+            "alignment": None,
+            "precision": None,
+            "recall": None,
+        }
+
     def _build_score_summary_input(self, score_output: Dict[str, Any]) -> Dict[str, Any]:
         versions = []
         for version in score_output["versions"]:
@@ -516,6 +841,16 @@ class ScorecardHistory(BaseReportBlock):
         else:
             champion_text = "none were champion-related"
 
+        versions = score_output.get("versions") or []
+        code_change_count = sum(1 for version in versions if version.get("diffs", {}).get("code", {}).get("has_changes"))
+        guideline_change_count = sum(1 for version in versions if version.get("diffs", {}).get("guidelines", {}).get("has_changes"))
+        performance = score_output.get("performance") or {}
+        evaluation_kinds = []
+        if performance.get("recent_feedback"):
+            evaluation_kinds.append("recent feedback")
+        if performance.get("regression"):
+            evaluation_kinds.append("regression")
+
         note_fragments = []
         for version in score_output.get("versions") or []:
             note = str(version.get("note") or "").strip()
@@ -524,13 +859,33 @@ class ScorecardHistory(BaseReportBlock):
             else:
                 note_fragments.append(f"Version {version.get('version_id')}")
 
-        notes_text = "; ".join(note_fragments)
-        if len(notes_text) > 900:
-            notes_text = notes_text[:900].rstrip() + "..."
-        return (
-            f"{featured_count} starred version{' was' if featured_count == 1 else 's were'} "
-            f"created in the window; {champion_text}. {notes_text}"
-        ).strip()
+        note_bullets = []
+        for note in note_fragments[:5]:
+            if len(note) > 240:
+                note = note[:237].rstrip() + "..."
+            note_bullets.append(f"  - {note}")
+        if len(note_fragments) > len(note_bullets):
+            note_bullets.append(f"  - {len(note_fragments) - len(note_bullets)} additional version notes are available below.")
+
+        evaluation_text = (
+            f"Gauge data is available for {' and '.join(evaluation_kinds)}."
+            if evaluation_kinds
+            else "No completed evaluation gauge data was found for the latest included version."
+        )
+
+        return "\n".join([
+            "- **Overview**",
+            f"  - {featured_count} starred version{' was' if featured_count == 1 else 's were'} created in the window.",
+            f"  - Champion coverage: {champion_text}.",
+            "- **Guidelines**",
+            f"  - {guideline_change_count} included version{' changed' if guideline_change_count == 1 else 's changed'} guideline text.",
+            "- **Code / configuration**",
+            f"  - {code_change_count} included version{' changed' if code_change_count == 1 else 's changed'} score configuration.",
+            "- **Evaluations**",
+            f"  - {evaluation_text}",
+            "- **Change notes**",
+            *(note_bullets or ["  - No version notes were provided."]),
+        ]).strip()
 
     def _limit_text(self, text: str) -> str:
         if len(text) <= self.SUMMARY_DIFF_CHAR_LIMIT:
@@ -557,15 +912,19 @@ class ScorecardHistory(BaseReportBlock):
         }
         prompt = (
             "Summarize the featured score-version history below for a report audience.\n"
-            "Explain what changed over the time period in chronological order.\n"
-            "Explicitly state whether all, none, or some included changes were promoted to champion.\n"
+            "The JSON object must contain exactly one key named overall_summary.\n"
+            "The value of overall_summary must be a single Markdown string containing categorized bullet lists, not paragraphs.\n"
+            "Inside that string, use these exact top-level Markdown bullets: **Overview**, **Guidelines**, **Code / configuration**, **Champion promotion**, **Evaluation evidence**, and **Notable score changes**.\n"
+            "Under each Markdown top-level bullet, include concise nested bullets. Keep wording direct and executive-readable.\n"
+            "Explain what changed over the time period in chronological order where chronology matters.\n"
+            "Explicitly state whether all, none, or some included changes were promoted to champion under **Champion promotion**.\n"
             "Use version notes as the source of per-version descriptions and use diffs only to clarify what changed.\n"
-            "Keep overall_summary to one concise paragraph.\n"
+            "Do not write filler like 'this got better' unless the supplied evaluation data supports it.\n"
             "The response must be valid JSON, not Python dict syntax. Use double quotes for every key and string.\n"
             "The first character of the response must be { and the last character must be }.\n"
-            "Return only strict JSON with this shape:\n"
+            "Return only strict JSON with exactly this shape:\n"
             "{\n"
-            '  "overall_summary": "string"\n'
+            '  "overall_summary": "- **Overview**\\n  - ...\\n- **Guidelines**\\n  - ..."\n'
             "}\n\n"
             f"History data:\n{json.dumps(prompt_payload, indent=2, sort_keys=False)}"
         )
@@ -593,13 +952,46 @@ class ScorecardHistory(BaseReportBlock):
         return parsed
 
     def _parse_json_object(self, value: Any) -> Dict[str, Any]:
-        if isinstance(value, dict):
-            return value
+        parsed = self._parse_json_value(value)
+        return parsed if isinstance(parsed, dict) else {}
+
+    def _parse_json_value(self, value: Any) -> Any:
         if isinstance(value, str) and value.strip():
-            parsed = json.loads(value)
-            if isinstance(parsed, dict):
-                return parsed
-        return {}
+            try:
+                return json.loads(value)
+            except Exception:
+                return None
+        return value
+
+    def _parse_datetime(self, value: Any) -> Optional[datetime]:
+        if isinstance(value, datetime):
+            dt = value
+        elif isinstance(value, str) and value.strip():
+            try:
+                dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        else:
+            return None
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    def _finite_number(self, value: Any) -> Optional[float]:
+        if isinstance(value, bool):
+            return None
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+        return number if math.isfinite(number) else None
+
+    def _first_finite(self, *values: Any) -> Optional[float]:
+        for value in values:
+            number = self._finite_number(value)
+            if number is not None:
+                return number
+        return None
 
     async def _run_tac_inference(self, user_message: str, system_prompt: str = "") -> Optional[str]:
         try:

--- a/plexus/reports/blocks/scorecard_history_test.py
+++ b/plexus/reports/blocks/scorecard_history_test.py
@@ -1,0 +1,377 @@
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from plexus.reports.blocks.scorecard_history import ScorecardHistory
+
+
+@pytest.fixture
+def mock_api_client():
+    client = MagicMock()
+    client.account_id = "acct-1"
+    return client
+
+
+def _version(
+    version_id,
+    *,
+    score_id="score-1",
+    created_at="2026-04-10T12:00:00+00:00",
+    is_featured="true",
+    parent_version_id=None,
+    configuration=None,
+    guidelines=None,
+    note=None,
+    champion_history=None,
+):
+    return {
+        "id": version_id,
+        "scoreId": score_id,
+        "configuration": configuration if configuration is not None else f"name: {version_id}\n",
+        "guidelines": guidelines if guidelines is not None else f"# {version_id}\n",
+        "isFeatured": is_featured,
+        "note": note if note is not None else f"{version_id} note",
+        "branch": None,
+        "parentVersionId": parent_version_id,
+        "metadata": {"championHistory": champion_history or []},
+        "createdAt": created_at,
+        "updatedAt": created_at,
+    }
+
+
+def _summary_response(*score_ids):
+    return json.dumps({
+        "overall_summary": "Some included changes were promoted to champion.",
+        "score_summaries": {
+            score_id: f"Summary for {score_id}."
+            for score_id in score_ids
+        },
+    })
+
+
+def _block(config, api_client):
+    return ScorecardHistory(config=config, params={"account_id": "acct-1"}, api_client=api_client)
+
+
+@pytest.mark.asyncio
+async def test_accepts_days_window(mock_api_client):
+    block = _block({"scorecard": "sc-1", "days": 10}, mock_api_client)
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+
+    with (
+        patch.object(block, "_now_utc", return_value=datetime(2026, 5, 5, 12, tzinfo=timezone.utc)),
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[])),
+    ):
+        output, _ = await block.generate()
+
+    assert output["report_type"] == "scorecard_history"
+    assert output["date_range"]["start"] == "2026-04-25T12:00:00+00:00"
+    assert output["date_range"]["end"] == "2026-05-05T12:00:00+00:00"
+    assert output["scores"] == []
+
+
+@pytest.mark.asyncio
+async def test_accepts_explicit_start_and_end_window(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-15"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[])),
+    ):
+        output, _ = await block.generate()
+
+    assert output["date_range"]["start"].startswith("2026-04-01T00:00:00")
+    assert output["date_range"]["end"].startswith("2026-04-15T23:59:59")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config,error",
+    [
+        ({"scorecard": "sc-1", "start_date": "2026-04-01"}, "Both 'start_date' and 'end_date'"),
+        (
+            {"scorecard": "sc-1", "days": 30, "start_date": "2026-04-01", "end_date": "2026-04-15"},
+            "Use either 'days' or 'start_date'+'end_date'",
+        ),
+        ({"scorecard": "sc-1", "days": 0}, "'days' must be a positive integer"),
+    ],
+)
+async def test_rejects_invalid_window_configs(mock_api_client, config, error):
+    block = ScorecardHistory(config=config, params={}, api_client=mock_api_client)
+
+    output, _ = await block.generate()
+
+    assert error in output["error"]
+
+
+@pytest.mark.asyncio
+async def test_single_score_mode_filters_scope(mock_api_client):
+    block = _block(
+        {
+            "scorecard": "sc-1",
+            "score": "Score 1",
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-30",
+        },
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None)
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])) as resolve_scores,
+        patch.object(
+            block,
+            "_fetch_versions_for_score",
+            new=AsyncMock(return_value=[_version("v1", note="Tightened routing criteria.")]),
+        ),
+        patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
+    ):
+        output, _ = await block.generate()
+
+    resolve_scores.assert_awaited_once_with(scorecard_id="sc-1", score_identifier="Score 1")
+    assert output["scope"] == "single_score"
+    assert output["score_id"] == "score-1"
+    assert [score["score_id"] for score in output["scores"]] == ["score-1"]
+
+
+@pytest.mark.asyncio
+async def test_filters_featured_versions_created_in_window_and_omits_unchanged_scores(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scopes = [
+        SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None),
+        SimpleNamespace(score_id="score-2", score_name="Score 2", champion_version_id=None),
+    ]
+    versions_by_score = {
+        "score-1": [
+            _version("v0", created_at="2026-03-25T12:00:00+00:00", is_featured="true"),
+            _version("v1", created_at="2026-04-10T12:00:00+00:00", is_featured="false"),
+            _version("v2", created_at="2026-04-12T12:00:00+00:00", is_featured="true"),
+        ],
+        "score-2": [
+            _version("v3", score_id="score-2", created_at="2026-03-30T12:00:00+00:00", is_featured="true"),
+            _version("v4", score_id="score-2", created_at="2026-04-12T12:00:00+00:00", is_featured="false"),
+        ],
+    }
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=scopes)),
+        patch.object(
+            block,
+            "_fetch_versions_for_score",
+            new=AsyncMock(side_effect=lambda score_id: versions_by_score[score_id]),
+        ),
+        patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
+    ):
+        output, _ = await block.generate()
+
+    assert [score["score_id"] for score in output["scores"]] == ["score-1"]
+    assert [version["version_id"] for version in output["scores"][0]["versions"]] == ["v2"]
+    assert output["summary"]["scores_changed_count"] == 1
+    assert output["summary"]["featured_version_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_builds_parent_diff_payloads(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None)
+    parent = _version(
+        "v0",
+        created_at="2026-03-25T12:00:00+00:00",
+        configuration="name: old\n",
+        guidelines="# Old\n",
+    )
+    featured = _version(
+        "v1",
+        parent_version_id="v0",
+        configuration="name: new\n",
+        guidelines="# New\n",
+        note="Changed the classification threshold.",
+    )
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[parent, featured])),
+        patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
+    ):
+        output, _ = await block.generate()
+
+    version = output["scores"][0]["versions"][0]
+    assert version["parent_version_id"] == "v0"
+    assert version["diffs"]["code"]["original"] == "name: old\n"
+    assert version["diffs"]["code"]["modified"] == "name: new\n"
+    assert "-name: old" in version["diffs"]["code"]["unified_diff"]
+    assert "+name: new" in version["diffs"]["code"]["unified_diff"]
+    assert version["diffs"]["guidelines"]["original"] == "# Old\n"
+    assert version["diffs"]["guidelines"]["modified"] == "# New\n"
+    assert version["diffs"]["code"]["has_changes"] is True
+
+
+@pytest.mark.asyncio
+async def test_fetches_missing_parent_version_for_diff(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None)
+    featured = _version("v1", parent_version_id="v0", configuration="name: new\n")
+    parent = _version("v0", configuration="name: old\n")
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[featured])),
+        patch.object(block, "_fetch_score_version_by_id", new=AsyncMock(return_value=parent)) as fetch_parent,
+        patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
+    ):
+        output, _ = await block.generate()
+
+    fetch_parent.assert_awaited_once_with("v0")
+    assert output["scores"][0]["versions"][0]["diffs"]["code"]["original"] == "name: old\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "champion_version_id,history_by_version,expected",
+    [
+        ("v1", {"v1": ["2026-04-12T12:00:00+00:00"], "v2": ["2026-04-15T12:00:00+00:00"]}, "all"),
+        (None, {}, "none"),
+        ("v1", {"v1": ["2026-04-12T12:00:00+00:00"]}, "some"),
+    ],
+)
+async def test_champion_coverage_all_none_some(
+    mock_api_client,
+    champion_version_id,
+    history_by_version,
+    expected,
+):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=champion_version_id)
+
+    def history_for(version_id):
+        return [
+            {"versionId": version_id, "enteredAt": entered_at, "previousChampionVersionId": "v0"}
+            for entered_at in history_by_version.get(version_id, [])
+        ]
+
+    versions = [
+        _version("v1", champion_history=history_for("v1")),
+        _version("v2", created_at="2026-04-14T12:00:00+00:00", champion_history=history_for("v2")),
+    ]
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=versions)),
+        patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
+    ):
+        output, _ = await block.generate()
+
+    assert output["summary"]["champion_coverage"] == expected
+
+
+@pytest.mark.asyncio
+async def test_uses_llm_summary_and_score_summaries(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None)
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[_version("v1")])),
+        patch.object(
+            block,
+            "_run_tac_inference",
+            new=AsyncMock(return_value=json.dumps({
+                "overall_summary": "Overall LLM summary.",
+                "score_summaries": {"score-1": "Score-specific LLM summary."},
+            })),
+        ) as run_llm,
+    ):
+        output, _ = await block.generate()
+
+    assert run_llm.await_count == 1
+    assert output["summary"]["text"] == "Overall LLM summary."
+    assert "1 starred version was created" in output["scores"][0]["summary"]
+    assert "v1 note" in output["scores"][0]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_llm_summary_failure_returns_report_error(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None)
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[_version("v1")])),
+        patch.object(block, "_run_tac_inference", new=AsyncMock(side_effect=RuntimeError("LLM unavailable"))),
+    ):
+        output, _ = await block.generate()
+
+    assert "LLM unavailable" in output["error"]
+    assert output["scores"] == []
+
+
+def test_extracts_structured_tactus_summary_as_json(mock_api_client):
+    block = _block({"scorecard": "sc-1"}, mock_api_client)
+
+    extracted = block._extract_tactus_text({
+        "text": {
+            "overall_summary": "Overall.",
+        }
+    })
+
+    assert json.loads(extracted) == {
+        "overall_summary": "Overall.",
+    }
+
+
+def test_extracts_nested_tactus_message_text(mock_api_client):
+    block = _block({"scorecard": "sc-1"}, mock_api_client)
+
+    extracted = block._extract_tactus_text({
+        "text": {
+            "output": [
+                {
+                    "content": [
+                        {"text": "{\"overall_summary\":\"Overall.\",\"score_summaries\":{}}"}
+                    ]
+                }
+            ]
+        }
+    })
+
+    assert extracted == "{\"overall_summary\":\"Overall.\",\"score_summaries\":{}}"

--- a/plexus/reports/blocks/scorecard_history_test.py
+++ b/plexus/reports/blocks/scorecard_history_test.py
@@ -42,6 +42,43 @@ def _version(
     }
 
 
+def _evaluation(
+    evaluation_id,
+    *,
+    evaluation_type,
+    status="COMPLETED",
+    created_at="2026-04-12T12:00:00+00:00",
+    score_version_id="v1",
+    accuracy=80,
+    alignment=0.7,
+    precision=0.6,
+    recall=0.5,
+    dataset_id=None,
+):
+    parameters = {"dataset_id": dataset_id} if dataset_id else {}
+    return {
+        "id": evaluation_id,
+        "type": evaluation_type,
+        "status": status,
+        "createdAt": created_at,
+        "updatedAt": created_at,
+        "parameters": parameters,
+        "scoreId": "score-1",
+        "scoreVersionId": score_version_id,
+        "accuracy": accuracy,
+        "processedItems": 90,
+        "totalItems": 100,
+        "metrics": {
+            "alignment": alignment,
+            "accuracy": accuracy,
+            "precision": precision,
+            "recall": recall,
+        },
+        "cost": 1.25,
+        "taskId": "task-1",
+    }
+
+
 def _summary_response(*score_ids):
     return json.dumps({
         "overall_summary": "Some included changes were promoted to champion.",
@@ -134,6 +171,7 @@ async def test_single_score_mode_filters_scope(mock_api_client):
             "_fetch_versions_for_score",
             new=AsyncMock(return_value=[_version("v1", note="Tightened routing criteria.")]),
         ),
+        patch.object(block, "_fetch_evaluations_for_version", new=AsyncMock(return_value=[])),
         patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
     ):
         output, _ = await block.generate()
@@ -175,6 +213,7 @@ async def test_filters_featured_versions_created_in_window_and_omits_unchanged_s
             "_fetch_versions_for_score",
             new=AsyncMock(side_effect=lambda score_id: versions_by_score[score_id]),
         ),
+        patch.object(block, "_fetch_evaluations_for_version", new=AsyncMock(return_value=[])),
         patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
     ):
         output, _ = await block.generate()
@@ -211,6 +250,7 @@ async def test_builds_parent_diff_payloads(mock_api_client):
         patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
         patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
         patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[parent, featured])),
+        patch.object(block, "_fetch_evaluations_for_version", new=AsyncMock(return_value=[])),
         patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
     ):
         output, _ = await block.generate()
@@ -224,6 +264,13 @@ async def test_builds_parent_diff_payloads(mock_api_client):
     assert version["diffs"]["guidelines"]["original"] == "# Old\n"
     assert version["diffs"]["guidelines"]["modified"] == "# New\n"
     assert version["diffs"]["code"]["has_changes"] is True
+    window_diff = output["scores"][0]["window_diff"]
+    assert window_diff["baseline_version_id"] == "v0"
+    assert window_diff["latest_version_id"] == "v1"
+    assert window_diff["code"]["original"] == "name: old\n"
+    assert window_diff["code"]["modified"] == "name: new\n"
+    assert "-name: old" in window_diff["code"]["unified_diff"]
+    assert "+name: new" in window_diff["code"]["unified_diff"]
 
 
 @pytest.mark.asyncio
@@ -242,6 +289,7 @@ async def test_fetches_missing_parent_version_for_diff(mock_api_client):
         patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
         patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[featured])),
         patch.object(block, "_fetch_score_version_by_id", new=AsyncMock(return_value=parent)) as fetch_parent,
+        patch.object(block, "_fetch_evaluations_for_version", new=AsyncMock(return_value=[])),
         patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
     ):
         output, _ = await block.generate()
@@ -287,6 +335,7 @@ async def test_champion_coverage_all_none_some(
         patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
         patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
         patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=versions)),
+        patch.object(block, "_fetch_evaluations_for_version", new=AsyncMock(return_value=[])),
         patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
     ):
         output, _ = await block.generate()
@@ -307,6 +356,7 @@ async def test_uses_llm_summary_and_score_summaries(mock_api_client):
         patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
         patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
         patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[_version("v1")])),
+        patch.object(block, "_fetch_evaluations_for_version", new=AsyncMock(return_value=[])),
         patch.object(
             block,
             "_run_tac_inference",
@@ -337,12 +387,178 @@ async def test_llm_summary_failure_returns_report_error(mock_api_client):
         patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
         patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
         patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[_version("v1")])),
+        patch.object(block, "_fetch_evaluations_for_version", new=AsyncMock(return_value=[])),
         patch.object(block, "_run_tac_inference", new=AsyncMock(side_effect=RuntimeError("LLM unavailable"))),
     ):
         output, _ = await block.generate()
 
     assert "LLM unavailable" in output["error"]
     assert output["scores"] == []
+
+
+@pytest.mark.asyncio
+async def test_performance_uses_latest_in_window_version_and_created_at_predecessor(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None)
+    versions = [
+        _version("v0", created_at="2026-03-31T12:00:00+00:00", is_featured="true"),
+        _version("v1", created_at="2026-04-10T12:00:00+00:00", is_featured="true"),
+        _version("v2", created_at="2026-04-20T12:00:00+00:00", is_featured="true"),
+    ]
+    evaluations_by_version = {
+        "v0": [_evaluation("eval-v0-feedback", evaluation_type="feedback", score_version_id="v0", alignment=0.42)],
+        "v2": [_evaluation("eval-v2-feedback", evaluation_type="feedback", score_version_id="v2", alignment=0.84)],
+    }
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=versions)),
+        patch.object(
+            block,
+            "_fetch_evaluations_for_version",
+            new=AsyncMock(side_effect=lambda version_id: evaluations_by_version.get(version_id, [])),
+        ),
+        patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
+    ):
+        output, _ = await block.generate()
+
+    performance = output["scores"][0]["performance"]
+    assert performance["current_version_id"] == "v2"
+    assert performance["baseline_version_id"] == "v0"
+    assert performance["recent_feedback"]["current"]["evaluation_id"] == "eval-v2-feedback"
+    assert performance["recent_feedback"]["current"]["metrics"] == {
+        "alignment": 0.84,
+        "accuracy": 80.0,
+        "precision": 0.6,
+        "recall": 0.5,
+    }
+    assert performance["recent_feedback"]["baseline"]["evaluation_id"] == "eval-v0-feedback"
+    assert performance["recent_feedback"]["baseline"]["metrics"]["alignment"] == 0.42
+
+
+@pytest.mark.asyncio
+async def test_regression_baseline_requires_same_dataset(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None)
+    versions = [
+        _version("v0", created_at="2026-03-31T12:00:00+00:00"),
+        _version("v1", created_at="2026-04-10T12:00:00+00:00"),
+    ]
+    evaluations_by_version = {
+        "v0": [
+            _evaluation(
+                "eval-v0-regression-other",
+                evaluation_type="accuracy",
+                score_version_id="v0",
+                alignment=0.91,
+                dataset_id="dataset-other",
+            ),
+            _evaluation(
+                "eval-v0-regression-same",
+                evaluation_type="accuracy",
+                score_version_id="v0",
+                alignment=0.72,
+                dataset_id="dataset-1",
+            ),
+        ],
+        "v1": [
+            _evaluation(
+                "eval-v1-regression",
+                evaluation_type="accuracy",
+                score_version_id="v1",
+                alignment=0.81,
+                dataset_id="dataset-1",
+            )
+        ],
+    }
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=versions)),
+        patch.object(
+            block,
+            "_fetch_evaluations_for_version",
+            new=AsyncMock(side_effect=lambda version_id: evaluations_by_version.get(version_id, [])),
+        ),
+        patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
+    ):
+        output, _ = await block.generate()
+
+    regression = output["scores"][0]["performance"]["regression"]
+    assert regression["current"]["evaluation_id"] == "eval-v1-regression"
+    assert regression["current"]["dataset_id"] == "dataset-1"
+    assert regression["baseline"]["evaluation_id"] == "eval-v0-regression-same"
+    assert regression["baseline"]["dataset_id"] == "dataset-1"
+
+
+@pytest.mark.asyncio
+async def test_omits_regression_without_dataset_and_omits_empty_performance(mock_api_client):
+    block = _block(
+        {"scorecard": "sc-1", "start_date": "2026-04-01", "end_date": "2026-04-30"},
+        mock_api_client,
+    )
+    scorecard = SimpleNamespace(id="sc-1", name="Scorecard")
+    scope = SimpleNamespace(score_id="score-1", score_name="Score 1", champion_version_id=None)
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_fetch_versions_for_score", new=AsyncMock(return_value=[_version("v1")])),
+        patch.object(
+            block,
+            "_fetch_evaluations_for_version",
+            new=AsyncMock(return_value=[_evaluation("eval-v1-accuracy", evaluation_type="accuracy")]),
+        ),
+        patch.object(block, "_run_tac_inference", new=AsyncMock(return_value=_summary_response("score-1"))),
+    ):
+        output, _ = await block.generate()
+
+    assert "performance" not in output["scores"][0]
+
+
+def test_selects_best_completed_evaluation_by_alignment_then_created_at(mock_api_client):
+    block = _block({"scorecard": "sc-1"}, mock_api_client)
+    evaluations = [
+        _evaluation("failed", evaluation_type="feedback", status="FAILED", alignment=0.99),
+        _evaluation("older-best", evaluation_type="feedback", alignment=0.80, created_at="2026-04-10T12:00:00+00:00"),
+        _evaluation("latest-tie", evaluation_type="feedback", alignment=0.80, created_at="2026-04-11T12:00:00+00:00"),
+        _evaluation("lower-latest", evaluation_type="feedback", alignment=0.70, created_at="2026-04-12T12:00:00+00:00"),
+    ]
+
+    selected = block._select_best_evaluation(evaluations, "feedback")
+
+    assert selected["id"] == "latest-tie"
+
+
+def test_metrics_payload_extracts_list_metrics_and_omits_missing_values(mock_api_client):
+    block = _block({"scorecard": "sc-1"}, mock_api_client)
+    evaluation = _evaluation(
+        "eval-list",
+        evaluation_type="feedback",
+        accuracy=None,
+        alignment=None,
+        precision=None,
+        recall=None,
+    )
+    evaluation["metrics"] = [
+        {"name": "Alignment", "value": 0.63},
+        {"name": "Precision", "value": 0.52},
+    ]
+
+    payload = block._metrics_payload(evaluation)
+
+    assert payload["metrics"] == {"alignment": 0.63, "precision": 0.52}
+    assert "dataset_id" not in payload
 
 
 def test_extracts_structured_tactus_summary_as_json(mock_api_client):

--- a/plexus/reports/procedures/single_turn_inference_reasoning.tac
+++ b/plexus/reports/procedures/single_turn_inference_reasoning.tac
@@ -18,18 +18,72 @@ Procedure {
         system_prompt = field.string{default = ""},
     },
     function(input)
-        local result = responder()
-        local text = ""
-        if type(result) == "table" then
-            text = result.output or result.response or ""
-        elseif result ~= nil then
-            -- Python object (lupa userdata) — try .output attribute access
-            local ok, output = pcall(function() return result.output end)
-            if ok and output ~= nil then
-                text = tostring(output)
-            else
-                text = tostring(result)
+        local function extract_text(value, depth)
+            depth = depth or 0
+            if value == nil or depth > 8 then
+                return ""
             end
+
+            local value_type = type(value)
+            if value_type == "string" then
+                return value
+            end
+            if value_type == "number" or value_type == "boolean" then
+                return tostring(value)
+            end
+            if value_type == "table" then
+                if type(value["overall_summary"]) == "string" then
+                    local escaped_summary = value["overall_summary"]
+                        :gsub("\\", "\\\\")
+                        :gsub('"', '\\"')
+                        :gsub("\n", "\\n")
+                        :gsub("\r", "\\r")
+                        :gsub("\t", "\\t")
+                    return '{"overall_summary":"' .. escaped_summary .. '"}'
+                end
+
+                local preferred_keys = { "reason", "text", "output", "content", "message", "response", "result" }
+                for _, key in ipairs(preferred_keys) do
+                    local extracted = extract_text(value[key], depth + 1)
+                    if extracted ~= "" then
+                        return extracted
+                    end
+                end
+
+                for _, nested in pairs(value) do
+                    local extracted = extract_text(nested, depth + 1)
+                    if extracted ~= "" then
+                        return extracted
+                    end
+                end
+
+                return ""
+            end
+
+            local object_keys = { "output", "text", "content", "response" }
+            for _, key in ipairs(object_keys) do
+                local ok, nested = pcall(function() return value[key] end)
+                if ok and nested ~= nil then
+                    local extracted = extract_text(nested, depth + 1)
+                    if extracted ~= "" then
+                        return extracted
+                    end
+                end
+            end
+
+            return ""
+        end
+
+        local result = responder()
+        local text = extract_text(result)
+        if text == "" and result ~= nil and type(result) ~= "table" then
+            text = tostring(result)
+        end
+        if type(text) ~= "string" then
+            text = tostring(text or "")
+        end
+        if string.find(string.lower(text), "<lua table at ", 1, true) then
+            text = ""
         end
         return { text = text }
     end

--- a/project/events/2026-05-05T16:25:28.536Z__eab2add7-9ad5-4eeb-a823-39bed9e8c747.json
+++ b/project/events/2026-05-05T16:25:28.536Z__eab2add7-9ad5-4eeb-a823-39bed9e8c747.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "eab2add7-9ad5-4eeb-a823-39bed9e8c747",
+  "issue_id": "plx-7c56b501-71cf-4991-b0d2-1d2dabfc2b38",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T16:25:28.536Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Feature: Scorecard History report\n\nAs a lab report user, I want a scorecard history report for starred score-version changes, so that I can explain what changed over a time period and whether those changes reached champion.\n\nScenario: Scorecard-wide history shows only changed scores\nGiven a scorecard has multiple scores\nAnd some scores have featured versions created in the requested window\nWhen I run the Scorecard History report without a score parameter\nThen the report includes only scores with featured versions created in the window.\n\nScenario: Single-score history limits scope\nGiven a scorecard has a selected score\nWhen I run the Scorecard History report with a score parameter\nThen the report includes featured versions created in the window only for that score.\n\nScenario: Champion coverage is summarized\nGiven included featured versions have champion status for all, none, or some versions\nWhen the report summary is generated\nThen it states whether all, none, or some included changes were promoted to champion.\n\nScenario: Diffs are available on demand\nGiven an included version has a parent version\nWhen I expand the version and then expand code or guidelines diff\nThen I see the original and modified content in a Monaco diff view.",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Scorecard history report summarizes starred score-version changes"
+  }
+}

--- a/project/events/2026-05-05T16:25:33.584Z__45d8e341-9004-4df1-905e-e17af25b4b28.json
+++ b/project/events/2026-05-05T16:25:33.584Z__45d8e341-9004-4df1-905e-e17af25b4b28.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "45d8e341-9004-4df1-905e-e17af25b4b28",
+  "issue_id": "plx-18d3b779-b749-4df4-809d-a994e9630049",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T16:25:33.584Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Build the Python ScorecardHistory report block with scorecard/score/date parameters, featured-version filtering, champion awareness from existing fields, parent diff payloads, and LLM summary generation. No schema changes.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Implement ScorecardHistory report block"
+  }
+}

--- a/project/events/2026-05-05T16:25:33.610Z__17ef54f2-f899-4ab2-b4eb-027a3a8ab1a6.json
+++ b/project/events/2026-05-05T16:25:33.610Z__17ef54f2-f899-4ab2-b4eb-027a3a8ab1a6.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "17ef54f2-f899-4ab2-b4eb-027a3a8ab1a6",
+  "issue_id": "plx-c5108007-7ea4-48b1-83d2-ce2984ce701f",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T16:25:33.610Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Add the dashboard ScorecardHistory block renderer, compacted output loading, summary-first layout, collapsed score versions, and collapsed Monaco code/guideline diffs.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Render ScorecardHistory dashboard block"
+  }
+}

--- a/project/events/2026-05-05T16:25:33.643Z__2b2cd742-3cfd-4185-ac2f-af6fd8fa3d15.json
+++ b/project/events/2026-05-05T16:25:33.643Z__2b2cd742-3cfd-4185-ac2f-af6fd8fa3d15.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "2b2cd742-3cfd-4185-ac2f-af6fd8fa3d15",
+  "issue_id": "plx-63486e72-bf52-420c-b93e-33959d6647c2",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T16:25:33.643Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Register the report block and add the direct plexus feedback report scorecard-history command with days and explicit date-window support.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Wire ScorecardHistory CLI and registry"
+  }
+}

--- a/project/events/2026-05-05T16:25:33.676Z__a7a89b14-e221-49b2-a40e-50bf1a195f36.json
+++ b/project/events/2026-05-05T16:25:33.676Z__a7a89b14-e221-49b2-a40e-50bf1a195f36.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "a7a89b14-e221-49b2-a40e-50bf1a195f36",
+  "issue_id": "plx-a341e48e-5868-4582-bcc1-449650d6f3c9",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T16:25:33.676Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Add backend, CLI, and dashboard tests for filtering, champion coverage, diff payloads, collapsed UI behavior, and mocked LLM summaries.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Test ScorecardHistory report"
+  }
+}

--- a/project/events/2026-05-05T16:25:39.429Z__9e2d8d15-4688-437c-b6ae-bb95265cff5c.json
+++ b/project/events/2026-05-05T16:25:39.429Z__9e2d8d15-4688-437c-b6ae-bb95265cff5c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9e2d8d15-4688-437c-b6ae-bb95265cff5c",
+  "issue_id": "plx-7c56b501-71cf-4991-b0d2-1d2dabfc2b38",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T16:25:39.429Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-05T16:25:41.844Z__67c57fd7-e396-44eb-9f1f-1c73572a9d47.json
+++ b/project/events/2026-05-05T16:25:41.844Z__67c57fd7-e396-44eb-9f1f-1c73572a9d47.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "67c57fd7-e396-44eb-9f1f-1c73572a9d47",
+  "issue_id": "plx-18d3b779-b749-4df4-809d-a994e9630049",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T16:25:41.844Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-05T16:25:44.947Z__131e2967-5fc6-43f4-88f0-b9f349aa5c07.json
+++ b/project/events/2026-05-05T16:25:44.947Z__131e2967-5fc6-43f4-88f0-b9f349aa5c07.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "131e2967-5fc6-43f4-88f0-b9f349aa5c07",
+  "issue_id": "plx-7c56b501-71cf-4991-b0d2-1d2dabfc2b38",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:25:44.947Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "cf01c53e-492d-4a4c-9aa7-6e25d0afb499"
+  }
+}

--- a/project/events/2026-05-05T16:42:08.252Z__49c16cf2-0476-4767-b2ab-41b0b680e243.json
+++ b/project/events/2026-05-05T16:42:08.252Z__49c16cf2-0476-4767-b2ab-41b0b680e243.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "49c16cf2-0476-4767-b2ab-41b0b680e243",
+  "issue_id": "plx-e613769c-052f-4300-8a3a-5a509c72c6fb",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:42:08.252Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "db0a414b-ebcd-45f9-8ab5-0f729f8a9f43"
+  }
+}

--- a/project/events/2026-05-05T16:42:12.708Z__650bc2de-5f92-4cce-9595-50f58cec4d48.json
+++ b/project/events/2026-05-05T16:42:12.708Z__650bc2de-5f92-4cce-9595-50f58cec4d48.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "650bc2de-5f92-4cce-9595-50f58cec4d48",
+  "issue_id": "plx-3d9714df-787a-44bc-8908-61108ced4042",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:42:12.708Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "86527252-a327-4651-beb6-76bec7a663a1"
+  }
+}

--- a/project/events/2026-05-05T16:42:17.363Z__66a35c14-324a-41ab-97f0-0aef68b53523.json
+++ b/project/events/2026-05-05T16:42:17.363Z__66a35c14-324a-41ab-97f0-0aef68b53523.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "66a35c14-324a-41ab-97f0-0aef68b53523",
+  "issue_id": "plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:42:17.363Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "f547f141-995e-4842-8d27-cc3617f50783"
+  }
+}

--- a/project/events/2026-05-05T16:46:05.757Z__027cbaef-8041-432a-94fd-808a7fce2876.json
+++ b/project/events/2026-05-05T16:46:05.757Z__027cbaef-8041-432a-94fd-808a7fce2876.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "027cbaef-8041-432a-94fd-808a7fce2876",
+  "issue_id": "plx-551be737-6e5b-4b82-9eba-461786aa9e2c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T16:46:05.757Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-05T16:46:05.760Z__d2d6576c-079a-43f0-93aa-b81202634620.json
+++ b/project/events/2026-05-05T16:46:05.760Z__d2d6576c-079a-43f0-93aa-b81202634620.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d2d6576c-079a-43f0-93aa-b81202634620",
+  "issue_id": "plx-551be737-6e5b-4b82-9eba-461786aa9e2c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:46:05.760Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "184eb2ca-a207-42b6-a2b3-6bfa60e6a267"
+  }
+}

--- a/project/events/2026-05-05T16:46:05.764Z__43cb1f1b-68c1-4011-97cf-1dfd73919bb5.json
+++ b/project/events/2026-05-05T16:46:05.764Z__43cb1f1b-68c1-4011-97cf-1dfd73919bb5.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "43cb1f1b-68c1-4011-97cf-1dfd73919bb5",
+  "issue_id": "plx-bc8f6c54-3ed9-40f9-aad8-a95685df6624",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:46:05.764Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "08857331-77b8-4cd8-8d2c-a8aae18eec9f"
+  }
+}

--- a/project/events/2026-05-05T16:57:49.020Z__ceebd307-d74d-467f-a5f7-c9d6dd494fbc.json
+++ b/project/events/2026-05-05T16:57:49.020Z__ceebd307-d74d-467f-a5f7-c9d6dd494fbc.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ceebd307-d74d-467f-a5f7-c9d6dd494fbc",
+  "issue_id": "plx-18d3b779-b749-4df4-809d-a994e9630049",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:57:49.020Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a4671be7-37b5-466b-9261-81d94dfbe0af"
+  }
+}

--- a/project/events/2026-05-05T16:58:23.396Z__8563d72f-67f6-456b-8cda-ff8f7554ca0e.json
+++ b/project/events/2026-05-05T16:58:23.396Z__8563d72f-67f6-456b-8cda-ff8f7554ca0e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8563d72f-67f6-456b-8cda-ff8f7554ca0e",
+  "issue_id": "plx-18d3b779-b749-4df4-809d-a994e9630049",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:58:23.396Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "6551bb35-a8cf-4113-adec-24e9e8b9413c"
+  }
+}

--- a/project/events/2026-05-05T16:58:31.985Z__84a3c0e3-9454-4d2a-9126-8907d3e43d32.json
+++ b/project/events/2026-05-05T16:58:31.985Z__84a3c0e3-9454-4d2a-9126-8907d3e43d32.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "84a3c0e3-9454-4d2a-9126-8907d3e43d32",
+  "issue_id": "plx-18d3b779-b749-4df4-809d-a994e9630049",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T16:58:31.985Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-05T16:58:34.714Z__aff2d216-7307-414b-bcb5-35acca1122f7.json
+++ b/project/events/2026-05-05T16:58:34.714Z__aff2d216-7307-414b-bcb5-35acca1122f7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "aff2d216-7307-414b-bcb5-35acca1122f7",
+  "issue_id": "plx-c5108007-7ea4-48b1-83d2-ce2984ce701f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:58:34.714Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "7fe8085c-fe0e-4fda-9567-b3f67b2fcc7e"
+  }
+}

--- a/project/events/2026-05-05T16:58:36.722Z__50838b2b-d97e-42c9-9e94-5adb2ee3009d.json
+++ b/project/events/2026-05-05T16:58:36.722Z__50838b2b-d97e-42c9-9e94-5adb2ee3009d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "50838b2b-d97e-42c9-9e94-5adb2ee3009d",
+  "issue_id": "plx-c5108007-7ea4-48b1-83d2-ce2984ce701f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T16:58:36.722Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-05T16:58:39.661Z__67e809f7-19e7-4f1b-b6a7-03cd9bdb940a.json
+++ b/project/events/2026-05-05T16:58:39.661Z__67e809f7-19e7-4f1b-b6a7-03cd9bdb940a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "67e809f7-19e7-4f1b-b6a7-03cd9bdb940a",
+  "issue_id": "plx-63486e72-bf52-420c-b93e-33959d6647c2",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:58:39.661Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "b7589cb2-2542-496c-b525-27b70935cad1"
+  }
+}

--- a/project/events/2026-05-05T16:58:41.552Z__8c873ec5-d919-4321-83f4-babb841abf65.json
+++ b/project/events/2026-05-05T16:58:41.552Z__8c873ec5-d919-4321-83f4-babb841abf65.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8c873ec5-d919-4321-83f4-babb841abf65",
+  "issue_id": "plx-63486e72-bf52-420c-b93e-33959d6647c2",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T16:58:41.552Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-05T16:58:44.271Z__9ee3c605-02b0-459e-a62e-56ec13b7a4bd.json
+++ b/project/events/2026-05-05T16:58:44.271Z__9ee3c605-02b0-459e-a62e-56ec13b7a4bd.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9ee3c605-02b0-459e-a62e-56ec13b7a4bd",
+  "issue_id": "plx-a341e48e-5868-4582-bcc1-449650d6f3c9",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:58:44.271Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "20e312a9-0c3b-40fd-b5d7-ab1b6076dd91"
+  }
+}

--- a/project/events/2026-05-05T16:58:46.168Z__9f60b0b9-7060-4354-ae24-79afadd2b09f.json
+++ b/project/events/2026-05-05T16:58:46.168Z__9f60b0b9-7060-4354-ae24-79afadd2b09f.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9f60b0b9-7060-4354-ae24-79afadd2b09f",
+  "issue_id": "plx-a341e48e-5868-4582-bcc1-449650d6f3c9",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T16:58:46.168Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-05T16:58:49.159Z__5f41ea62-b770-4c3d-a4cb-fdde97575e01.json
+++ b/project/events/2026-05-05T16:58:49.159Z__5f41ea62-b770-4c3d-a4cb-fdde97575e01.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5f41ea62-b770-4c3d-a4cb-fdde97575e01",
+  "issue_id": "plx-7c56b501-71cf-4991-b0d2-1d2dabfc2b38",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T16:58:49.159Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "fa3b3620-7b25-4524-9365-01bd93cb08e7"
+  }
+}

--- a/project/events/2026-05-05T16:58:51.109Z__94641c6b-d5a2-4a10-acef-afa3d47b3244.json
+++ b/project/events/2026-05-05T16:58:51.109Z__94641c6b-d5a2-4a10-acef-afa3d47b3244.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "94641c6b-d5a2-4a10-acef-afa3d47b3244",
+  "issue_id": "plx-7c56b501-71cf-4991-b0d2-1d2dabfc2b38",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T16:58:51.109Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-05T17:26:42.462Z__a8b92b2e-adef-42f4-a599-7303c98b5aa2.json
+++ b/project/events/2026-05-05T17:26:42.462Z__a8b92b2e-adef-42f4-a599-7303c98b5aa2.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "a8b92b2e-adef-42f4-a599-7303c98b5aa2",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T17:26:42.462Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "priority": 1,
+    "status": "open",
+    "title": "Add evaluation gauges to Scorecard History report"
+  }
+}

--- a/project/events/2026-05-05T17:26:57.260Z__d65e7f8d-4d52-4095-ac01-21db46de10e2.json
+++ b/project/events/2026-05-05T17:26:57.260Z__d65e7f8d-4d52-4095-ac01-21db46de10e2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d65e7f8d-4d52-4095-ac01-21db46de10e2",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T17:26:57.260Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-05T17:33:45.736Z__e69d2510-8290-4d28-a7bc-6cb51ef01756.json
+++ b/project/events/2026-05-05T17:33:45.736Z__e69d2510-8290-4d28-a7bc-6cb51ef01756.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e69d2510-8290-4d28-a7bc-6cb51ef01756",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T17:33:45.736Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "80154d8b-0cc2-493b-95e6-51bca3c1822a"
+  }
+}

--- a/project/events/2026-05-05T17:34:23.182Z__943658eb-2b3d-4b8f-b40f-eaa256d7898c.json
+++ b/project/events/2026-05-05T17:34:23.182Z__943658eb-2b3d-4b8f-b40f-eaa256d7898c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "943658eb-2b3d-4b8f-b40f-eaa256d7898c",
+  "issue_id": "plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T17:34:23.182Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a06090c6-37a3-45aa-be81-c521d01e8a53"
+  }
+}

--- a/project/events/2026-05-05T17:44:08.936Z__07193695-e7d7-4167-937a-fba665ccccae.json
+++ b/project/events/2026-05-05T17:44:08.936Z__07193695-e7d7-4167-937a-fba665ccccae.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "07193695-e7d7-4167-937a-fba665ccccae",
+  "issue_id": "plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T17:44:08.936Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "1a4d3812-787c-47ef-9198-5341d3a9f1b0"
+  }
+}

--- a/project/events/2026-05-05T17:47:28.721Z__44a31678-e334-49ab-b7f1-b1a32f021ce6.json
+++ b/project/events/2026-05-05T17:47:28.721Z__44a31678-e334-49ab-b7f1-b1a32f021ce6.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "44a31678-e334-49ab-b7f1-b1a32f021ce6",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T17:47:28.721Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "d3b48fbd-aead-4d21-bb1e-819f3103ee2e"
+  }
+}

--- a/project/events/2026-05-05T17:57:04.942Z__ca41f30c-9cd3-4f57-be61-8f4c5cfffbd5.json
+++ b/project/events/2026-05-05T17:57:04.942Z__ca41f30c-9cd3-4f57-be61-8f4c5cfffbd5.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ca41f30c-9cd3-4f57-be61-8f4c5cfffbd5",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T17:57:04.942Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "bc22409b-b505-4014-9489-da19f720f1b3"
+  }
+}

--- a/project/events/2026-05-05T17:57:57.824Z__bbaa8d37-8c38-4688-9f8f-e5c2b65074cc.json
+++ b/project/events/2026-05-05T17:57:57.824Z__bbaa8d37-8c38-4688-9f8f-e5c2b65074cc.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bbaa8d37-8c38-4688-9f8f-e5c2b65074cc",
+  "issue_id": "plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T17:57:57.824Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "ae76caf0-b309-4a3a-b1fd-fdb2f725df17"
+  }
+}

--- a/project/events/2026-05-05T17:59:10.380Z__260ffebc-eb12-4afe-bf6f-f40b6e9b279e.json
+++ b/project/events/2026-05-05T17:59:10.380Z__260ffebc-eb12-4afe-bf6f-f40b6e9b279e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "260ffebc-eb12-4afe-bf6f-f40b6e9b279e",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T17:59:10.380Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "eee782ab-8335-4075-b146-3be96105d344"
+  }
+}

--- a/project/events/2026-05-05T18:00:05.425Z__2a09b2aa-8e03-407e-90af-96b7f5ee8716.json
+++ b/project/events/2026-05-05T18:00:05.425Z__2a09b2aa-8e03-407e-90af-96b7f5ee8716.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2a09b2aa-8e03-407e-90af-96b7f5ee8716",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T18:00:05.425Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "4e0dae7e-dc7a-4aa8-aef6-d6eabcf798e2"
+  }
+}

--- a/project/events/2026-05-05T18:08:42.197Z__e6bf3617-b965-4602-9583-d6d645c3e9af.json
+++ b/project/events/2026-05-05T18:08:42.197Z__e6bf3617-b965-4602-9583-d6d645c3e9af.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e6bf3617-b965-4602-9583-d6d645c3e9af",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T18:08:42.197Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "eefb314d-35a5-4d32-8658-5fadfc94c984"
+  }
+}

--- a/project/events/2026-05-05T18:09:22.185Z__7f227275-6924-405c-8e8f-2bfe0fb56632.json
+++ b/project/events/2026-05-05T18:09:22.185Z__7f227275-6924-405c-8e8f-2bfe0fb56632.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7f227275-6924-405c-8e8f-2bfe0fb56632",
+  "issue_id": "plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T18:09:22.185Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "9c7ed6de-0ff5-4d91-bc05-945319c75702"
+  }
+}

--- a/project/events/2026-05-05T18:12:07.176Z__f8d4a7ad-fcf6-4577-b59b-62e291bdb8d8.json
+++ b/project/events/2026-05-05T18:12:07.176Z__f8d4a7ad-fcf6-4577-b59b-62e291bdb8d8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f8d4a7ad-fcf6-4577-b59b-62e291bdb8d8",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T18:12:07.176Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a67db98a-2957-4c4a-a392-a46ffb2c84cd"
+  }
+}

--- a/project/events/2026-05-05T18:13:31.089Z__a775c991-9ed4-49be-80d8-9c59c5041feb.json
+++ b/project/events/2026-05-05T18:13:31.089Z__a775c991-9ed4-49be-80d8-9c59c5041feb.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a775c991-9ed4-49be-80d8-9c59c5041feb",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T18:13:31.089Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "ccbf4558-1ddc-4021-94ff-4dd3a288cb85"
+  }
+}

--- a/project/issues/plx-18d3b779-b749-4df4-809d-a994e9630049.json
+++ b/project/issues/plx-18d3b779-b749-4df4-809d-a994e9630049.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-18d3b779-b749-4df4-809d-a994e9630049",
+  "title": "Implement ScorecardHistory report block",
+  "description": "Build the Python ScorecardHistory report block with scorecard/score/date parameters, featured-version filtering, champion awareness from existing fields, parent diff payloads, and LLM summary generation. No schema changes.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "a4671be7-37b5-466b-9261-81d94dfbe0af",
+      "author": "ryan",
+      "text": "Implemented ScorecardHistory backend block with scorecard/single-score scope resolution, days or explicit date windows, featured-version filtering, champion-awareness, parent diff payloads, and LLM top summary error handling.",
+      "created_at": "2026-05-05T16:57:49.020173Z"
+    },
+    {
+      "id": "6551bb35-a8cf-4113-adec-24e9e8b9413c",
+      "author": "ryan",
+      "text": "Backend validation complete: focused report block tests pass and the manual ScorecardHistory run succeeded against SelectQuote HCS Medium-Risk using scorecard external ID 1438.",
+      "created_at": "2026-05-05T16:58:23.396424Z"
+    }
+  ],
+  "created_at": "2026-05-05T16:25:33.584076Z",
+  "updated_at": "2026-05-05T16:58:31.984959Z",
+  "closed_at": "2026-05-05T16:58:31.984959Z",
+  "custom": {}
+}

--- a/project/issues/plx-3d9714df-787a-44bc-8908-61108ced4042.json
+++ b/project/issues/plx-3d9714df-787a-44bc-8908-61108ced4042.json
@@ -34,10 +34,16 @@
       "author": "ryan",
       "text": "Stopped the active Dosage optimizer direct-CLI process on 2026-04-23 at process level. Terminated optimizer shell PID 95073 and child optimizer PID 95085; verification via pgrep shows no remaining `python -m plexus.cli procedure optimize --scorecard SelectQuote HCS Medium-Risk --score Medication Review: Dosage` process. Also cleaned up the abandoned item-ID feedback invalidation process from the earlier failed command path.",
       "created_at": "2026-04-23T20:51:30.135593Z"
+    },
+    {
+      "id": "86527252-a327-4651-beb6-76bec7a663a1",
+      "author": "ryan",
+      "text": "2026-05-05 Dosage optimization continuation: after the approved invalidation and cleaned baseline, tested three candidate versions. Rejected 0436ddcd-4128-47be-a808-c77c0a17ca30 because it regressed to 74.39% (61/82). Skipped 1d35f881-8884-4523-81b6-4e2fceb10de0 because it matched baseline at 80.49% while adding context cost. Promoted 0c2bf0b8-6923-4b5a-9da7-98a526562df5 after eval 2fd9ab6b-1547-4264-a366-6949008b6276 scored 86.59% (71/82), confusion [[40,6],[5,31]], alignment 0.7349, precision 83.78%, recall 86.11%. Champion moved from d1fb6cf4-4633-4909-9d50-7ad5f7be4d42 to 0c2bf0b8-6923-4b5a-9da7-98a526562df5 and was verified by score.info.",
+      "created_at": "2026-05-05T16:42:12.708568Z"
     }
   ],
   "created_at": "2026-04-23T05:59:09.781153Z",
-  "updated_at": "2026-04-23T20:51:30.135593Z",
+  "updated_at": "2026-05-05T16:42:12.708568Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-551be737-6e5b-4b82-9eba-461786aa9e2c.json
+++ b/project/issues/plx-551be737-6e5b-4b82-9eba-461786aa9e2c.json
@@ -3,16 +3,23 @@
   "title": "Align Medication Review Pharmacy implementation with current-pharmacy guideline",
   "description": "The current Medication Review: Pharmacy champion code is materially looser than the published guideline. The system/user prompts currently allow broad pharmacy-information discussion and even say No only when no pharmacy discussion occurs, while the guideline requires establishing a specific current pharmacy and excludes general/future/transfer-only discussion. Fix the live implementation so the prompt logic matches the published current-pharmacy rubric, then verify on representative SRX and SPM examples.",
   "type": "sub-task",
-  "status": "open",
+  "status": "in_progress",
   "priority": 2,
   "assignee": null,
   "creator": null,
   "parent": "plx-d856c7eb-ce41-4d1b-a2e6-196d825a6634",
   "labels": [],
   "dependencies": [],
-  "comments": [],
+  "comments": [
+    {
+      "id": "184eb2ca-a207-42b6-a2b3-6bfa60e6a267",
+      "author": "ryan",
+      "text": "2026-05-05: Starting active Pharmacy optimization pass after user requested better Pharmacy/Prescriber performance. Will inspect current champion, run recent feedback evaluation, then test narrow implementation/guideline candidates only if they preserve the client policy alignment.",
+      "created_at": "2026-05-05T16:46:05.760276Z"
+    }
+  ],
   "created_at": "2026-04-23T19:57:23.591053Z",
-  "updated_at": "2026-04-23T19:57:23.591053Z",
+  "updated_at": "2026-05-05T16:46:05.760276Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-63486e72-bf52-420c-b93e-33959d6647c2.json
+++ b/project/issues/plx-63486e72-bf52-420c-b93e-33959d6647c2.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-63486e72-bf52-420c-b93e-33959d6647c2",
+  "title": "Wire ScorecardHistory CLI and registry",
+  "description": "Register the report block and add the direct plexus feedback report scorecard-history command with days and explicit date-window support.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "b7589cb2-2542-496c-b525-27b70935cad1",
+      "author": "ryan",
+      "text": "Registered ScorecardHistory in the report block registry and added the direct CLI command: plexus feedback report scorecard-history --scorecard <identifier> [--score <identifier>] with --days or --start-date/--end-date.",
+      "created_at": "2026-05-05T16:58:39.661791Z"
+    }
+  ],
+  "created_at": "2026-05-05T16:25:33.642893Z",
+  "updated_at": "2026-05-05T16:58:41.552222Z",
+  "closed_at": "2026-05-05T16:58:41.552222Z",
+  "custom": {}
+}

--- a/project/issues/plx-7c56b501-71cf-4991-b0d2-1d2dabfc2b38.json
+++ b/project/issues/plx-7c56b501-71cf-4991-b0d2-1d2dabfc2b38.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-7c56b501-71cf-4991-b0d2-1d2dabfc2b38",
+  "title": "Scorecard history report summarizes starred score-version changes",
+  "description": "Feature: Scorecard History report\n\nAs a lab report user, I want a scorecard history report for starred score-version changes, so that I can explain what changed over a time period and whether those changes reached champion.\n\nScenario: Scorecard-wide history shows only changed scores\nGiven a scorecard has multiple scores\nAnd some scores have featured versions created in the requested window\nWhen I run the Scorecard History report without a score parameter\nThen the report includes only scores with featured versions created in the window.\n\nScenario: Single-score history limits scope\nGiven a scorecard has a selected score\nWhen I run the Scorecard History report with a score parameter\nThen the report includes featured versions created in the window only for that score.\n\nScenario: Champion coverage is summarized\nGiven included featured versions have champion status for all, none, or some versions\nWhen the report summary is generated\nThen it states whether all, none, or some included changes were promoted to champion.\n\nScenario: Diffs are available on demand\nGiven an included version has a parent version\nWhen I expand the version and then expand code or guidelines diff\nThen I see the original and modified content in a Monaco diff view.",
+  "type": "story",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "cf01c53e-492d-4a4c-9aa7-6e25d0afb499",
+      "author": "ryan",
+      "text": "Implementation branch created from origin/develop. Confirmed no schema changes; the report will use existing Score/ScoreVersion fields only: isFeatured, createdAt, parentVersionId, metadata.championHistory, configuration, guidelines, and championVersionId.",
+      "created_at": "2026-05-05T16:25:44.947578Z"
+    },
+    {
+      "id": "fa3b3620-7b25-4524-9365-01bd93cb08e7",
+      "author": "ryan",
+      "text": "Scorecard History behavior implemented with no schema changes. It reports starred versions created inside the requested window, omits unchanged scores, includes parent code/guideline diffs for on-demand dashboard viewing, and summarizes champion coverage across all/none/some included changes.",
+      "created_at": "2026-05-05T16:58:49.159400Z"
+    }
+  ],
+  "created_at": "2026-05-05T16:25:28.535393Z",
+  "updated_at": "2026-05-05T16:58:51.108890Z",
+  "closed_at": "2026-05-05T16:58:51.108890Z",
+  "custom": {}
+}

--- a/project/issues/plx-a341e48e-5868-4582-bcc1-449650d6f3c9.json
+++ b/project/issues/plx-a341e48e-5868-4582-bcc1-449650d6f3c9.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-a341e48e-5868-4582-bcc1-449650d6f3c9",
+  "title": "Test ScorecardHistory report",
+  "description": "Add backend, CLI, and dashboard tests for filtering, champion coverage, diff payloads, collapsed UI behavior, and mocked LLM summaries.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "20e312a9-0c3b-40fd-b5d7-ab1b6076dd91",
+      "author": "ryan",
+      "text": "Validation complete: Python report block tests pass, CLI mapping tests pass, ScorecardHistory Jest tests pass, dashboard typecheck passed, py_compile passed, and manual CLI validation completed using scorecard external ID 1438.",
+      "created_at": "2026-05-05T16:58:44.271501Z"
+    }
+  ],
+  "created_at": "2026-05-05T16:25:33.676470Z",
+  "updated_at": "2026-05-05T16:58:46.168149Z",
+  "closed_at": "2026-05-05T16:58:46.168149Z",
+  "custom": {}
+}

--- a/project/issues/plx-bc8f6c54-3ed9-40f9-aad8-a95685df6624.json
+++ b/project/issues/plx-bc8f6c54-3ed9-40f9-aad8-a95685df6624.json
@@ -82,10 +82,16 @@
       "author": "ryan",
       "text": "Previous Prescriber optimizer launch cab4382c-09a9-4458-bfb0-cd6da0ca3fb5 failed at bootstrap because the cleaned regression pool has only 47 qualifying rows and max_samples=200 implies a hard minimum of 50 rows. Verified that widening to 365 days or all-time does not increase the usable pool beyond 47. Relaunched clean from direct CLI with days=365, max_samples=188, max_iterations=20, start_version=63892e5d-bacc-483c-89ff-429ff2131100, and the recorded GPT 5.4 mini hint. New live run: procedure=175ddd08-5d42-4519-828a-118015348800 task=f6a2c021-46a7-402b-9e61-2c21333e106c chat=f97ea77b-6429-4008-9829-dd91ef9d9db5 log=/tmp/prescriber-optimizer-relaunch-20260423-173949.log pid=54245. Direct CLI log shows the associated dataset was accepted at 47 rows (dataset 9ad2c963-125b-40ac-806f-c4ab6e7b5483), then the optimizer progressed into fresh baseline evaluation dispatch and root-cause analysis, which is past the prior failure point.",
       "created_at": "2026-04-23T21:44:22.489112Z"
+    },
+    {
+      "id": "08857331-77b8-4cd8-8d2c-a8aae18eec9f",
+      "author": "ryan",
+      "text": "2026-05-05: Starting follow-up Prescriber optimization pass after post-invalidation champion re-eval landed at 87.21%. Will inspect current champion, use recent feedback/RCA evidence, and test narrow candidates without reintroducing explicit customer-confirmation requirements.",
+      "created_at": "2026-05-05T16:46:05.764080Z"
     }
   ],
   "created_at": "2026-04-23T19:51:47.677766Z",
-  "updated_at": "2026-04-23T21:44:22.489112Z",
+  "updated_at": "2026-05-05T16:46:05.764080Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-c5108007-7ea4-48b1-83d2-ce2984ce701f.json
+++ b/project/issues/plx-c5108007-7ea4-48b1-83d2-ce2984ce701f.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-c5108007-7ea4-48b1-83d2-ce2984ce701f",
+  "title": "Render ScorecardHistory dashboard block",
+  "description": "Add the dashboard ScorecardHistory block renderer, compacted output loading, summary-first layout, collapsed score versions, and collapsed Monaco code/guideline diffs.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "7fe8085c-fe0e-4fda-9567-b3f67b2fcc7e",
+      "author": "ryan",
+      "text": "Implemented the ScorecardHistory dashboard block with visible top and per-score summaries, collapsed score-version sections by default, collapsed code/guidelines diffs by default, and lazy-mounted Monaco DiffEditor views after expansion.",
+      "created_at": "2026-05-05T16:58:34.714792Z"
+    }
+  ],
+  "created_at": "2026-05-05T16:25:33.610545Z",
+  "updated_at": "2026-05-05T16:58:36.722221Z",
+  "closed_at": "2026-05-05T16:58:36.722221Z",
+  "custom": {}
+}

--- a/project/issues/plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1.json
+++ b/project/issues/plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1.json
@@ -1,0 +1,67 @@
+{
+  "id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "title": "Add evaluation gauges to Scorecard History report",
+  "description": "",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "80154d8b-0cc2-493b-95e6-51bca3c1822a",
+      "author": "ryan",
+      "text": "Implemented local backend and dashboard support for Scorecard History evaluation gauges. Manual fresh report run created report 1d2ebc2e-ef3e-4bbe-81ce-9cd81a0a81a8 with performance payloads on 4 of 5 changed scores. Awaiting human review; not committed or pushed.",
+      "created_at": "2026-05-05T17:33:45.735168Z"
+    },
+    {
+      "id": "d3b48fbd-aead-4d21-bb1e-819f3103ee2e",
+      "author": "ryan",
+      "text": "Updated generated summaries to categorized Markdown bullet lists for top-level and per-score summaries. Fresh report 054d4876-d764-4d7a-85d2-1b301425affa generated successfully for human review.",
+      "created_at": "2026-05-05T17:47:28.721303Z"
+    },
+    {
+      "id": "bc22409b-b505-4014-9489-da19f720f1b3",
+      "author": "ryan",
+      "text": "Adding score-level window diffs: compare the latest same-score version before the report window to the latest in-window starred version, in addition to existing per-version diffs.",
+      "created_at": "2026-05-05T17:57:04.941272Z"
+    },
+    {
+      "id": "eee782ab-8335-4075-b146-3be96105d344",
+      "author": "ryan",
+      "text": "Added full-window score diffs from the latest version before the report window to the latest included starred version. Fresh report b43acd7d-11c5-411b-9528-3805a2c8984c generated with window_diff on all 5 changed scores.",
+      "created_at": "2026-05-05T17:59:10.380255Z"
+    },
+    {
+      "id": "4e0dae7e-dc7a-4aa8-aef6-d6eabcf798e2",
+      "author": "ryan",
+      "text": "Adjusted Scorecard History evaluation metric tabs to use the score component's subtle underline tab styling: transparent background, no pill/shadow, active border-only indicator.",
+      "created_at": "2026-05-05T18:00:05.422131Z"
+    },
+    {
+      "id": "eefb314d-35a5-4d32-8658-5fadfc94c984",
+      "author": "ryan",
+      "text": "Removed the per-dataset label/evaluation-id row above Scorecard History gauges so the subtle tab selector sits directly above the gauge grid.",
+      "created_at": "2026-05-05T18:08:42.196656Z"
+    },
+    {
+      "id": "a67db98a-2957-4c4a-a392-a46ffb2c84cd",
+      "author": "ryan",
+      "text": "Changed the Scorecard History score summary/gauge layout from viewport-breakpoint grid to wrapping flex columns, so gauges move below the text when the score section itself is too narrow.",
+      "created_at": "2026-05-05T18:12:07.176232Z"
+    },
+    {
+      "id": "ccbf4558-1ddc-4021-94ff-4dd3a288cb85",
+      "author": "ryan",
+      "text": "Moved Scorecard History change notes into their own full-width row after the summary/gauge row, so wrapped/narrow layouts show gauges before change notes.",
+      "created_at": "2026-05-05T18:13:31.088602Z"
+    }
+  ],
+  "created_at": "2026-05-05T17:26:42.461913Z",
+  "updated_at": "2026-05-05T18:13:31.088602Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-e613769c-052f-4300-8a3a-5a509c72c6fb.json
+++ b/project/issues/plx-e613769c-052f-4300-8a3a-5a509c72c6fb.json
@@ -142,10 +142,16 @@
       "author": "ryan",
       "text": "Invalidated exactly the two approved Prescriber contradiction items via targeted feedback invalidation: 305141716 (73c423c3-1ac0-4400-bcfe-82db678665b1) and 309504413 (43709332-f4e0-4338-b3e1-e59121b47c92). Both returned updated=true and already_invalid=false. No other Prescriber feedback items were touched.",
       "created_at": "2026-04-23T20:38:26.497835Z"
+    },
+    {
+      "id": "db0a414b-ebcd-45f9-8ab5-0f729f8a9f43",
+      "author": "ryan",
+      "text": "2026-05-05 update: executed the user-approved strong policy-drift invalidations from the latest Medication Review pass. Invalidated Dosage feedback d95201b3-ce0e-4b08-8924-677197ac303a and Prescriber feedback 396d3c3b-827a-40b9-be91-f9efb4cee341 only. Post-invalidation re-evals completed: Dosage eval 60ff1cfa-64e1-4d99-a898-3a11e08a13a6 on champion d1fb6cf4 = 80.49% (66/82), confusion [[39,7],[9,27]]; Prescriber eval 5ec4100f-f06e-4377-bf7d-33a9f41a4929 on champion 3a51521a = 87.21% (75/86), confusion [[56,2],[9,19]]. No other feedback items invalidated.",
+      "created_at": "2026-05-05T16:42:08.251098Z"
     }
   ],
   "created_at": "2026-04-22T14:30:09.933567Z",
-  "updated_at": "2026-04-23T20:38:26.497835Z",
+  "updated_at": "2026-05-05T16:42:08.251098Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb.json
+++ b/project/issues/plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb.json
@@ -10,9 +10,16 @@
   "parent": null,
   "labels": [],
   "dependencies": [],
-  "comments": [],
+  "comments": [
+    {
+      "id": "f547f141-995e-4842-8d27-cc3617f50783",
+      "author": "ryan",
+      "text": "2026-05-05 champion state update: Medication Review Dosage, Pharmacy, and Prescriber had already been aligned to the client policy that dosage/pharmacy/prescriber customer confirmation is not separately required when Individual Confirmation covers individual confirmation. Champions now: Dosage 0c2bf0b8-6923-4b5a-9da7-98a526562df5 (promoted today after 86.59% cleaned 30-day feedback eval), Pharmacy 8f226eb1-f6a7-4a94-a712-d7314ba4acf7, Prescriber 3a51521a-691d-4e90-8e89-67ad6f3ce595. Post-invalidation Prescriber eval confirmed 87.21% (75/86). Strong policy-drift invalidations performed today were limited to Dosage d95201b3-ce0e-4b08-8924-677197ac303a and Prescriber 396d3c3b-827a-40b9-be91-f9efb4cee341.",
+      "created_at": "2026-05-05T16:42:17.363094Z"
+    }
+  ],
   "created_at": "2026-04-22T13:19:21.731868Z",
-  "updated_at": "2026-04-22T13:19:51.547815Z",
+  "updated_at": "2026-05-05T16:42:17.363094Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb.json
+++ b/project/issues/plx-f506cb4b-4478-4ab6-87dd-701cc8c41beb.json
@@ -16,10 +16,34 @@
       "author": "ryan",
       "text": "2026-05-05 champion state update: Medication Review Dosage, Pharmacy, and Prescriber had already been aligned to the client policy that dosage/pharmacy/prescriber customer confirmation is not separately required when Individual Confirmation covers individual confirmation. Champions now: Dosage 0c2bf0b8-6923-4b5a-9da7-98a526562df5 (promoted today after 86.59% cleaned 30-day feedback eval), Pharmacy 8f226eb1-f6a7-4a94-a712-d7314ba4acf7, Prescriber 3a51521a-691d-4e90-8e89-67ad6f3ce595. Post-invalidation Prescriber eval confirmed 87.21% (75/86). Strong policy-drift invalidations performed today were limited to Dosage d95201b3-ce0e-4b08-8924-677197ac303a and Prescriber 396d3c3b-827a-40b9-be91-f9efb4cee341.",
       "created_at": "2026-05-05T16:42:17.363094Z"
+    },
+    {
+      "id": "a06090c6-37a3-45aa-be81-c521d01e8a53",
+      "author": "ryan",
+      "text": "2026-05-05: User requested clearer ScoreVersion labels/notes explaining what changed and why. Updating existing Medication Review champion and recent candidate ScoreVersion notes directly via updateScoreVersion so version history/promotion packets are self-explanatory.",
+      "created_at": "2026-05-05T17:34:23.181935Z"
+    },
+    {
+      "id": "1a4d3812-787c-47ef-9198-5341d3a9f1b0",
+      "author": "ryan",
+      "text": "Pharmacy GPT-5.4-mini model-only candidate 35b96510-fae1-4c02-9243-e0f8cc5641d4 evaluated on the same 72 newest feedback items: 66/72 (91.67%), confusion no/no=5 no/yes=0 yes/no=6 yes/yes=61, below current champion 8f226eb1-f6a7-4a94-a712-d7314ba4acf7 at 68/72 (94.44%). Leaving Pharmacy champion unchanged and labeling the GPT-5.4-mini version as rejected.",
+      "created_at": "2026-05-05T17:44:08.936113Z"
+    },
+    {
+      "id": "ae76caf0-b309-4a3a-b1fd-fdb2f725df17",
+      "author": "ryan",
+      "text": "Pharmacy paired model repeat completed after user noted single-run stochastic variation: gpt-5-mini candidate 051a6bc5 repeated at 68/72 (94.44%, eval e999605e), while GPT-5.4-mini candidate 35b96510 repeated at 66/72 (91.67%, eval fccff8cd). Updated ScoreVersion notes to frame this as no demonstrated improvement / not promoted, not proof that GPT-5.4-mini is intrinsically worse. Pharmacy champion remains 8f226eb1.",
+      "created_at": "2026-05-05T17:57:57.823613Z"
+    },
+    {
+      "id": "9c7ed6de-0ff5-4d91-bc05-945319c75702",
+      "author": "ryan",
+      "text": "User requested moving Medication Review: Dosage to GPT-5.4-mini and trying it. Creating a model-only Dosage candidate from current champion 0c2bf0b8, then evaluating on recent feedback before any champion promotion.",
+      "created_at": "2026-05-05T18:09:22.185104Z"
     }
   ],
   "created_at": "2026-04-22T13:19:21.731868Z",
-  "updated_at": "2026-05-05T16:42:17.363094Z",
+  "updated_at": "2026-05-05T18:09:22.185104Z",
   "closed_at": null,
   "custom": {}
 }


### PR DESCRIPTION
## Summary
- add Scorecard History performance payloads for recent feedback and regression evaluations
- render evaluation gauges with baseline needles and subtle metric tabs
- add full-window diffs, categorized summaries, and focused backend/dashboard tests

## Validation
- npm test -- ScorecardHistory --runInBand
- python3.12 -m pytest plexus/reports/blocks/scorecard_history_test.py