### PR TITLE
Prototype private GraphQL proxy

### DIFF
--- a/project/events/2026-05-05T20:49:03.847Z__0bcfdeb8-2209-431c-9650-f541a4c9cc6c.json
+++ b/project/events/2026-05-05T20:49:03.847Z__0bcfdeb8-2209-431c-9650-f541a4c9cc6c.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "0bcfdeb8-2209-431c-9650-f541a4c9cc6c",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-05T20:49:03.847Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Build a standalone containerized private GraphQL proxy under services/private-graphql-proxy. It should use PostgreSQL for authoritative private models (Item, ScoreResult, FeedbackItem, Identifier), cache read-only control-plane AppSync responses with 15 minute freshness and 24 hour stale window, and include real smoke-test harnesses that can connect to production AppSync for read-only control-plane verification while proving private writes remain local.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Prototype private GraphQL proxy with PostgreSQL smoke tests"
+  }
+}

--- a/project/events/2026-05-05T20:49:05.118Z__d6a95ea1-adac-41f4-ac81-fa561ed451d7.json
+++ b/project/events/2026-05-05T20:49:05.118Z__d6a95ea1-adac-41f4-ac81-fa561ed451d7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d6a95ea1-adac-41f4-ac81-fa561ed451d7",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T20:49:05.118Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-05T20:55:21.021Z__cc046d52-e2e6-4f78-b9d2-03148033d9b2.json
+++ b/project/events/2026-05-05T20:55:21.021Z__cc046d52-e2e6-4f78-b9d2-03148033d9b2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cc046d52-e2e6-4f78-b9d2-03148033d9b2",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T20:55:21.021Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a6cecd27-7364-42c8-9dbb-422e1371e06b"
+  }
+}

--- a/project/events/2026-05-05T21:03:18.279Z__115f752e-cd33-4af7-8664-22816a473307.json
+++ b/project/events/2026-05-05T21:03:18.279Z__115f752e-cd33-4af7-8664-22816a473307.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "115f752e-cd33-4af7-8664-22816a473307",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T21:03:18.279Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "fdadabb6-c50d-4b4a-906a-6c8a58b5e0c2"
+  }
+}

--- a/project/events/2026-05-05T21:04:14.619Z__9e9a065c-61bc-4ff8-9645-6c388101d01c.json
+++ b/project/events/2026-05-05T21:04:14.619Z__9e9a065c-61bc-4ff8-9645-6c388101d01c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9e9a065c-61bc-4ff8-9645-6c388101d01c",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T21:04:14.619Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "0a1cd234-5c4b-402f-b4ee-724d3fb0c120"
+  }
+}

--- a/project/events/2026-05-05T21:10:55.057Z__0acfd3d9-fa59-47a1-b3de-99f52d6b0495.json
+++ b/project/events/2026-05-05T21:10:55.057Z__0acfd3d9-fa59-47a1-b3de-99f52d6b0495.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0acfd3d9-fa59-47a1-b3de-99f52d6b0495",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T21:10:55.057Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "886b311e-459f-4a7a-93d8-73bc2faa351d"
+  }
+}

--- a/project/events/2026-05-05T21:14:08.613Z__988d02f5-b22a-4423-87d3-a9d0c58c2166.json
+++ b/project/events/2026-05-05T21:14:08.613Z__988d02f5-b22a-4423-87d3-a9d0c58c2166.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "988d02f5-b22a-4423-87d3-a9d0c58c2166",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-05T21:14:08.613Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e16d1947-d42b-441e-bffd-cc02bd61e1e6"
+  }
+}

--- a/project/events/2026-05-05T21:15:01.391Z__abc82d30-4e2d-468e-adbb-1c946a5a00d8.json
+++ b/project/events/2026-05-05T21:15:01.391Z__abc82d30-4e2d-468e-adbb-1c946a5a00d8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "abc82d30-4e2d-468e-adbb-1c946a5a00d8",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-05T21:15:01.391Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-0b6b0c04-880b-473f-9a50-df9f721367a4.json
+++ b/project/issues/plx-0b6b0c04-880b-473f-9a50-df9f721367a4.json
@@ -1,0 +1,49 @@
+{
+  "id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "title": "Prototype private GraphQL proxy with PostgreSQL smoke tests",
+  "description": "Build a standalone containerized private GraphQL proxy under services/private-graphql-proxy. It should use PostgreSQL for authoritative private models (Item, ScoreResult, FeedbackItem, Identifier), cache read-only control-plane AppSync responses with 15 minute freshness and 24 hour stale window, and include real smoke-test harnesses that can connect to production AppSync for read-only control-plane verification while proving private writes remain local.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "a6cecd27-7364-42c8-9dbb-422e1371e06b",
+      "author": "ryan",
+      "text": "Implemented the initial private GraphQL proxy prototype in a clean worktree on feature/private-graphql-proxy-prototype. Added a standalone FastAPI service under services/private-graphql-proxy, PostgreSQL schemas for private_data and control_cache, AppSync cache-aside forwarding for allowlisted control-plane reads, local private model CRUD/list routing for Item/ScoreResult/FeedbackItem/Identifier, Docker Compose smoke harness, and tests. Verified offline classifier/routing tests pass and Compose config renders. Full container smoke run is blocked locally because Docker daemon is not running.",
+      "created_at": "2026-05-05T20:55:21.021447Z"
+    },
+    {
+      "id": "fdadabb6-c50d-4b4a-906a-6c8a58b5e0c2",
+      "author": "ryan",
+      "text": "Ran Docker Compose smoke testing with real AppSync credentials from /Users/ryan/Projects/Plexus/.env and read-only control-plane fixture IDs. The real API control-plane smoke and local PostgreSQL private-data smoke passed: 2 passed, 1 skipped, 6 deselected. The skipped test is the optional existing Plexus client compatibility smoke because the smoke container installs only the proxy requirements and not the full Plexus dependency stack (missing pandas). Real AppSync interactions were read-only; private model writes were local PostgreSQL-only.",
+      "created_at": "2026-05-05T21:03:18.278980Z"
+    },
+    {
+      "id": "0a1cd234-5c4b-402f-b4ee-724d3fb0c120",
+      "author": "ryan",
+      "text": "Follow-up read-only Docker check: ran only services/private-graphql-proxy/tests/test_smoke_proxy.py::test_control_plane_cache_smoke_read_only against the real AppSync credentials from .env through the proxy/PostgreSQL Compose stack. Pytest result: 1 passed in 0.64s. No AWS mutations were executed. Containers and temporary env file were cleaned up afterward.",
+      "created_at": "2026-05-05T21:04:14.619332Z"
+    },
+    {
+      "id": "886b311e-459f-4a7a-93d8-73bc2faa351d",
+      "author": "ryan",
+      "text": "Added explicit seeded Item read-path smoke coverage. The test seeds a local PostgreSQL-backed Item through the proxy, then verifies getItem, listItemByAccountIdAndUpdatedAt, listItemByScoreIdAndUpdatedAt, and listItemByAccountIdAndExternalId all return that item. Ran it in Docker Compose against the proxy/PostgreSQL stack with AppSync credentials blank: 1 passed in 0.14s. This exercises private Item reads without touching AWS.",
+      "created_at": "2026-05-05T21:10:55.057539Z"
+    },
+    {
+      "id": "e16d1947-d42b-441e-bffd-cc02bd61e1e6",
+      "author": "ryan",
+      "text": "Added and ran focused ScoreResult-for-Item smoke coverage. The test seeds a local Item, creates a ScoreResult with itemId pointing to that Item, then verifies getScoreResult, listScoreResultByItemId, and listScoreResultByItemIdAndTypeAndScoreIdAndUpdatedAt all return it. It also exposed and fixed a prototype bug where private GraphQL responses returned full documents instead of honoring selected fields. Rebuilt the proxy Docker image and reran the focused smoke: 1 passed in 0.12s. AppSync credentials were blank; AWS was not touched.",
+      "created_at": "2026-05-05T21:14:08.612978Z"
+    }
+  ],
+  "created_at": "2026-05-05T20:49:03.847277Z",
+  "updated_at": "2026-05-05T21:15:01.390372Z",
+  "closed_at": "2026-05-05T21:15:01.390372Z",
+  "custom": {}
+}

--- a/services/private-graphql-proxy/Dockerfile
+++ b/services/private-graphql-proxy/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY services/private-graphql-proxy/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY services/private-graphql-proxy/proxy ./proxy
+
+EXPOSE 8000
+CMD ["uvicorn", "proxy.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/private-graphql-proxy/README.md
+++ b/services/private-graphql-proxy/README.md
@@ -1,0 +1,58 @@
+# Private GraphQL Proxy Prototype
+
+This service is a standalone prototype for keeping Plexus private data-plane
+models out of AWS while preserving the existing GraphQL client contract.
+
+The proxy exposes:
+
+- `POST /graphql`
+- `GET /healthz`
+- `GET /readyz`
+
+Private models are authoritative in PostgreSQL:
+
+- `Item`
+- `ScoreResult`
+- `FeedbackItem`
+- `Identifier`
+
+Read-only control-plane queries are forwarded to AppSync and cached in
+PostgreSQL. The default cache freshness TTL is 15 minutes and the stale-serving
+window is 24 hours.
+
+## Configuration
+
+```bash
+export PLEXUS_PROXY_DATABASE_URL=postgresql://plexus:plexus@localhost:55432/plexus_proxy
+export PLEXUS_PROXY_API_KEY=local-smoke-key
+export PLEXUS_PROXY_UPSTREAM_API_URL=https://example.appsync-api.us-east-1.amazonaws.com/graphql
+# Set PLEXUS_PROXY_UPSTREAM_API_KEY in your shell or secret manager.
+export PLEXUS_PROXY_CACHE_TTL_SECONDS=900
+export PLEXUS_PROXY_CACHE_STALE_SECONDS=86400
+```
+
+Scoring-side clients should point `PLEXUS_API_URL` at the proxy endpoint and
+use `PLEXUS_API_KEY` for the proxy API key.
+
+## Smoke Tests
+
+The smoke harness starts PostgreSQL, the proxy, and a pytest runner:
+
+```bash
+services/private-graphql-proxy/scripts/smoke.sh
+```
+
+Real AppSync smoke coverage is read-only and requires fixture IDs:
+
+```bash
+export PLEXUS_PROXY_UPSTREAM_API_URL=...
+# Set PLEXUS_PROXY_UPSTREAM_API_KEY in your shell or secret manager.
+export PLEXUS_PROXY_SMOKE_ACCOUNT_ID=...
+export PLEXUS_PROXY_SMOKE_SCORECARD_ID=...
+export PLEXUS_PROXY_SMOKE_SCORE_ID=...
+export PLEXUS_PROXY_SMOKE_SCORE_VERSION_ID=...
+export PLEXUS_PROXY_SMOKE_EVALUATION_ID=...
+```
+
+Private model smoke writes use generated test IDs and only write to local
+PostgreSQL through the proxy.

--- a/services/private-graphql-proxy/docker-compose.smoke.yml
+++ b/services/private-graphql-proxy/docker-compose.smoke.yml
@@ -1,0 +1,58 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: plexus
+      POSTGRES_PASSWORD: plexus
+      POSTGRES_DB: plexus_proxy
+    ports:
+      - "55432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U plexus -d plexus_proxy"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  proxy:
+    build:
+      context: ../..
+      dockerfile: services/private-graphql-proxy/Dockerfile
+    environment:
+      PLEXUS_PROXY_DATABASE_URL: postgresql://plexus:plexus@postgres:5432/plexus_proxy
+      PLEXUS_PROXY_API_KEY: ${PLEXUS_PROXY_API_KEY:-local-smoke-key}
+      PLEXUS_PROXY_UPSTREAM_API_URL: ${PLEXUS_PROXY_UPSTREAM_API_URL:-}
+      PLEXUS_PROXY_UPSTREAM_API_KEY: ${PLEXUS_PROXY_UPSTREAM_API_KEY:-}
+      PLEXUS_PROXY_CACHE_TTL_SECONDS: ${PLEXUS_PROXY_CACHE_TTL_SECONDS:-900}
+      PLEXUS_PROXY_CACHE_STALE_SECONDS: ${PLEXUS_PROXY_CACHE_STALE_SECONDS:-86400}
+      PLEXUS_PROXY_ENABLE_DEBUG: "true"
+    ports:
+      - "18080:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/readyz')"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  smoke-tests:
+    image: python:3.12-slim
+    working_dir: /workspace
+    environment:
+      PYTHONPATH: /workspace:/workspace/services/private-graphql-proxy
+      PLEXUS_API_URL: http://proxy:8000/graphql
+      PLEXUS_API_KEY: ${PLEXUS_PROXY_API_KEY:-local-smoke-key}
+      PLEXUS_PROXY_SMOKE_ACCOUNT_ID: ${PLEXUS_PROXY_SMOKE_ACCOUNT_ID:-}
+      PLEXUS_PROXY_SMOKE_SCORECARD_ID: ${PLEXUS_PROXY_SMOKE_SCORECARD_ID:-}
+      PLEXUS_PROXY_SMOKE_SCORE_ID: ${PLEXUS_PROXY_SMOKE_SCORE_ID:-}
+      PLEXUS_PROXY_SMOKE_SCORE_VERSION_ID: ${PLEXUS_PROXY_SMOKE_SCORE_VERSION_ID:-}
+      PLEXUS_PROXY_SMOKE_EVALUATION_ID: ${PLEXUS_PROXY_SMOKE_EVALUATION_ID:-}
+    volumes:
+      - ../..:/workspace
+    command: >
+      sh -c "pip install --no-cache-dir -r services/private-graphql-proxy/requirements.txt &&
+             pytest -o addopts='' -m integration services/private-graphql-proxy/tests -q"
+    depends_on:
+      proxy:
+        condition: service_healthy

--- a/services/private-graphql-proxy/proxy/__init__.py
+++ b/services/private-graphql-proxy/proxy/__init__.py
@@ -1,0 +1,1 @@
+"""Private GraphQL proxy prototype."""

--- a/services/private-graphql-proxy/proxy/app.py
+++ b/services/private-graphql-proxy/proxy/app.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import timezone
+from typing import Any, Optional
+
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from .config import Settings
+from .graphql_tools import (
+    RootField,
+    all_argument_values,
+    argument_value,
+    build_operation_plan,
+    build_root_only_query,
+    project_list_connection,
+    project_value,
+)
+from .store import PostgresStore, cache_key_for, utcnow
+from .upstream import UpstreamAppSyncClient
+
+
+settings = Settings.from_env()
+store = PostgresStore(settings.database_url)
+upstream = UpstreamAppSyncClient(
+    settings.upstream_api_url,
+    settings.upstream_api_key,
+    settings.upstream_timeout_seconds,
+    settings.upstream_disabled,
+)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    store.initialize()
+    yield
+
+
+app = FastAPI(
+    title="Plexus Private GraphQL Proxy",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/readyz")
+def readyz() -> dict[str, str]:
+    if not store.ready():
+        raise HTTPException(status_code=503, detail="database is not ready")
+    return {"status": "ready"}
+
+
+@app.get("/debug/upstream-requests")
+def debug_upstream_requests() -> list[dict[str, Any]]:
+    if not settings.enable_debug:
+        raise HTTPException(status_code=404, detail="debug endpoints are disabled")
+    return store.upstream_requests()
+
+
+@app.post("/graphql")
+async def graphql_endpoint(
+    request: Request,
+    x_api_key: Optional[str] = Header(default=None),
+) -> JSONResponse:
+    if settings.proxy_api_key and x_api_key != settings.proxy_api_key:
+        raise HTTPException(status_code=401, detail="invalid proxy API key")
+
+    payload = await request.json()
+    query = payload.get("query")
+    variables = payload.get("variables") or {}
+    operation_name = payload.get("operationName")
+    if not query:
+        raise HTTPException(status_code=400, detail="GraphQL query is required")
+
+    try:
+        plan = build_operation_plan(query, operation_name)
+    except Exception as exc:
+        return graphql_error(str(exc), status_code=400)
+
+    if plan.blocked_fields:
+        blocked = ", ".join(field.name for field in plan.blocked_fields)
+        return graphql_error(
+            f"operation contains unsupported or unsafe root fields: {blocked}",
+            status_code=400,
+        )
+
+    data: dict[str, Any] = {}
+    extensions: dict[str, Any] = {"proxy": {"private": [], "control": []}}
+
+    for field in plan.private_fields:
+        data[field.response_key] = handle_private_field(field, variables, plan.operation_type)
+        extensions["proxy"]["private"].append(field.name)
+
+    if plan.control_fields:
+        control_query = (
+            query
+            if len(plan.control_fields) == len(plan.root_fields)
+            else build_root_only_query(plan, plan.control_fields)
+        )
+        control_response, cache_status = execute_control_query(
+            control_query,
+            variables,
+            operation_name,
+            [field.name for field in plan.control_fields],
+        )
+        data.update(control_response.get("data") or {})
+        extensions["proxy"]["control"].append(
+            {"roots": [field.name for field in plan.control_fields], "cache": cache_status}
+        )
+
+    return JSONResponse({"data": data, "extensions": extensions})
+
+
+def handle_private_field(
+    field: RootField,
+    variables: dict[str, Any],
+    operation_type: str,
+) -> Any:
+    if not field.model:
+        raise HTTPException(status_code=400, detail=f"{field.name} has no private model")
+
+    if operation_type == "mutation":
+        input_doc = argument_value(field.node, "input", variables)
+        if not isinstance(input_doc, dict):
+            raise HTTPException(status_code=400, detail=f"{field.name} requires an input object")
+        if field.name.startswith("create"):
+            return project_value(
+                store.upsert_private(field.model, input_doc),
+                field.node.selection_set,
+            )
+        if field.name.startswith("update"):
+            return project_value(
+                store.update_private(field.model, input_doc),
+                field.node.selection_set,
+            )
+        if field.name.startswith("delete"):
+            return project_value(
+                store.delete_private(field.model, input_doc),
+                field.node.selection_set,
+            )
+        raise HTTPException(status_code=400, detail=f"unsupported private mutation {field.name}")
+
+    if operation_type != "query":
+        raise HTTPException(status_code=400, detail="subscriptions are not supported")
+
+    if field.name.startswith("get"):
+        return project_value(
+            store.get_private(field.model, key_arguments(field, variables)),
+            field.node.selection_set,
+        )
+
+    if field.name.startswith("list"):
+        args = all_argument_values(field.node, variables)
+        filters = list_filters(args)
+        filters.update(composite_begins_with_filters(args))
+        sort_field = sort_field_for_root(field.name)
+        sort_direction = args.get("sortDirection") or "ASC"
+        items = store.list_private(
+            field.model,
+            filters,
+            sort_direction=sort_direction,
+            sort_field=sort_field,
+            limit=args.get("limit"),
+        )
+        return project_list_connection(
+            {"items": items, "nextToken": None},
+            field.node.selection_set,
+        )
+
+    raise HTTPException(status_code=400, detail=f"unsupported private query {field.name}")
+
+
+def execute_control_query(
+    query: str,
+    variables: dict[str, Any],
+    operation_name: Optional[str],
+    root_fields: list[str],
+) -> tuple[dict[str, Any], str]:
+    key = cache_key_for(query, variables, operation_name)
+    cache_row = store.get_cache(key)
+    now = utcnow()
+    if cache_row and cache_row["expires_at"].astimezone(timezone.utc) >= now:
+        return cache_row["response"], "fresh"
+
+    try:
+        response = upstream.execute(query, variables, operation_name)
+        store.record_upstream_request(operation_name, root_fields, query, variables)
+        store.put_cache(
+            key,
+            operation_name,
+            query,
+            variables,
+            response,
+            settings.cache_ttl_seconds,
+            settings.cache_stale_seconds,
+        )
+        return response, "miss"
+    except Exception as exc:
+        if cache_row and cache_row["stale_until"].astimezone(timezone.utc) >= now:
+            return cache_row["response"], "stale"
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+def key_arguments(field: RootField, variables: dict[str, Any]) -> dict[str, Any]:
+    args = all_argument_values(field.node, variables)
+    if field.model == "Identifier":
+        return {"itemId": args.get("itemId"), "name": args.get("name")}
+    return {"id": args.get("id")}
+
+
+def list_filters(args: dict[str, Any]) -> dict[str, Any]:
+    ignored = {"filter", "limit", "nextToken", "sortDirection"}
+    filters = {
+        name: value
+        for name, value in args.items()
+        if name not in ignored and value is not None and not isinstance(value, dict)
+    }
+    filter_arg = args.get("filter")
+    if isinstance(filter_arg, dict):
+        filters.update(filter_arg)
+    for name, value in args.items():
+        if name in ignored or value is None:
+            continue
+        if isinstance(value, dict) and "eq" in value:
+            filters[name] = value["eq"]
+    return filters
+
+
+def composite_begins_with_filters(args: dict[str, Any]) -> dict[str, Any]:
+    filters: dict[str, Any] = {}
+    for value in args.values():
+        if not isinstance(value, dict):
+            continue
+        begins_with = value.get("beginsWith")
+        if isinstance(begins_with, dict):
+            filters.update(begins_with)
+    return filters
+
+
+def sort_field_for_root(root_name: str) -> Optional[str]:
+    suffixes = (
+        ("UpdatedAt", "updatedAt"),
+        ("CreatedAt", "createdAt"),
+        ("EditedAt", "editedAt"),
+        ("Position", "position"),
+        ("Name", "name"),
+    )
+    for suffix, field_name in suffixes:
+        if root_name.endswith(suffix):
+            return field_name
+    return None
+
+
+def graphql_error(message: str, status_code: int = 200) -> JSONResponse:
+    return JSONResponse({"errors": [{"message": message}]}, status_code=status_code)

--- a/services/private-graphql-proxy/proxy/config.py
+++ b/services/private-graphql-proxy/proxy/config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Settings:
+    database_url: str
+    upstream_api_url: Optional[str]
+    upstream_api_key: Optional[str]
+    proxy_api_key: Optional[str]
+    cache_ttl_seconds: int
+    cache_stale_seconds: int
+    upstream_timeout_seconds: float
+    upstream_disabled: bool
+    enable_debug: bool
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        return cls(
+            database_url=os.getenv(
+                "PLEXUS_PROXY_DATABASE_URL",
+                "postgresql://plexus:plexus@localhost:5432/plexus_proxy",
+            ),
+            upstream_api_url=os.getenv("PLEXUS_PROXY_UPSTREAM_API_URL"),
+            upstream_api_key=os.getenv("PLEXUS_PROXY_UPSTREAM_API_KEY"),
+            proxy_api_key=os.getenv("PLEXUS_PROXY_API_KEY"),
+            cache_ttl_seconds=int(os.getenv("PLEXUS_PROXY_CACHE_TTL_SECONDS", "900")),
+            cache_stale_seconds=int(os.getenv("PLEXUS_PROXY_CACHE_STALE_SECONDS", "86400")),
+            upstream_timeout_seconds=float(os.getenv("PLEXUS_PROXY_UPSTREAM_TIMEOUT_SECONDS", "30")),
+            upstream_disabled=os.getenv("PLEXUS_PROXY_UPSTREAM_DISABLED", "false").lower()
+            in {"1", "true", "yes"},
+            enable_debug=os.getenv("PLEXUS_PROXY_ENABLE_DEBUG", "false").lower()
+            in {"1", "true", "yes"},
+        )

--- a/services/private-graphql-proxy/proxy/graphql_tools.py
+++ b/services/private-graphql-proxy/proxy/graphql_tools.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+from graphql import parse, print_ast
+from graphql.language.ast import (
+    BooleanValueNode,
+    DocumentNode,
+    FieldNode,
+    FloatValueNode,
+    FragmentDefinitionNode,
+    IntValueNode,
+    ListValueNode,
+    NullValueNode,
+    ObjectFieldNode,
+    ObjectValueNode,
+    OperationDefinitionNode,
+    SelectionSetNode,
+    StringValueNode,
+    VariableNode,
+)
+
+
+PRIVATE_MODELS = {"Item", "ScoreResult", "FeedbackItem", "Identifier"}
+PRIVATE_PLURALS = {
+    "Item": "Items",
+    "ScoreResult": "ScoreResults",
+    "FeedbackItem": "FeedbackItems",
+    "Identifier": "Identifiers",
+}
+CONTROL_MODELS = {
+    "Account",
+    "Scorecard",
+    "Score",
+    "ScoreVersion",
+    "Evaluation",
+    "Task",
+    "TaskStage",
+    "ScoringJob",
+    "BatchJob",
+    "Report",
+    "ReportBlock",
+    "ReportConfiguration",
+    "DataSource",
+    "DataSourceVersion",
+    "Procedure",
+    "ProcedureTemplate",
+}
+
+
+@dataclass(frozen=True)
+class RootField:
+    node: FieldNode
+    name: str
+    response_key: str
+    classification: str
+    model: Optional[str]
+
+
+@dataclass(frozen=True)
+class OperationPlan:
+    document: DocumentNode
+    operation: OperationDefinitionNode
+    root_fields: tuple[RootField, ...]
+
+    @property
+    def operation_type(self) -> str:
+        return self.operation.operation.value
+
+    @property
+    def private_fields(self) -> tuple[RootField, ...]:
+        return tuple(field for field in self.root_fields if field.classification == "private")
+
+    @property
+    def control_fields(self) -> tuple[RootField, ...]:
+        return tuple(field for field in self.root_fields if field.classification == "control")
+
+    @property
+    def blocked_fields(self) -> tuple[RootField, ...]:
+        return tuple(field for field in self.root_fields if field.classification == "blocked")
+
+
+def build_operation_plan(query: str, operation_name: Optional[str]) -> OperationPlan:
+    document = parse(query)
+    operation = _select_operation(document, operation_name)
+    root_fields = tuple(_root_field(operation, node) for node in operation.selection_set.selections)
+    return OperationPlan(document=document, operation=operation, root_fields=root_fields)
+
+
+def build_root_only_query(plan: OperationPlan, fields: Iterable[RootField]) -> str:
+    selected_names = {field.name for field in fields}
+    selected_nodes = tuple(
+        field.node
+        for field in plan.root_fields
+        if field.name in selected_names
+    )
+    used_variables = set()
+    for node in selected_nodes:
+        used_variables.update(_variable_names(node))
+
+    operation = copy.copy(plan.operation)
+    operation.variable_definitions = tuple(
+        definition
+        for definition in operation.variable_definitions or ()
+        if definition.variable.name.value in used_variables
+    )
+    operation.selection_set = SelectionSetNode(selections=selected_nodes)
+    fragments = tuple(
+        definition
+        for definition in plan.document.definitions
+        if isinstance(definition, FragmentDefinitionNode)
+    )
+    return print_ast(DocumentNode(definitions=(operation, *fragments)))
+
+
+def argument_value(field: FieldNode, name: str, variables: dict[str, Any]) -> Any:
+    for argument in field.arguments or ():
+        if argument.name.value == name:
+            return value_from_ast(argument.value, variables)
+    return None
+
+
+def all_argument_values(field: FieldNode, variables: dict[str, Any]) -> dict[str, Any]:
+    return {
+        argument.name.value: value_from_ast(argument.value, variables)
+        for argument in field.arguments or ()
+    }
+
+
+def value_from_ast(node: Any, variables: dict[str, Any]) -> Any:
+    if isinstance(node, VariableNode):
+        return variables.get(node.name.value)
+    if isinstance(node, StringValueNode):
+        return node.value
+    if isinstance(node, IntValueNode):
+        return int(node.value)
+    if isinstance(node, FloatValueNode):
+        return float(node.value)
+    if isinstance(node, BooleanValueNode):
+        return bool(node.value)
+    if isinstance(node, NullValueNode):
+        return None
+    if isinstance(node, ListValueNode):
+        return [value_from_ast(value, variables) for value in node.values]
+    if isinstance(node, ObjectValueNode):
+        return {
+            field.name.value: value_from_ast(field.value, variables)
+            for field in node.fields
+            if isinstance(field, ObjectFieldNode)
+        }
+    return None
+
+
+def project_value(value: Any, selection_set: Optional[SelectionSetNode]) -> Any:
+    if value is None or selection_set is None:
+        return value
+    if isinstance(value, list):
+        return [project_value(item, selection_set) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    projected: dict[str, Any] = {}
+    for selection in selection_set.selections:
+        if not isinstance(selection, FieldNode):
+            continue
+        field_name = selection.name.value
+        response_key = selection.alias.value if selection.alias else field_name
+        child = value.get(field_name)
+        if isinstance(child, list):
+            projected[response_key] = [
+                project_value(item, selection.selection_set)
+                for item in child
+            ]
+        elif isinstance(child, dict):
+            projected[response_key] = project_value(child, selection.selection_set)
+        else:
+            projected[response_key] = child
+    return projected
+
+
+def project_list_connection(
+    connection: dict[str, Any],
+    selection_set: Optional[SelectionSetNode],
+) -> dict[str, Any]:
+    if selection_set is None:
+        return connection
+
+    projected: dict[str, Any] = {}
+    for selection in selection_set.selections:
+        if not isinstance(selection, FieldNode):
+            continue
+        field_name = selection.name.value
+        response_key = selection.alias.value if selection.alias else field_name
+        if field_name == "items":
+            projected[response_key] = [
+                project_value(item, selection.selection_set)
+                for item in connection.get("items", [])
+            ]
+        else:
+            projected[response_key] = connection.get(field_name)
+    return projected
+
+
+def model_from_private_root(root_name: str) -> Optional[str]:
+    for model in sorted(PRIVATE_MODELS, key=len, reverse=True):
+        plural = PRIVATE_PLURALS[model]
+        if root_name in {
+            f"get{model}",
+            f"create{model}",
+            f"update{model}",
+            f"delete{model}",
+            f"list{plural}",
+        }:
+            return model
+        if root_name.startswith(f"list{model}By"):
+            return model
+    return None
+
+
+def is_control_read_root(root_name: str) -> bool:
+    for model in sorted(CONTROL_MODELS, key=len, reverse=True):
+        if root_name == f"get{model}":
+            return True
+        if root_name == f"list{model}s":
+            return True
+        if root_name.startswith(f"list{model}By"):
+            return True
+    return False
+
+
+def _select_operation(
+    document: DocumentNode,
+    operation_name: Optional[str],
+) -> OperationDefinitionNode:
+    operations = [
+        definition
+        for definition in document.definitions
+        if isinstance(definition, OperationDefinitionNode)
+    ]
+    if operation_name:
+        for operation in operations:
+            if operation.name and operation.name.value == operation_name:
+                return operation
+        raise ValueError(f"GraphQL operation '{operation_name}' was not found")
+    if len(operations) != 1:
+        raise ValueError("operationName is required when multiple operations are present")
+    return operations[0]
+
+
+def _root_field(operation: OperationDefinitionNode, node: Any) -> RootField:
+    if not isinstance(node, FieldNode):
+        raise ValueError("Only root GraphQL fields are supported by the prototype proxy")
+
+    name = node.name.value
+    response_key = node.alias.value if node.alias else name
+    private_model = model_from_private_root(name)
+    if private_model:
+        return RootField(node, name, response_key, "private", private_model)
+
+    if operation.operation.value == "query" and is_control_read_root(name):
+        return RootField(node, name, response_key, "control", None)
+
+    return RootField(node, name, response_key, "blocked", None)
+
+
+def _variable_names(node: Any) -> set[str]:
+    if isinstance(node, VariableNode):
+        return {node.name.value}
+    if isinstance(node, (str, int, float, bool)) or node is None:
+        return set()
+    if isinstance(node, (list, tuple)):
+        names = set()
+        for child in node:
+            names.update(_variable_names(child))
+        return names
+    if hasattr(node, "keys"):
+        names = set()
+        for key in node.keys:
+            names.update(_variable_names(getattr(node, key)))
+        return names
+    return set()

--- a/services/private-graphql-proxy/proxy/store.py
+++ b/services/private-graphql-proxy/proxy/store.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso_now() -> str:
+    return utcnow().isoformat().replace("+00:00", "Z")
+
+
+def parse_datetime(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return None
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    table: str
+    pk_fields: tuple[str, ...]
+    columns: dict[str, str]
+    default_order: str
+
+    def column_for(self, field_name: str) -> Optional[str]:
+        return self.columns.get(field_name)
+
+
+MODEL_CONFIGS: dict[str, ModelConfig] = {
+    "Item": ModelConfig(
+        table="private_data.items",
+        pk_fields=("id",),
+        default_order="updated_at",
+        columns={
+            "id": "id",
+            "accountId": "account_id",
+            "scoreId": "score_id",
+            "evaluationId": "evaluation_id",
+            "externalId": "external_id",
+            "isEvaluation": "is_evaluation",
+            "createdByType": "created_by_type",
+            "createdAt": "created_at",
+            "updatedAt": "updated_at",
+        },
+    ),
+    "Identifier": ModelConfig(
+        table="private_data.identifiers",
+        pk_fields=("itemId", "name"),
+        default_order="position",
+        columns={
+            "itemId": "item_id",
+            "name": "name",
+            "value": "value",
+            "accountId": "account_id",
+            "position": "position",
+            "createdAt": "created_at",
+            "updatedAt": "updated_at",
+        },
+    ),
+    "ScoreResult": ModelConfig(
+        table="private_data.score_results",
+        pk_fields=("id",),
+        default_order="updated_at",
+        columns={
+            "id": "id",
+            "itemId": "item_id",
+            "accountId": "account_id",
+            "scorecardId": "scorecard_id",
+            "scoreId": "score_id",
+            "scoreVersionId": "score_version_id",
+            "evaluationId": "evaluation_id",
+            "scoringJobId": "scoring_job_id",
+            "feedbackItemId": "feedback_item_id",
+            "type": "type",
+            "status": "status",
+            "code": "code",
+            "createdAt": "created_at",
+            "updatedAt": "updated_at",
+        },
+    ),
+    "FeedbackItem": ModelConfig(
+        table="private_data.feedback_items",
+        pk_fields=("id",),
+        default_order="updated_at",
+        columns={
+            "id": "id",
+            "accountId": "account_id",
+            "scorecardId": "scorecard_id",
+            "scoreId": "score_id",
+            "itemId": "item_id",
+            "cacheKey": "cache_key",
+            "editedAt": "edited_at",
+            "createdAt": "created_at",
+            "updatedAt": "updated_at",
+        },
+    ),
+}
+
+
+class PostgresStore:
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+
+    def connect(self):
+        return psycopg.connect(self.database_url, row_factory=dict_row)
+
+    def initialize(self) -> None:
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    create schema if not exists private_data;
+                    create schema if not exists control_cache;
+                    create schema if not exists proxy_debug;
+
+                    create table if not exists private_data.items (
+                        id text primary key,
+                        account_id text not null,
+                        score_id text,
+                        evaluation_id text,
+                        external_id text,
+                        is_evaluation boolean,
+                        created_by_type text,
+                        created_at timestamptz,
+                        updated_at timestamptz,
+                        doc jsonb not null
+                    );
+                    create index if not exists items_account_updated_idx on private_data.items (account_id, updated_at);
+                    create index if not exists items_account_created_idx on private_data.items (account_id, created_at);
+                    create index if not exists items_score_updated_idx on private_data.items (score_id, updated_at);
+                    create index if not exists items_score_created_idx on private_data.items (score_id, created_at);
+                    create unique index if not exists items_account_external_idx on private_data.items (account_id, external_id) where external_id is not null;
+                    create index if not exists items_doc_gin_idx on private_data.items using gin (doc);
+
+                    create table if not exists private_data.identifiers (
+                        item_id text not null,
+                        name text not null,
+                        value text not null,
+                        account_id text not null,
+                        position integer,
+                        created_at timestamptz,
+                        updated_at timestamptz,
+                        doc jsonb not null,
+                        primary key (item_id, name)
+                    );
+                    create index if not exists identifiers_account_value_idx on private_data.identifiers (account_id, value);
+                    create index if not exists identifiers_account_name_value_idx on private_data.identifiers (account_id, name, value);
+                    create index if not exists identifiers_item_position_idx on private_data.identifiers (item_id, position);
+                    create index if not exists identifiers_item_name_idx on private_data.identifiers (item_id, name);
+                    create index if not exists identifiers_doc_gin_idx on private_data.identifiers using gin (doc);
+
+                    create table if not exists private_data.score_results (
+                        id text primary key,
+                        item_id text not null,
+                        account_id text not null,
+                        scorecard_id text not null,
+                        score_id text,
+                        score_version_id text,
+                        evaluation_id text,
+                        scoring_job_id text,
+                        feedback_item_id text,
+                        type text,
+                        status text,
+                        code text,
+                        created_at timestamptz,
+                        updated_at timestamptz,
+                        doc jsonb not null
+                    );
+                    create index if not exists score_results_account_updated_idx on private_data.score_results (account_id, updated_at);
+                    create index if not exists score_results_item_idx on private_data.score_results (item_id);
+                    create index if not exists score_results_scoring_job_idx on private_data.score_results (scoring_job_id);
+                    create index if not exists score_results_scorecard_updated_idx on private_data.score_results (scorecard_id, updated_at);
+                    create index if not exists score_results_scorecard_item_created_idx on private_data.score_results (scorecard_id, item_id, created_at);
+                    create index if not exists score_results_evaluation_idx on private_data.score_results (evaluation_id);
+                    create index if not exists score_results_score_version_idx on private_data.score_results (score_version_id);
+                    create index if not exists score_results_score_idx on private_data.score_results (score_id);
+                    create index if not exists score_results_scorecard_score_item_idx on private_data.score_results (scorecard_id, score_id, item_id);
+                    create index if not exists score_results_item_scorecard_score_idx on private_data.score_results (item_id, scorecard_id, score_id);
+                    create index if not exists score_results_type_status_updated_idx on private_data.score_results (type, status, updated_at);
+                    create index if not exists score_results_item_type_score_updated_idx on private_data.score_results (item_id, type, score_id, updated_at);
+                    create index if not exists score_results_doc_gin_idx on private_data.score_results using gin (doc);
+
+                    create table if not exists private_data.feedback_items (
+                        id text primary key,
+                        account_id text not null,
+                        scorecard_id text not null,
+                        score_id text not null,
+                        item_id text not null,
+                        cache_key text not null,
+                        edited_at timestamptz,
+                        created_at timestamptz,
+                        updated_at timestamptz,
+                        doc jsonb not null
+                    );
+                    create index if not exists feedback_items_account_updated_idx on private_data.feedback_items (account_id, updated_at);
+                    create index if not exists feedback_items_account_edited_idx on private_data.feedback_items (account_id, edited_at);
+                    create index if not exists feedback_items_account_scorecard_score_updated_idx on private_data.feedback_items (account_id, scorecard_id, score_id, updated_at);
+                    create index if not exists feedback_items_account_scorecard_score_edited_idx on private_data.feedback_items (account_id, scorecard_id, score_id, edited_at);
+                    create index if not exists feedback_items_cache_key_idx on private_data.feedback_items (cache_key);
+                    create index if not exists feedback_items_item_idx on private_data.feedback_items (item_id);
+                    create index if not exists feedback_items_doc_gin_idx on private_data.feedback_items using gin (doc);
+
+                    create table if not exists control_cache.graphql_responses (
+                        cache_key text primary key,
+                        operation_name text,
+                        variables_hash text not null,
+                        selection_hash text not null,
+                        query text not null,
+                        variables jsonb not null,
+                        response jsonb not null,
+                        fetched_at timestamptz not null,
+                        expires_at timestamptz not null,
+                        stale_until timestamptz not null
+                    );
+                    create index if not exists graphql_responses_expires_idx on control_cache.graphql_responses (expires_at);
+                    create index if not exists graphql_responses_stale_until_idx on control_cache.graphql_responses (stale_until);
+
+                    create table if not exists proxy_debug.upstream_requests (
+                        id bigserial primary key,
+                        created_at timestamptz not null default now(),
+                        operation_name text,
+                        root_fields text[] not null,
+                        forwarded_query text not null,
+                        variables jsonb not null
+                    );
+                    """
+                )
+                conn.commit()
+
+    def ready(self) -> bool:
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute("select 1 as ready")
+                return cur.fetchone()["ready"] == 1
+
+    def upsert_private(self, model: str, input_doc: dict[str, Any]) -> dict[str, Any]:
+        config = MODEL_CONFIGS[model]
+        doc = self._normalize_private_doc(model, dict(input_doc))
+        columns = list(config.columns.values())
+        values = [self._column_value(doc, field) for field in config.columns]
+        pk_columns = [config.columns[field] for field in config.pk_fields]
+        update_columns = [column for column in columns if column not in pk_columns]
+
+        sql = f"""
+            insert into {config.table} ({", ".join(columns)}, doc)
+            values ({", ".join(["%s"] * len(columns))}, %s)
+            on conflict ({", ".join(pk_columns)})
+            do update set
+                {", ".join(f"{column} = excluded.{column}" for column in update_columns)},
+                doc = excluded.doc
+            returning doc
+        """
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (*values, Jsonb(doc)))
+                row = cur.fetchone()
+                conn.commit()
+        return row["doc"]
+
+    def update_private(self, model: str, input_doc: dict[str, Any]) -> Optional[dict[str, Any]]:
+        existing = self.get_private(model, self._key_from_input(model, input_doc))
+        if not existing:
+            return None
+        merged = {**existing, **input_doc}
+        if "updatedAt" not in input_doc:
+            merged["updatedAt"] = iso_now()
+        return self.upsert_private(model, merged)
+
+    def get_private(self, model: str, key: dict[str, Any]) -> Optional[dict[str, Any]]:
+        config = MODEL_CONFIGS[model]
+        clauses = []
+        values = []
+        for field_name in config.pk_fields:
+            clauses.append(f"{config.columns[field_name]} = %s")
+            values.append(key.get(field_name))
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"select doc from {config.table} where {' and '.join(clauses)}",
+                    tuple(values),
+                )
+                row = cur.fetchone()
+        return row["doc"] if row else None
+
+    def delete_private(self, model: str, key: dict[str, Any]) -> Optional[dict[str, Any]]:
+        config = MODEL_CONFIGS[model]
+        clauses = []
+        values = []
+        for field_name in config.pk_fields:
+            clauses.append(f"{config.columns[field_name]} = %s")
+            values.append(key.get(field_name))
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"delete from {config.table} where {' and '.join(clauses)} returning doc",
+                    tuple(values),
+                )
+                row = cur.fetchone()
+                conn.commit()
+        return row["doc"] if row else None
+
+    def list_private(
+        self,
+        model: str,
+        filters: dict[str, Any],
+        sort_direction: str = "ASC",
+        sort_field: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[dict[str, Any]]:
+        config = MODEL_CONFIGS[model]
+        clauses = []
+        values: list[Any] = []
+        for field_name, expected in filters.items():
+            column = config.column_for(field_name)
+            if not column:
+                continue
+            if isinstance(expected, dict):
+                if "eq" in expected:
+                    clauses.append(f"{column} = %s")
+                    values.append(expected["eq"])
+                elif "beginsWith" in expected:
+                    clauses.append(f"{column}::text like %s")
+                    values.append(f"{expected['beginsWith']}%")
+            else:
+                clauses.append(f"{column} = %s")
+                values.append(expected)
+
+        where_sql = f"where {' and '.join(clauses)}" if clauses else ""
+        order_column = config.column_for(sort_field or "") or config.default_order
+        direction = "DESC" if sort_direction.upper() == "DESC" else "ASC"
+        limit_sql = "limit %s" if limit else ""
+        if limit:
+            values.append(limit)
+
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    select doc
+                    from {config.table}
+                    {where_sql}
+                    order by {order_column} {direction} nulls last
+                    {limit_sql}
+                    """,
+                    tuple(values),
+                )
+                rows = cur.fetchall()
+        return [row["doc"] for row in rows]
+
+    def get_cache(self, cache_key: str) -> Optional[dict[str, Any]]:
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    select response, fetched_at, expires_at, stale_until
+                    from control_cache.graphql_responses
+                    where cache_key = %s
+                    """,
+                    (cache_key,),
+                )
+                return cur.fetchone()
+
+    def put_cache(
+        self,
+        cache_key: str,
+        operation_name: Optional[str],
+        query: str,
+        variables: dict[str, Any],
+        response: dict[str, Any],
+        ttl_seconds: int,
+        stale_seconds: int,
+    ) -> None:
+        fetched_at = utcnow()
+        expires_at = fetched_at + timedelta(seconds=ttl_seconds)
+        stale_until = fetched_at + timedelta(seconds=stale_seconds)
+        variables_json = stable_json(variables)
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    insert into control_cache.graphql_responses (
+                        cache_key, operation_name, variables_hash, selection_hash,
+                        query, variables, response, fetched_at, expires_at, stale_until
+                    )
+                    values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    on conflict (cache_key) do update set
+                        operation_name = excluded.operation_name,
+                        variables_hash = excluded.variables_hash,
+                        selection_hash = excluded.selection_hash,
+                        query = excluded.query,
+                        variables = excluded.variables,
+                        response = excluded.response,
+                        fetched_at = excluded.fetched_at,
+                        expires_at = excluded.expires_at,
+                        stale_until = excluded.stale_until
+                    """,
+                    (
+                        cache_key,
+                        operation_name,
+                        digest(variables_json),
+                        digest(query),
+                        query,
+                        Jsonb(variables),
+                        Jsonb(response),
+                        fetched_at,
+                        expires_at,
+                        stale_until,
+                    ),
+                )
+                conn.commit()
+
+    def cleanup_expired_cache(self) -> int:
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "delete from control_cache.graphql_responses where stale_until < now()"
+                )
+                deleted = cur.rowcount
+                conn.commit()
+        return deleted
+
+    def record_upstream_request(
+        self,
+        operation_name: Optional[str],
+        root_fields: list[str],
+        forwarded_query: str,
+        variables: dict[str, Any],
+    ) -> None:
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    insert into proxy_debug.upstream_requests (
+                        operation_name, root_fields, forwarded_query, variables
+                    )
+                    values (%s, %s, %s, %s)
+                    """,
+                    (operation_name, root_fields, forwarded_query, Jsonb(variables)),
+                )
+                conn.commit()
+
+    def upstream_requests(self) -> list[dict[str, Any]]:
+        with self.connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    select id, created_at, operation_name, root_fields, forwarded_query, variables
+                    from proxy_debug.upstream_requests
+                    order by id desc
+                    limit 100
+                    """
+                )
+                return cur.fetchall()
+
+    def _normalize_private_doc(self, model: str, doc: dict[str, Any]) -> dict[str, Any]:
+        if model != "Identifier" and not doc.get("id"):
+            doc["id"] = str(uuid.uuid4())
+        now = iso_now()
+        doc.setdefault("createdAt", now)
+        doc.setdefault("updatedAt", now)
+        if model == "Identifier":
+            doc.setdefault("position", 0)
+        return doc
+
+    def _key_from_input(self, model: str, input_doc: dict[str, Any]) -> dict[str, Any]:
+        config = MODEL_CONFIGS[model]
+        return {field: input_doc.get(field) for field in config.pk_fields}
+
+    def _column_value(self, doc: dict[str, Any], field_name: str) -> Any:
+        value = doc.get(field_name)
+        if field_name in {"createdAt", "updatedAt", "editedAt"}:
+            return parse_datetime(value)
+        return value
+
+
+def cache_key_for(query: str, variables: dict[str, Any], operation_name: Optional[str]) -> str:
+    return digest(stable_json({"query": query, "variables": variables, "operationName": operation_name}))
+
+
+def digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def stable_json(value: Any) -> str:
+    return json.dumps(value or {}, sort_keys=True, separators=(",", ":"), default=str)

--- a/services/private-graphql-proxy/proxy/upstream.py
+++ b/services/private-graphql-proxy/proxy/upstream.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import requests
+
+
+class UpstreamAppSyncClient:
+    def __init__(
+        self,
+        api_url: Optional[str],
+        api_key: Optional[str],
+        timeout_seconds: float,
+        disabled: bool = False,
+    ):
+        self.api_url = api_url
+        self.api_key = api_key
+        self.timeout_seconds = timeout_seconds
+        self.disabled = disabled
+
+    def execute(
+        self,
+        query: str,
+        variables: dict[str, Any],
+        operation_name: Optional[str],
+    ) -> dict[str, Any]:
+        if self.disabled:
+            raise RuntimeError("upstream AppSync access is disabled")
+        if not self.api_url or not self.api_key:
+            raise RuntimeError("upstream AppSync URL/key are not configured")
+
+        response = requests.post(
+            self.api_url,
+            json={
+                "query": query,
+                "variables": variables or {},
+                "operationName": operation_name,
+            },
+            headers={
+                "Content-Type": "application/json",
+                "x-api-key": self.api_key,
+            },
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if "errors" in payload:
+            raise RuntimeError(f"upstream GraphQL errors: {payload['errors']}")
+        return payload

--- a/services/private-graphql-proxy/requirements.txt
+++ b/services/private-graphql-proxy/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.124.4
+uvicorn[standard]==0.42.0
+graphql-core==3.2.6
+psycopg[binary]==3.3.2
+requests==2.32.5
+httpx==0.28.1
+gql[requests]==3.5.3
+pytest==8.2.2

--- a/services/private-graphql-proxy/scripts/smoke.sh
+++ b/services/private-graphql-proxy/scripts/smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/.."
+docker compose -f docker-compose.smoke.yml up --build --abort-on-container-exit --exit-code-from smoke-tests smoke-tests

--- a/services/private-graphql-proxy/tests/test_app_routing.py
+++ b/services/private-graphql-proxy/tests/test_app_routing.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from fastapi.testclient import TestClient
+
+from proxy import app as proxy_app
+from proxy.store import utcnow
+
+
+class InMemoryStore:
+    def __init__(self):
+        self.private = {
+            "Item": {},
+            "Identifier": {},
+            "ScoreResult": {},
+            "FeedbackItem": {},
+        }
+        self.cache = {}
+        self.upstream_audit = []
+
+    def upsert_private(self, model, input_doc):
+        doc = dict(input_doc)
+        if model == "Identifier":
+            key = (doc["itemId"], doc["name"])
+        else:
+            key = doc["id"]
+        self.private[model][key] = doc
+        return doc
+
+    def update_private(self, model, input_doc):
+        if model == "Identifier":
+            key = (input_doc["itemId"], input_doc["name"])
+        else:
+            key = input_doc["id"]
+        existing = self.private[model].get(key)
+        if not existing:
+            return None
+        existing.update(input_doc)
+        return existing
+
+    def get_private(self, model, key):
+        if model == "Identifier":
+            private_key = (key["itemId"], key["name"])
+        else:
+            private_key = key["id"]
+        return self.private[model].get(private_key)
+
+    def delete_private(self, model, key):
+        if model == "Identifier":
+            private_key = (key["itemId"], key["name"])
+        else:
+            private_key = key["id"]
+        return self.private[model].pop(private_key, None)
+
+    def list_private(self, model, filters, sort_direction="ASC", sort_field=None, limit=None):
+        docs = list(self.private[model].values())
+        for name, expected in filters.items():
+            docs = [doc for doc in docs if doc.get(name) == expected]
+        if limit:
+            docs = docs[:limit]
+        return docs
+
+    def get_cache(self, cache_key):
+        return self.cache.get(cache_key)
+
+    def put_cache(self, cache_key, operation_name, query, variables, response, ttl_seconds, stale_seconds):
+        now = utcnow()
+        self.cache[cache_key] = {
+            "response": response,
+            "fetched_at": now,
+            "expires_at": now + timedelta(seconds=ttl_seconds),
+            "stale_until": now + timedelta(seconds=stale_seconds),
+        }
+
+    def record_upstream_request(self, operation_name, root_fields, forwarded_query, variables):
+        self.upstream_audit.append(
+            {
+                "operation_name": operation_name,
+                "root_fields": root_fields,
+                "forwarded_query": forwarded_query,
+                "variables": variables,
+            }
+        )
+
+
+class FakeUpstream:
+    def __init__(self):
+        self.calls = 0
+
+    def execute(self, query, variables, operation_name):
+        self.calls += 1
+        score_id = variables.get("id") or variables.get("scoreId")
+        return {"data": {"getScore": {"id": score_id, "name": "Cached score"}}}
+
+
+def client_with_fakes(monkeypatch):
+    store = InMemoryStore()
+    upstream = FakeUpstream()
+    monkeypatch.setattr(proxy_app, "store", store)
+    monkeypatch.setattr(proxy_app, "upstream", upstream)
+    return TestClient(proxy_app.app), store, upstream
+
+
+def test_private_operation_uses_local_store_only(monkeypatch):
+    client, store, upstream = client_with_fakes(monkeypatch)
+
+    response = client.post(
+        "/graphql",
+        json={
+            "query": """
+            mutation CreateItem($input: CreateItemInput!) {
+                createItem(input: $input) { id accountId text }
+            }
+            """,
+            "variables": {
+                "input": {
+                    "id": "item-1",
+                    "accountId": "account-1",
+                    "text": "private text",
+                }
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["createItem"]["id"] == "item-1"
+    assert set(response.json()["data"]["createItem"]) == {"id", "accountId", "text"}
+    assert store.private["Item"]["item-1"]["text"] == "private text"
+    assert upstream.calls == 0
+
+
+def test_control_operation_is_cached(monkeypatch):
+    client, _store, upstream = client_with_fakes(monkeypatch)
+    payload = {
+        "query": "query GetScore($id: ID!) { getScore(id: $id) { id name } }",
+        "variables": {"id": "score-1"},
+        "operationName": "GetScore",
+    }
+
+    first = client.post("/graphql", json=payload)
+    second = client.post("/graphql", json=payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["data"] == {"getScore": {"id": "score-1", "name": "Cached score"}}
+    assert second.json()["data"] == first.json()["data"]
+    assert upstream.calls == 1
+
+
+def test_mixed_query_splits_private_and_control_roots(monkeypatch):
+    client, store, upstream = client_with_fakes(monkeypatch)
+    store.upsert_private(
+        "Item",
+        {"id": "item-1", "accountId": "account-1", "text": "private text"},
+    )
+
+    response = client.post(
+        "/graphql",
+        json={
+            "query": """
+            query Mixed($itemId: ID!, $scoreId: ID!) {
+                getItem(id: $itemId) { id text }
+                getScore(id: $scoreId) { id name }
+            }
+            """,
+            "variables": {"itemId": "item-1", "scoreId": "score-1"},
+            "operationName": "Mixed",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["getItem"]["text"] == "private text"
+    assert response.json()["data"]["getScore"]["id"] == "score-1"
+    assert upstream.calls == 1
+    assert store.upstream_audit[0]["root_fields"] == ["getScore"]
+    assert "getItem" not in store.upstream_audit[0]["forwarded_query"]

--- a/services/private-graphql-proxy/tests/test_operation_classifier.py
+++ b/services/private-graphql-proxy/tests/test_operation_classifier.py
@@ -1,0 +1,49 @@
+from proxy.graphql_tools import build_operation_plan, build_root_only_query
+
+
+def test_classifies_private_and_control_roots():
+    plan = build_operation_plan(
+        """
+        query Mixed($itemId: ID!, $scoreId: ID!) {
+            getItem(id: $itemId) { id text }
+            getScore(id: $scoreId) { id name }
+        }
+        """,
+        "Mixed",
+    )
+
+    assert [field.name for field in plan.private_fields] == ["getItem"]
+    assert [field.name for field in plan.control_fields] == ["getScore"]
+    assert not plan.blocked_fields
+
+
+def test_blocks_control_plane_mutations():
+    plan = build_operation_plan(
+        """
+        mutation Unsafe($input: CreateScoreInput!) {
+            createScore(input: $input) { id name }
+        }
+        """,
+        "Unsafe",
+    )
+
+    assert [field.name for field in plan.blocked_fields] == ["createScore"]
+
+
+def test_builds_control_only_query_for_mixed_operation():
+    plan = build_operation_plan(
+        """
+        query Mixed($itemId: ID!, $scoreId: ID!) {
+            getItem(id: $itemId) { id text }
+            getScore(id: $scoreId) { id name }
+        }
+        """,
+        "Mixed",
+    )
+
+    control_query = build_root_only_query(plan, plan.control_fields)
+
+    assert "getScore" in control_query
+    assert "getItem" not in control_query
+    assert "$scoreId" in control_query
+    assert "$itemId" not in control_query

--- a/services/private-graphql-proxy/tests/test_smoke_proxy.py
+++ b/services/private-graphql-proxy/tests/test_smoke_proxy.py
@@ -1,0 +1,465 @@
+import os
+import sys
+import types
+import uuid
+
+import pytest
+import requests
+
+
+pytestmark = pytest.mark.integration
+
+
+def proxy_url() -> str:
+    return os.getenv("PLEXUS_API_URL", "http://localhost:18080/graphql")
+
+
+def proxy_headers() -> dict[str, str]:
+    return {"x-api-key": os.getenv("PLEXUS_API_KEY", "local-smoke-key")}
+
+
+def execute(query: str, variables: dict | None = None) -> dict:
+    response = requests.post(
+        proxy_url(),
+        json={"query": query, "variables": variables or {}},
+        headers=proxy_headers(),
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    assert "errors" not in payload, payload
+    return payload["data"]
+
+
+def test_private_models_round_trip_through_proxy():
+    suffix = str(uuid.uuid4())
+    account_id = f"smoke-account-{suffix}"
+    item_id = f"smoke-item-{suffix}"
+    score_result_id = f"smoke-score-result-{suffix}"
+    feedback_item_id = f"smoke-feedback-item-{suffix}"
+    scorecard_id = f"smoke-scorecard-{suffix}"
+    score_id = f"smoke-score-{suffix}"
+    cache_key = f"smoke-cache-{suffix}"
+
+    item = execute(
+        """
+        mutation CreateItem($input: CreateItemInput!) {
+            createItem(input: $input) { id accountId text externalId createdAt updatedAt }
+        }
+        """,
+        {
+            "input": {
+                "id": item_id,
+                "accountId": account_id,
+                "text": "local private smoke item",
+                "externalId": f"external-{suffix}",
+                "isEvaluation": False,
+                "createdByType": "prediction",
+            }
+        },
+    )["createItem"]
+    assert item["id"] == item_id
+
+    identifier = execute(
+        """
+        mutation CreateIdentifier($input: CreateIdentifierInput!) {
+            createIdentifier(input: $input) { itemId name value accountId position }
+        }
+        """,
+        {
+            "input": {
+                "itemId": item_id,
+                "name": "Smoke ID",
+                "value": f"identifier-{suffix}",
+                "accountId": account_id,
+                "position": 0,
+            }
+        },
+    )["createIdentifier"]
+    assert identifier["itemId"] == item_id
+
+    score_result = execute(
+        """
+        mutation CreateScoreResult($input: CreateScoreResultInput!) {
+            createScoreResult(input: $input) { id itemId accountId scorecardId scoreId value type status }
+        }
+        """,
+        {
+            "input": {
+                "id": score_result_id,
+                "itemId": item_id,
+                "accountId": account_id,
+                "scorecardId": scorecard_id,
+                "scoreId": score_id,
+                "value": "Yes",
+                "type": "prediction",
+                "status": "COMPLETED",
+            }
+        },
+    )["createScoreResult"]
+    assert score_result["id"] == score_result_id
+
+    feedback_item = execute(
+        """
+        mutation CreateFeedbackItem($input: CreateFeedbackItemInput!) {
+            createFeedbackItem(input: $input) { id itemId accountId scorecardId scoreId cacheKey }
+        }
+        """,
+        {
+            "input": {
+                "id": feedback_item_id,
+                "itemId": item_id,
+                "accountId": account_id,
+                "scorecardId": scorecard_id,
+                "scoreId": score_id,
+                "cacheKey": cache_key,
+                "initialAnswerValue": "Yes",
+                "finalAnswerValue": "No",
+            }
+        },
+    )["createFeedbackItem"]
+    assert feedback_item["id"] == feedback_item_id
+
+    assert execute(
+        "query GetItem($id: ID!) { getItem(id: $id) { id text } }",
+        {"id": item_id},
+    )["getItem"]["text"] == "local private smoke item"
+
+    identifier_items = execute(
+        """
+        query FindIdentifier($accountId: String!, $value: String!) {
+            listIdentifierByAccountIdAndValue(accountId: $accountId, value: {eq: $value}) {
+                items { itemId name value }
+                nextToken
+            }
+        }
+        """,
+        {"accountId": account_id, "value": f"identifier-{suffix}"},
+    )["listIdentifierByAccountIdAndValue"]["items"]
+    assert identifier_items[0]["itemId"] == item_id
+
+    score_items = execute(
+        """
+        query FindScoreResult($itemId: String!, $type: String!, $scoreId: String!) {
+            listScoreResultByItemIdAndTypeAndScoreIdAndUpdatedAt(
+                itemId: $itemId,
+                typeScoreIdUpdatedAt: {beginsWith: {type: $type, scoreId: $scoreId}},
+                sortDirection: DESC,
+                limit: 1
+            ) {
+                items { id itemId scoreId type }
+                nextToken
+            }
+        }
+        """,
+        {"itemId": item_id, "type": "prediction", "scoreId": score_id},
+    )["listScoreResultByItemIdAndTypeAndScoreIdAndUpdatedAt"]["items"]
+    assert score_items[0]["id"] == score_result_id
+
+    feedback_items = execute(
+        """
+        query FindFeedback($cacheKey: String!) {
+            listFeedbackItemByCacheKey(cacheKey: $cacheKey) {
+                items { id cacheKey itemId }
+                nextToken
+            }
+        }
+        """,
+        {"cacheKey": cache_key},
+    )["listFeedbackItemByCacheKey"]["items"]
+    assert feedback_items[0]["id"] == feedback_item_id
+
+
+def test_seeded_item_read_paths_through_proxy():
+    suffix = str(uuid.uuid4())
+    account_id = f"item-read-account-{suffix}"
+    score_id = f"item-read-score-{suffix}"
+    item_id = f"item-read-{suffix}"
+    external_id = f"item-read-external-{suffix}"
+
+    seeded = execute(
+        """
+        mutation SeedItem($input: CreateItemInput!) {
+            createItem(input: $input) {
+                id
+                accountId
+                scoreId
+                externalId
+                text
+                metadata
+                createdAt
+                updatedAt
+            }
+        }
+        """,
+        {
+            "input": {
+                "id": item_id,
+                "accountId": account_id,
+                "scoreId": score_id,
+                "externalId": external_id,
+                "text": "seeded local item read smoke",
+                "metadata": {"source": "private-graphql-proxy-smoke", "suffix": suffix},
+                "isEvaluation": False,
+                "createdByType": "prediction",
+            }
+        },
+    )["createItem"]
+    assert seeded["id"] == item_id
+
+    by_id = execute(
+        """
+        query GetSeededItem($id: ID!) {
+            getItem(id: $id) {
+                id
+                accountId
+                scoreId
+                externalId
+                text
+                metadata
+            }
+        }
+        """,
+        {"id": item_id},
+    )["getItem"]
+    assert by_id["id"] == item_id
+    assert by_id["text"] == "seeded local item read smoke"
+    assert by_id["metadata"]["source"] == "private-graphql-proxy-smoke"
+
+    by_account = execute(
+        """
+        query ItemsByAccount($accountId: String!) {
+            listItemByAccountIdAndUpdatedAt(
+                accountId: $accountId,
+                sortDirection: DESC,
+                limit: 5
+            ) {
+                items { id accountId externalId text }
+                nextToken
+            }
+        }
+        """,
+        {"accountId": account_id},
+    )["listItemByAccountIdAndUpdatedAt"]["items"]
+    assert [item["id"] for item in by_account] == [item_id]
+
+    by_score = execute(
+        """
+        query ItemsByScore($scoreId: String!) {
+            listItemByScoreIdAndUpdatedAt(
+                scoreId: $scoreId,
+                sortDirection: DESC,
+                limit: 5
+            ) {
+                items { id scoreId externalId text }
+                nextToken
+            }
+        }
+        """,
+        {"scoreId": score_id},
+    )["listItemByScoreIdAndUpdatedAt"]["items"]
+    assert [item["id"] for item in by_score] == [item_id]
+
+    by_external_id = execute(
+        """
+        query ItemByExternalId($accountId: String!, $externalId: String!) {
+            listItemByAccountIdAndExternalId(
+                accountId: $accountId,
+                externalId: {eq: $externalId},
+                limit: 1
+            ) {
+                items { id accountId externalId text }
+                nextToken
+            }
+        }
+        """,
+        {"accountId": account_id, "externalId": external_id},
+    )["listItemByAccountIdAndExternalId"]["items"]
+    assert [item["id"] for item in by_external_id] == [item_id]
+
+
+def test_score_result_can_be_created_for_seeded_item():
+    suffix = str(uuid.uuid4())
+    account_id = f"score-result-account-{suffix}"
+    item_id = f"score-result-item-{suffix}"
+    score_result_id = f"score-result-{suffix}"
+    scorecard_id = f"score-result-scorecard-{suffix}"
+    score_id = f"score-result-score-{suffix}"
+    score_version_id = f"score-result-version-{suffix}"
+
+    execute(
+        """
+        mutation SeedItem($input: CreateItemInput!) {
+            createItem(input: $input) { id accountId text }
+        }
+        """,
+        {
+            "input": {
+                "id": item_id,
+                "accountId": account_id,
+                "scoreId": score_id,
+                "externalId": f"score-result-external-{suffix}",
+                "text": "item that will receive a score result",
+                "isEvaluation": False,
+                "createdByType": "prediction",
+            }
+        },
+    )
+
+    created = execute(
+        """
+        mutation CreateScoreResult($input: CreateScoreResultInput!) {
+            createScoreResult(input: $input) {
+                id
+                itemId
+                accountId
+                scorecardId
+                scoreId
+                scoreVersionId
+                value
+                explanation
+                confidence
+                metadata
+                type
+                status
+            }
+        }
+        """,
+        {
+            "input": {
+                "id": score_result_id,
+                "itemId": item_id,
+                "accountId": account_id,
+                "scorecardId": scorecard_id,
+                "scoreId": score_id,
+                "scoreVersionId": score_version_id,
+                "value": "Pass",
+                "explanation": "Created by private GraphQL proxy smoke test",
+                "confidence": 0.98,
+                "metadata": {"source": "private-graphql-proxy-smoke", "suffix": suffix},
+                "type": "prediction",
+                "status": "COMPLETED",
+                "code": "200",
+            }
+        },
+    )["createScoreResult"]
+    assert created["id"] == score_result_id
+    assert created["itemId"] == item_id
+    assert created["metadata"]["source"] == "private-graphql-proxy-smoke"
+
+    by_id = execute(
+        """
+        query GetScoreResult($id: ID!) {
+            getScoreResult(id: $id) {
+                id
+                itemId
+                scoreId
+                value
+                status
+            }
+        }
+        """,
+        {"id": score_result_id},
+    )["getScoreResult"]
+    assert by_id == {
+        "id": score_result_id,
+        "itemId": item_id,
+        "scoreId": score_id,
+        "value": "Pass",
+        "status": "COMPLETED",
+    }
+
+    by_item = execute(
+        """
+        query ScoreResultsByItem($itemId: String!) {
+            listScoreResultByItemId(itemId: $itemId) {
+                items { id itemId scoreId value status }
+                nextToken
+            }
+        }
+        """,
+        {"itemId": item_id},
+    )["listScoreResultByItemId"]["items"]
+    assert [result["id"] for result in by_item] == [score_result_id]
+
+    by_item_score_type = execute(
+        """
+        query ScoreResultsByItemScoreType($itemId: String!, $type: String!, $scoreId: String!) {
+            listScoreResultByItemIdAndTypeAndScoreIdAndUpdatedAt(
+                itemId: $itemId,
+                typeScoreIdUpdatedAt: {beginsWith: {type: $type, scoreId: $scoreId}},
+                sortDirection: DESC,
+                limit: 1
+            ) {
+                items { id itemId scoreId type value status }
+                nextToken
+            }
+        }
+        """,
+        {"itemId": item_id, "type": "prediction", "scoreId": score_id},
+    )["listScoreResultByItemIdAndTypeAndScoreIdAndUpdatedAt"]["items"]
+    assert [result["id"] for result in by_item_score_type] == [score_result_id]
+
+
+def test_control_plane_cache_smoke_read_only():
+    required = {
+        "PLEXUS_PROXY_SMOKE_ACCOUNT_ID": os.getenv("PLEXUS_PROXY_SMOKE_ACCOUNT_ID"),
+        "PLEXUS_PROXY_SMOKE_SCORECARD_ID": os.getenv("PLEXUS_PROXY_SMOKE_SCORECARD_ID"),
+        "PLEXUS_PROXY_SMOKE_SCORE_ID": os.getenv("PLEXUS_PROXY_SMOKE_SCORE_ID"),
+        "PLEXUS_PROXY_SMOKE_SCORE_VERSION_ID": os.getenv("PLEXUS_PROXY_SMOKE_SCORE_VERSION_ID"),
+        "PLEXUS_PROXY_SMOKE_EVALUATION_ID": os.getenv("PLEXUS_PROXY_SMOKE_EVALUATION_ID"),
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        pytest.skip(f"missing production read-only smoke fixture env vars: {', '.join(missing)}")
+
+    query = """
+    query ControlSmoke($accountId: ID!, $scorecardId: ID!, $scoreId: ID!, $scoreVersionId: ID!, $evaluationId: ID!) {
+        getAccount(id: $accountId) { id name key }
+        getScorecard(id: $scorecardId) { id name key }
+        getScore(id: $scoreId) { id name key }
+        getScoreVersion(id: $scoreVersionId) { id }
+        getEvaluation(id: $evaluationId) { id type status }
+    }
+    """
+    variables = {
+        "accountId": required["PLEXUS_PROXY_SMOKE_ACCOUNT_ID"],
+        "scorecardId": required["PLEXUS_PROXY_SMOKE_SCORECARD_ID"],
+        "scoreId": required["PLEXUS_PROXY_SMOKE_SCORE_ID"],
+        "scoreVersionId": required["PLEXUS_PROXY_SMOKE_SCORE_VERSION_ID"],
+        "evaluationId": required["PLEXUS_PROXY_SMOKE_EVALUATION_ID"],
+    }
+
+    first = execute(query, variables)
+    second = execute(query, variables)
+
+    assert first["getAccount"]["id"] == variables["accountId"]
+    assert second == first
+
+
+def test_existing_plexus_client_can_target_proxy():
+    if "plexus.utils" not in sys.modules:
+        utils_stub = types.ModuleType("plexus.utils")
+        utils_stub.truncate_dict_strings_inner = lambda value, *args, **kwargs: value
+        sys.modules["plexus.utils"] = utils_stub
+
+    try:
+        from plexus.dashboard.api.client import PlexusDashboardClient
+        from plexus.dashboard.api.models.item import Item
+    except Exception as exc:
+        pytest.skip(f"existing Plexus client dependencies are not installed: {exc}")
+
+    suffix = str(uuid.uuid4())
+    client = PlexusDashboardClient(api_url=proxy_url(), api_key=os.getenv("PLEXUS_API_KEY", "local-smoke-key"))
+    item = Item.create(
+        client,
+        evaluationId="prediction-default",
+        deterministic_id=f"client-smoke-item-{suffix}",
+        accountId=f"client-smoke-account-{suffix}",
+        text="created through existing Plexus client",
+        isEvaluation=False,
+        createdByType="prediction",
+    )
+
+    fetched = Item.get_by_id(item.id, client)
+    assert fetched.text == "created through existing Plexus client"


### PR DESCRIPTION
## Summary
- Adds a standalone private GraphQL proxy prototype under `services/private-graphql-proxy`.
- Routes private models (`Item`, `ScoreResult`, `FeedbackItem`, `Identifier`) to local PostgreSQL storage using JSONB plus projected indexes.
- Routes allowlisted read-only control-plane GraphQL operations to AppSync with PostgreSQL cache-aside behavior.
- Includes Docker Compose smoke harness for proxy + PostgreSQL + pytest.

## Testing
- `PYTHONPATH=services/private-graphql-proxy /tmp/plexus-private-graphql-proxy-venv/bin/pytest services/private-graphql-proxy/tests/test_operation_classifier.py services/private-graphql-proxy/tests/test_app_routing.py -q` -> 6 passed.
- Docker private Item read smoke -> 1 passed.
- Docker Item-to-ScoreResult smoke -> 1 passed.
- Docker real AppSync read-only control-plane cache smoke -> 1 passed.

## Security / Data Handling
- Real AppSync testing used local `.env` credentials but only for read-only control-plane queries.
- No real credentials, API URLs, production fixture IDs, or temporary smoke env files are committed.
- Private model smoke writes are local PostgreSQL-only and are not forwarded to AWS.

Kanbus: `plx-0b6b0c`