### PR TITLE
Close scorecard history Kanbus task

### DIFF
--- a/project/events/2026-05-05T18:15:59.823Z__4a04fa67-83fe-43c9-81dc-273039a4d97d.json
+++ b/project/events/2026-05-05T18:15:59.823Z__4a04fa67-83fe-43c9-81dc-273039a4d97d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4a04fa67-83fe-43c9-81dc-273039a4d97d",
+  "issue_id": "plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T18:15:59.823Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1.json
+++ b/project/issues/plx-cf8b5083-43d0-4f1d-90ba-27fee00ca4d1.json
@@ -3,7 +3,7 @@
   "title": "Add evaluation gauges to Scorecard History report",
   "description": "",
   "type": "task",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 1,
   "assignee": null,
   "creator": null,
@@ -61,7 +61,7 @@
     }
   ],
   "created_at": "2026-05-05T17:26:42.461913Z",
-  "updated_at": "2026-05-05T18:13:31.088602Z",
-  "closed_at": null,
+  "updated_at": "2026-05-05T18:15:59.821822Z",
+  "closed_at": "2026-05-05T18:15:59.821822Z",
   "custom": {}
 }


### PR DESCRIPTION
## Summary
- close Kanbus task plx-cf8b50 after the Scorecard History report changes landed

## Validation
- Kanbus-only follow-up