### PR TITLE
Add smoke-testable private GraphQL proxy prototype

### DIFF
--- a/plexus/cli/prediction/predictions.py
+++ b/plexus/cli/prediction/predictions.py
@@ -10,7 +10,7 @@ import sys
 import traceback
 import socket
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 
 from plexus.CustomLogging import logging
 from plexus.Registries import scorecard_registry
@@ -378,7 +378,7 @@ async def predict_impl(
                         tracker.current_stage.status_message = f"Running prediction for score: {score_name}"
                     
                     # Use centralized Scorecard path for dependency-aware predictions
-                    transcript, predictions, costs = await predict_score_with_individual_loading(
+                    scorecard_instance, predictions, costs = await predict_score_with_individual_loading(
                         scorecard_identifier, score_name, sample_row, used_item_id, no_cache=no_cache, yaml_only=yaml_only, specific_version=resolved_version
                     )
                     
@@ -397,6 +397,16 @@ async def predict_impl(
                                     row_result[f'{score_name}_trace'] = prediction.metadata.get('trace')
                                 else:
                                     row_result[f'{score_name}_trace'] = None
+                                score_result = persist_prediction_score_result(
+                                    scorecard_instance=scorecard_instance,
+                                    scorecard_identifier=scorecard_identifier,
+                                    score_name=score_name,
+                                    item_id=used_item_id,
+                                    prediction=prediction,
+                                    costs=costs,
+                                    trace=row_result[f'{score_name}_trace'],
+                                )
+                                row_result[f'{score_name}_score_result_id'] = score_result.id
                                 logging.info(f"Got predictions: {predictions}")
                         else:
                             # Handle Score.Result object
@@ -477,6 +487,16 @@ async def predict_impl(
                                     logging.warning(f"  ⚠️ No trace data found anywhere in predictions object")
                                 
                                 row_result[f'{score_name}_trace'] = trace
+                                score_result = persist_prediction_score_result(
+                                    scorecard_instance=scorecard_instance,
+                                    scorecard_identifier=scorecard_identifier,
+                                    score_name=score_name,
+                                    item_id=used_item_id,
+                                    prediction=predictions,
+                                    costs=costs,
+                                    trace=trace,
+                                )
+                                row_result[f'{score_name}_score_result_id'] = score_result.id
                                 logging.info(f"Got predictions: {predictions}")
                     else:
                         row_result[f'{score_name}_value'] = None
@@ -576,7 +596,7 @@ async def predict_impl(
                                 tracker.current_stage.status_message = f"Running prediction for score: {score_name}"
                                 tracker.update(current_items=current_prediction)
                             
-                            transcript, predictions, costs = await predict_score_with_individual_loading(
+                            scorecard_instance, predictions, costs = await predict_score_with_individual_loading(
                                 scorecard_identifier, score_name, sample_row, used_item_id, no_cache=no_cache, yaml_only=yaml_only, specific_version=resolved_version
                             )
                             
@@ -595,6 +615,16 @@ async def predict_impl(
                                             row_result[f'{score_name}_trace'] = prediction.metadata.get('trace')
                                         else:
                                             row_result[f'{score_name}_trace'] = None
+                                        score_result = persist_prediction_score_result(
+                                            scorecard_instance=scorecard_instance,
+                                            scorecard_identifier=scorecard_identifier,
+                                            score_name=score_name,
+                                            item_id=used_item_id,
+                                            prediction=prediction,
+                                            costs=costs,
+                                            trace=row_result[f'{score_name}_trace'],
+                                        )
+                                        row_result[f'{score_name}_score_result_id'] = score_result.id
                                         logging.info(f"Got predictions: {predictions}")
                                 else:
                                     # Handle Score.Result object
@@ -675,6 +705,16 @@ async def predict_impl(
                                             logging.warning(f"  ⚠️ No trace data found anywhere in predictions object")
                                         
                                         row_result[f'{score_name}_trace'] = trace
+                                        score_result = persist_prediction_score_result(
+                                            scorecard_instance=scorecard_instance,
+                                            scorecard_identifier=scorecard_identifier,
+                                            score_name=score_name,
+                                            item_id=used_item_id,
+                                            prediction=predictions,
+                                            costs=costs,
+                                            trace=trace,
+                                        )
+                                        row_result[f'{score_name}_score_result_id'] = score_result.id
                                         logging.info(f"Got predictions: {predictions}")
                             else:
                                 row_result[f'{score_name}_value'] = None
@@ -740,6 +780,7 @@ async def predict_impl(
                     for name in score_names:
                         score_data = {
                             'name': name,
+                            'score_result_id': result.get(f'{name}_score_result_id'),
                             'value': result.get(f'{name}_value'),
                             'explanation': result.get(f'{name}_explanation'),
                             'cost': result.get(f'{name}_cost'),
@@ -809,11 +850,14 @@ async def predict_impl(
                     
                     for name in score_names:
                         value = result.get(f'{name}_value')
+                        score_result_id = result.get(f'{name}_score_result_id')
                         explanation = result.get(f'{name}_explanation')
                         cost = result.get(f'{name}_cost')
                         trace = result.get(f'{name}_trace')
                         
                         rich.print(f"\n[bold cyan]{name} Score:[/bold cyan]")
+                        if score_result_id:
+                            rich.print(f"  [bold]ScoreResult ID:[/bold] {score_result_id}")
                         rich.print(f"  [bold]Value:[/bold] {value}")
                         if explanation:
                             rich.print(f"  [bold]Explanation:[/bold] {explanation}")
@@ -903,6 +947,7 @@ def output_excel(results, score_names, scorecard_identifier):
     columns = ['item_id', 'text']
     for name in score_names:
         columns.extend([
+            f'{name}_score_result_id',
             f'{name}_value',
             f'{name}_explanation',
             f'{name}_cost',
@@ -939,6 +984,146 @@ def output_excel(results, score_names, scorecard_identifier):
             cell.font = Font(bold=True)
 
     logging.info(f"Excel file '{filename}' has been created with the prediction results.")
+
+
+def _prediction_explanation(prediction: Any) -> str:
+    explanation = getattr(prediction, 'explanation', None)
+    if explanation:
+        return explanation
+    metadata = getattr(prediction, 'metadata', None)
+    if isinstance(metadata, dict):
+        return metadata.get('explanation', '') or ''
+    return ''
+
+
+def _prediction_score_id(prediction: Any) -> Optional[str]:
+    parameters = getattr(prediction, 'parameters', None)
+    score_id = getattr(parameters, 'id', None)
+    return str(score_id) if score_id else None
+
+
+def _scorecard_id_from_instance(scorecard_instance: Any) -> Optional[str]:
+    properties = getattr(scorecard_instance, 'properties', None)
+    if isinstance(properties, dict) and properties.get('id'):
+        return str(properties['id'])
+    scorecard_identifier = getattr(scorecard_instance, 'scorecard_identifier', None)
+    return str(scorecard_identifier) if scorecard_identifier else None
+
+
+def _score_version_id_from_instance(
+    scorecard_instance: Any,
+    score_name: str,
+    score_id: Optional[str],
+) -> Optional[str]:
+    for score_config in getattr(scorecard_instance, 'scores', []) or []:
+        if not isinstance(score_config, dict):
+            continue
+        identifiers = {
+            str(value)
+            for value in (
+                score_config.get('id'),
+                score_config.get('name'),
+                score_config.get('key'),
+                score_config.get('externalId'),
+                score_config.get('originalExternalId'),
+            )
+            if value
+        }
+        if (score_id and score_id in identifiers) or score_name in identifiers:
+            version_id = score_config.get('version') or score_config.get('championVersionId')
+            return str(version_id) if version_id else None
+    return None
+
+
+def persist_prediction_score_result(
+    *,
+    scorecard_instance: Any,
+    scorecard_identifier: str,
+    score_name: str,
+    item_id: str,
+    prediction: Any,
+    costs: Any,
+    trace: Any,
+) -> Any:
+    """Persist a successful `plexus predict` result through the configured GraphQL client."""
+    from plexus.cli.report.utils import resolve_account_id_for_command
+    from plexus.cli.shared.client_utils import create_client
+    from plexus.cli.shared.direct_memoized_resolvers import (
+        direct_memoized_resolve_score_identifier,
+        direct_memoized_resolve_scorecard_identifier,
+    )
+    from plexus.dashboard.api.models.score_result import ScoreResult
+
+    if not item_id:
+        raise ValueError("Cannot create ScoreResult without item_id")
+    if not hasattr(prediction, 'value') or prediction.value is None:
+        raise ValueError("Cannot create ScoreResult without prediction value")
+
+    client = create_client()
+    account_id = resolve_account_id_for_command(client, None)
+    scorecard_id = (
+        direct_memoized_resolve_scorecard_identifier(client, scorecard_identifier)
+        or _scorecard_id_from_instance(scorecard_instance)
+    )
+    if not scorecard_id:
+        raise ValueError(f"Could not resolve scorecard ID for {scorecard_identifier}")
+
+    score_id = _prediction_score_id(prediction) or direct_memoized_resolve_score_identifier(
+        client,
+        scorecard_id,
+        score_name,
+    )
+    if not score_id:
+        raise ValueError(f"Could not resolve score ID for {score_name}")
+
+    score_version_id = _score_version_id_from_instance(scorecard_instance, score_name, score_id)
+
+    prediction_metadata = getattr(prediction, 'metadata', None)
+    metadata = {
+        "source": "plexus predict",
+        "scorecard_identifier": scorecard_identifier,
+        "score_name": score_name,
+        "item_id": item_id,
+    }
+    if isinstance(prediction_metadata, dict):
+        metadata["prediction_metadata"] = {
+            key: value
+            for key, value in prediction_metadata.items()
+            if key != "trace"
+        }
+
+    cost_payload = costs if isinstance(costs, dict) else None
+    if cost_payload is None and costs is not None:
+        cost_payload = {"total_cost": costs}
+
+    create_kwargs = {
+        "scoreId": score_id,
+        "explanation": _prediction_explanation(prediction),
+        "metadata": metadata,
+    }
+    confidence = getattr(prediction, 'confidence', None)
+    if confidence is not None:
+        create_kwargs["confidence"] = confidence
+    if score_version_id:
+        create_kwargs["scoreVersionId"] = score_version_id
+    if trace is not None:
+        create_kwargs["trace"] = trace
+    if cost_payload is not None:
+        create_kwargs["cost"] = cost_payload
+
+    score_result = ScoreResult.create(
+        client=client,
+        value=str(prediction.value),
+        itemId=item_id,
+        accountId=account_id,
+        scorecardId=scorecard_id,
+        type="prediction",
+        status="COMPLETED",
+        code=getattr(prediction, 'code', None) or "200",
+        **create_kwargs,
+    )
+    logging.info(f"Created ScoreResult {score_result.id} for item {item_id}, score {score_name}")
+    return score_result
 
 
 def select_sample(scorecard_identifier, score_name, item_identifier, fresh, compare_to_feedback=False, scorecard_id=None, score_id=None):

--- a/plexus/cli/prediction/predictions_test.py
+++ b/plexus/cli/prediction/predictions_test.py
@@ -273,6 +273,12 @@ class TestPredictCommand:
 
 class TestPredictImpl:
     """Test the predict_impl async function"""
+
+    @pytest.fixture(autouse=True)
+    def mock_score_result_persistence(self):
+        with patch('plexus.cli.prediction.predictions.persist_prediction_score_result') as mock_persist:
+            mock_persist.return_value = Mock(id='score-result-123')
+            yield mock_persist
     
     @pytest.mark.asyncio
     async def test_predict_impl_success_fixed_format(self, mock_scorecard_registry, sample_scorecard_class):
@@ -302,7 +308,7 @@ class TestPredictImpl:
             mock_rich.print.assert_called()
     
     @pytest.mark.asyncio
-    async def test_predict_impl_success_json_format(self, mock_scorecard_registry, sample_scorecard_class):
+    async def test_predict_impl_success_json_format(self, mock_scorecard_registry, sample_scorecard_class, mock_score_result_persistence):
         """Test predict_impl with successful prediction in JSON format"""
         # Mock the new individual score loading pipeline
         with patch('plexus.cli.prediction.predictions.select_sample') as mock_select_sample, \
@@ -335,9 +341,13 @@ class TestPredictImpl:
             assert len(parsed_json) == 1
             assert parsed_json[0]['item_id'] == 'item-123'
             assert parsed_json[0]['scores'][0]['name'] == 'test-score'
+            assert parsed_json[0]['scores'][0]['score_result_id'] == 'score-result-123'
             assert parsed_json[0]['scores'][0]['value'] == 8.5
             # cost should be present either from result metadata or fallback
             assert 'cost' in parsed_json[0]['scores'][0]
+            mock_score_result_persistence.assert_called_once()
+            assert mock_score_result_persistence.call_args.kwargs['item_id'] == 'item-123'
+            assert mock_score_result_persistence.call_args.kwargs['score_name'] == 'test-score'
 
     @pytest.mark.asyncio
     async def test_predict_impl_json_without_cost_in_metadata_uses_fallback(self, mock_scorecard_registry, sample_scorecard_class):

--- a/project/events/2026-05-06T12:00:54.381Z__2a264b0f-641a-4b4c-ab40-6775de726faf.json
+++ b/project/events/2026-05-06T12:00:54.381Z__2a264b0f-641a-4b4c-ab40-6775de726faf.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "2a264b0f-641a-4b4c-ab40-6775de726faf",
+  "issue_id": "plx-4308ccc4-4925-4141-add9-4abf0ea17e6c",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T12:00:54.381Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Seed Hugging Face text-classification fixtures into the private GraphQL proxy/PostgreSQL data plane, run normal Plexus prediction code through the proxy against real read-only AppSync control-plane data, and assert private Item/Identifier traffic remains local.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Add full item-backed proxy scoring integration smoke"
+  }
+}

--- a/project/events/2026-05-06T12:00:56.562Z__6dc10b64-0b41-4329-af0b-9325e8956e48.json
+++ b/project/events/2026-05-06T12:00:56.562Z__6dc10b64-0b41-4329-af0b-9325e8956e48.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6dc10b64-0b41-4329-af0b-9325e8956e48",
+  "issue_id": "plx-4308ccc4-4925-4141-add9-4abf0ea17e6c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T12:00:56.562Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T12:12:22.822Z__6cd3c670-15a7-4d44-9da4-fb707cf845b4.json
+++ b/project/events/2026-05-06T12:12:22.822Z__6cd3c670-15a7-4d44-9da4-fb707cf845b4.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6cd3c670-15a7-4d44-9da4-fb707cf845b4",
+  "issue_id": "plx-4308ccc4-4925-4141-add9-4abf0ea17e6c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T12:12:22.822Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "e2f0935f-fe30-40a0-a6fc-f23a3787efe3"
+  }
+}

--- a/project/events/2026-05-06T12:12:22.839Z__2612ba35-ef86-4ded-a306-fb2158e156e1.json
+++ b/project/events/2026-05-06T12:12:22.839Z__2612ba35-ef86-4ded-a306-fb2158e156e1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2612ba35-ef86-4ded-a306-fb2158e156e1",
+  "issue_id": "plx-4308ccc4-4925-4141-add9-4abf0ea17e6c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T12:12:22.839Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-06T12:22:54.112Z__c6c458b2-941c-4da3-8310-54dd20ce4036.json
+++ b/project/events/2026-05-06T12:22:54.112Z__c6c458b2-941c-4da3-8310-54dd20ce4036.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c6c458b2-941c-4da3-8310-54dd20ce4036",
+  "issue_id": "plx-440ee64d-54a6-4d15-a51e-080310eff36a",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T12:22:54.112Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Correct the private GraphQL proxy scoring integration so standard plexus predict through the proxy is validated against the full expected contract, including local PostgreSQL ScoreResult creation and readback.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Make proxy scoring integration assert ScoreResult persistence"
+  }
+}

--- a/project/events/2026-05-06T12:23:01.595Z__4eaf001e-94aa-46f1-8782-17447a61b022.json
+++ b/project/events/2026-05-06T12:23:01.595Z__4eaf001e-94aa-46f1-8782-17447a61b022.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4eaf001e-94aa-46f1-8782-17447a61b022",
+  "issue_id": "plx-440ee64d-54a6-4d15-a51e-080310eff36a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T12:23:01.595Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T12:30:11.663Z__e713ca83-32fa-4f7c-865e-93288d0f7046.json
+++ b/project/events/2026-05-06T12:30:11.663Z__e713ca83-32fa-4f7c-865e-93288d0f7046.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e713ca83-32fa-4f7c-865e-93288d0f7046",
+  "issue_id": "plx-440ee64d-54a6-4d15-a51e-080310eff36a",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T12:30:11.663Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "6399f01b-085d-4c57-9ff8-4a1a51c4a8a4"
+  }
+}

--- a/project/events/2026-05-06T12:30:11.677Z__7fb26004-a55e-4664-84d6-15f4e55595e6.json
+++ b/project/events/2026-05-06T12:30:11.677Z__7fb26004-a55e-4664-84d6-15f4e55595e6.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7fb26004-a55e-4664-84d6-15f4e55595e6",
+  "issue_id": "plx-440ee64d-54a6-4d15-a51e-080310eff36a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T12:30:11.677Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-06T12:43:29.112Z__444f1fc3-c877-47ea-aa2f-cdc02757437c.json
+++ b/project/events/2026-05-06T12:43:29.112Z__444f1fc3-c877-47ea-aa2f-cdc02757437c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "444f1fc3-c877-47ea-aa2f-cdc02757437c",
+  "issue_id": "plx-0b6b0c04-880b-473f-9a50-df9f721367a4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T12:43:29.112Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "13c1f95f-a936-4d10-b819-b1ad0b2e1ce9"
+  }
+}

--- a/project/events/2026-05-06T12:43:33.191Z__a50aa9e1-74fc-4df5-8d7a-e019cd0417b4.json
+++ b/project/events/2026-05-06T12:43:33.191Z__a50aa9e1-74fc-4df5-8d7a-e019cd0417b4.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a50aa9e1-74fc-4df5-8d7a-e019cd0417b4",
+  "issue_id": "plx-4308ccc4-4925-4141-add9-4abf0ea17e6c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T12:43:33.191Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "544121a3-57b0-4575-954a-bfe171b00003"
+  }
+}

--- a/project/events/2026-05-06T12:43:37.661Z__15fa1d43-0163-48f6-a84f-411138a42988.json
+++ b/project/events/2026-05-06T12:43:37.661Z__15fa1d43-0163-48f6-a84f-411138a42988.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "15fa1d43-0163-48f6-a84f-411138a42988",
+  "issue_id": "plx-440ee64d-54a6-4d15-a51e-080310eff36a",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T12:43:37.661Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "fb9da607-af40-459a-b556-f2da9586e273"
+  }
+}

--- a/project/issues/plx-0b6b0c04-880b-473f-9a50-df9f721367a4.json
+++ b/project/issues/plx-0b6b0c04-880b-473f-9a50-df9f721367a4.json
@@ -40,10 +40,16 @@
       "author": "ryan",
       "text": "Added and ran focused ScoreResult-for-Item smoke coverage. The test seeds a local Item, creates a ScoreResult with itemId pointing to that Item, then verifies getScoreResult, listScoreResultByItemId, and listScoreResultByItemIdAndTypeAndScoreIdAndUpdatedAt all return it. It also exposed and fixed a prototype bug where private GraphQL responses returned full documents instead of honoring selected fields. Rebuilt the proxy Docker image and reran the focused smoke: 1 passed in 0.12s. AppSync credentials were blank; AWS was not touched.",
       "created_at": "2026-05-05T21:14:08.612978Z"
+    },
+    {
+      "id": "13c1f95f-a936-4d10-b819-b1ad0b2e1ce9",
+      "author": "ryan",
+      "text": "Updated outcome after scoring integration follow-up: the PostgreSQL design is a hybrid relational/document model. Private GraphQL rows use indexed relational projections for lookup fields plus authoritative jsonb documents for the full Item, Identifier, ScoreResult, and FeedbackItem payloads. The latest verification now covers standard plexus predict creating and reading back a local PostgreSQL ScoreResult through the proxy.",
+      "created_at": "2026-05-06T12:43:29.110221Z"
     }
   ],
   "created_at": "2026-05-05T20:49:03.847277Z",
-  "updated_at": "2026-05-05T21:15:01.390372Z",
+  "updated_at": "2026-05-06T12:43:29.110221Z",
   "closed_at": "2026-05-05T21:15:01.390372Z",
   "custom": {}
 }

--- a/project/issues/plx-4308ccc4-4925-4141-add9-4abf0ea17e6c.json
+++ b/project/issues/plx-4308ccc4-4925-4141-add9-4abf0ea17e6c.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-4308ccc4-4925-4141-add9-4abf0ea17e6c",
+  "title": "Add full item-backed proxy scoring integration smoke",
+  "description": "Seed Hugging Face text-classification fixtures into the private GraphQL proxy/PostgreSQL data plane, run normal Plexus prediction code through the proxy against real read-only AppSync control-plane data, and assert private Item/Identifier traffic remains local.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "e2f0935f-fe30-40a0-a6fc-f23a3787efe3",
+      "author": "ryan",
+      "text": "Implemented fixture-backed scoring integration. Added Hugging Face AG News seeder, full Plexus dependency Compose runner, real plexus predict integration test through the private proxy, and README instructions. Validation: proxy unit tests passed, proxy Docker smoke passed, full scoring integration passed with one seeded AG News item against read-only AppSync control-plane data.",
+      "created_at": "2026-05-06T12:12:22.822189Z"
+    }
+  ],
+  "created_at": "2026-05-06T12:00:54.381291Z",
+  "updated_at": "2026-05-06T12:12:22.838914Z",
+  "closed_at": "2026-05-06T12:12:22.838914Z",
+  "custom": {}
+}

--- a/project/issues/plx-4308ccc4-4925-4141-add9-4abf0ea17e6c.json
+++ b/project/issues/plx-4308ccc4-4925-4141-add9-4abf0ea17e6c.json
@@ -16,10 +16,16 @@
       "author": "ryan",
       "text": "Implemented fixture-backed scoring integration. Added Hugging Face AG News seeder, full Plexus dependency Compose runner, real plexus predict integration test through the private proxy, and README instructions. Validation: proxy unit tests passed, proxy Docker smoke passed, full scoring integration passed with one seeded AG News item against read-only AppSync control-plane data.",
       "created_at": "2026-05-06T12:12:22.822189Z"
+    },
+    {
+      "id": "544121a3-57b0-4575-954a-bfe171b00003",
+      "author": "ryan",
+      "text": "Clarification after review: the original scoring integration smoke was not sufficient by itself because it verified prediction output but did not assert ScoreResult persistence. Follow-up task plx-440ee6 corrected that by exercising the standard plexus predict command path and asserting ScoreResult create/readback through the proxy-backed PostgreSQL store.",
+      "created_at": "2026-05-06T12:43:33.191391Z"
     }
   ],
   "created_at": "2026-05-06T12:00:54.381291Z",
-  "updated_at": "2026-05-06T12:12:22.838914Z",
+  "updated_at": "2026-05-06T12:43:33.191391Z",
   "closed_at": "2026-05-06T12:12:22.838914Z",
   "custom": {}
 }

--- a/project/issues/plx-440ee64d-54a6-4d15-a51e-080310eff36a.json
+++ b/project/issues/plx-440ee64d-54a6-4d15-a51e-080310eff36a.json
@@ -16,10 +16,16 @@
       "author": "ryan",
       "text": "Implemented standard plexus predict ScoreResult persistence and tightened the private proxy scoring integration to assert create/readback of local PostgreSQL ScoreResults. Verified with Docker scoring integration against suco_home_improvement / blind_transfer_ai: prediction value Yes, ScoreResult persisted locally, and proxy debug showed 8 upstream control-plane requests with 0 private roots forwarded.",
       "created_at": "2026-05-06T12:30:11.663631Z"
+    },
+    {
+      "id": "fb9da607-af40-459a-b556-f2da9586e273",
+      "author": "ryan",
+      "text": "Final review note: the accepted implementation persists ScoreResult from the normal plexus predict CLI path, not a special harness-only shortcut. The integration test now seeds private Item/Identifier rows through the proxy, runs plexus predict with PLEXUS_API_URL pointed at the proxy, verifies the returned score_result_id with getScoreResult/listScoreResultByItemId, and checks proxy diagnostics for zero private upstream roots.",
+      "created_at": "2026-05-06T12:43:37.661128Z"
     }
   ],
   "created_at": "2026-05-06T12:22:54.112564Z",
-  "updated_at": "2026-05-06T12:30:11.676838Z",
+  "updated_at": "2026-05-06T12:43:37.661128Z",
   "closed_at": "2026-05-06T12:30:11.676838Z",
   "custom": {}
 }

--- a/project/issues/plx-440ee64d-54a6-4d15-a51e-080310eff36a.json
+++ b/project/issues/plx-440ee64d-54a6-4d15-a51e-080310eff36a.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-440ee64d-54a6-4d15-a51e-080310eff36a",
+  "title": "Make proxy scoring integration assert ScoreResult persistence",
+  "description": "Correct the private GraphQL proxy scoring integration so standard plexus predict through the proxy is validated against the full expected contract, including local PostgreSQL ScoreResult creation and readback.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "6399f01b-085d-4c57-9ff8-4a1a51c4a8a4",
+      "author": "ryan",
+      "text": "Implemented standard plexus predict ScoreResult persistence and tightened the private proxy scoring integration to assert create/readback of local PostgreSQL ScoreResults. Verified with Docker scoring integration against suco_home_improvement / blind_transfer_ai: prediction value Yes, ScoreResult persisted locally, and proxy debug showed 8 upstream control-plane requests with 0 private roots forwarded.",
+      "created_at": "2026-05-06T12:30:11.663631Z"
+    }
+  ],
+  "created_at": "2026-05-06T12:22:54.112564Z",
+  "updated_at": "2026-05-06T12:30:11.676838Z",
+  "closed_at": "2026-05-06T12:30:11.676838Z",
+  "custom": {}
+}

--- a/services/private-graphql-proxy/Dockerfile.scoring-integration
+++ b/services/private-graphql-proxy/Dockerfile.scoring-integration
@@ -1,0 +1,27 @@
+FROM python:3.12-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV POETRY_NO_INTERACTION=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        graphviz \
+        libcurl4-openssl-dev \
+        libgraphviz-dev \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+RUN pip install --no-cache-dir poetry==1.8.5
+
+COPY pyproject.toml poetry.lock poetry.toml ./
+RUN poetry config virtualenvs.create false \
+    && poetry install --with dev --no-root --no-ansi
+
+CMD ["pytest", "-o", "addopts=", "-m", "integration", "services/private-graphql-proxy/tests/test_scoring_integration.py", "-q"]

--- a/services/private-graphql-proxy/README.md
+++ b/services/private-graphql-proxy/README.md
@@ -56,3 +56,39 @@ export PLEXUS_PROXY_SMOKE_EVALUATION_ID=...
 
 Private model smoke writes use generated test IDs and only write to local
 PostgreSQL through the proxy.
+
+## Scoring Integration
+
+The scoring integration harness starts PostgreSQL, the proxy, and a full Plexus
+dependency runner. It seeds public Hugging Face text-classification examples as
+local private `Item` and `Identifier` rows, then runs the normal Plexus
+prediction CLI through the proxy.
+
+Required control-plane and score configuration values:
+
+```bash
+export PLEXUS_PROXY_UPSTREAM_API_URL="$PLEXUS_API_URL"
+# Set PLEXUS_PROXY_UPSTREAM_API_KEY from your shell or secret manager.
+export PLEXUS_ACCOUNT_KEY=...
+export PLEXUS_PROXY_SCORING_SCORECARD=...
+export PLEXUS_PROXY_SCORING_SCORE=...
+```
+
+Optional fixture controls:
+
+```bash
+export PLEXUS_PROXY_SCORING_DATASET=fancyzhx/ag_news
+export PLEXUS_PROXY_SCORING_SPLIT=test
+export PLEXUS_PROXY_SCORING_FIXTURE_LIMIT=3
+```
+
+Run the integration harness:
+
+```bash
+services/private-graphql-proxy/scripts/scoring-integration.sh
+```
+
+The runner sets `PLEXUS_API_URL` to the local proxy and clears the
+`NEXT_PUBLIC_PLEXUS_API_*` variables so the Plexus client cannot bypass the
+proxy. The test uses AppSync for read-only control-plane data and writes fixture
+private rows only to local PostgreSQL.

--- a/services/private-graphql-proxy/docker-compose.smoke.yml
+++ b/services/private-graphql-proxy/docker-compose.smoke.yml
@@ -56,3 +56,49 @@ services:
     depends_on:
       proxy:
         condition: service_healthy
+
+  scoring-integration:
+    profiles:
+      - scoring-integration
+    build:
+      context: ../..
+      dockerfile: services/private-graphql-proxy/Dockerfile.scoring-integration
+    working_dir: /workspace
+    environment:
+      PYTHONPATH: /workspace:/workspace/services/private-graphql-proxy
+      PLEXUS_API_URL: http://proxy:8000/graphql
+      PLEXUS_API_KEY: ${PLEXUS_PROXY_API_KEY:-local-smoke-key}
+      NEXT_PUBLIC_PLEXUS_API_URL: ""
+      NEXT_PUBLIC_PLEXUS_API_KEY: ""
+      PLEXUS_ACCOUNT_KEY: ${PLEXUS_ACCOUNT_KEY:-}
+      PLEXUS_PROXY_SCORING_ACCOUNT_ID: ${PLEXUS_PROXY_SCORING_ACCOUNT_ID:-}
+      PLEXUS_PROXY_SCORING_SCORECARD: ${PLEXUS_PROXY_SCORING_SCORECARD:-}
+      PLEXUS_PROXY_SCORING_SCORE: ${PLEXUS_PROXY_SCORING_SCORE:-}
+      PLEXUS_PROXY_SCORING_SCORE_ID: ${PLEXUS_PROXY_SCORING_SCORE_ID:-}
+      PLEXUS_PROXY_SCORING_DATASET: ${PLEXUS_PROXY_SCORING_DATASET:-fancyzhx/ag_news}
+      PLEXUS_PROXY_SCORING_SPLIT: ${PLEXUS_PROXY_SCORING_SPLIT:-test}
+      PLEXUS_PROXY_SCORING_START: ${PLEXUS_PROXY_SCORING_START:-0}
+      PLEXUS_PROXY_SCORING_FIXTURE_LIMIT: ${PLEXUS_PROXY_SCORING_FIXTURE_LIMIT:-3}
+      PLEXUS_PROXY_SCORING_FIXTURE_PREFIX: ${PLEXUS_PROXY_SCORING_FIXTURE_PREFIX:-proxy-scoring-ag-news}
+      PLEXUS_PROXY_SCORING_TIMEOUT_SECONDS: ${PLEXUS_PROXY_SCORING_TIMEOUT_SECONDS:-300}
+      SCORECARD_CACHE_DIR: /tmp/plexus-scorecards
+      HF_HOME: /tmp/huggingface
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      AZURE_API_KEY: ${AZURE_API_KEY:-}
+      AZURE_API_BASE: ${AZURE_API_BASE:-}
+      AZURE_API_VERSION: ${AZURE_API_VERSION:-}
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_ENDPOINT: ${AZURE_OPENAI_ENDPOINT:-}
+      AZURE_OPENAI_DEPLOYMENT: ${AZURE_OPENAI_DEPLOYMENT:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_REGION_NAME: ${AWS_REGION_NAME:-}
+      AWS_REGION: ${AWS_REGION:-}
+    volumes:
+      - ../..:/workspace
+    command: >
+      pytest -o addopts='' -m integration services/private-graphql-proxy/tests/test_scoring_integration.py -q
+    depends_on:
+      proxy:
+        condition: service_healthy

--- a/services/private-graphql-proxy/scripts/scoring-integration.sh
+++ b/services/private-graphql-proxy/scripts/scoring-integration.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  cat <<'EOF'
+Run the private GraphQL proxy scoring integration harness.
+
+Required environment:
+  PLEXUS_PROXY_UPSTREAM_API_URL
+  PLEXUS_PROXY_UPSTREAM_API_KEY
+  PLEXUS_ACCOUNT_KEY
+  PLEXUS_PROXY_SCORING_SCORECARD
+  PLEXUS_PROXY_SCORING_SCORE
+
+Optional:
+  PLEXUS_PROXY_SCORING_DATASET=fancyzhx/ag_news
+  PLEXUS_PROXY_SCORING_SPLIT=test
+  PLEXUS_PROXY_SCORING_FIXTURE_LIMIT=3
+EOF
+  exit 0
+fi
+
+cd "$(dirname "$0")/.."
+docker compose -f docker-compose.smoke.yml --profile scoring-integration up --build --abort-on-container-exit --exit-code-from scoring-integration scoring-integration

--- a/services/private-graphql-proxy/scripts/seed_huggingface_items.py
+++ b/services/private-graphql-proxy/scripts/seed_huggingface_items.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+
+AG_NEWS_LABELS = ("World", "Sports", "Business", "Sci/Tech")
+DEFAULT_DATASET = "fancyzhx/ag_news"
+DEFAULT_SPLIT = "test"
+DEFAULT_IDENTIFIER_NAME = "Hugging Face Fixture ID"
+DEFAULT_PREFIX = "proxy-ag-news"
+
+
+@dataclass(frozen=True)
+class SeededFixture:
+    id: str
+    external_id: str
+    identifier_name: str
+    identifier_value: str
+    label: int | str | None
+    label_name: str | None
+    row_index: int
+    text_preview: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "externalId": self.external_id,
+            "identifierName": self.identifier_name,
+            "identifierValue": self.identifier_value,
+            "label": self.label,
+            "labelName": self.label_name,
+            "rowIndex": self.row_index,
+            "textPreview": self.text_preview,
+        }
+
+
+class GraphQLClient:
+    def __init__(self, url: str, api_key: str):
+        self.url = url
+        self.api_key = api_key
+
+    def execute(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        response = requests.post(
+            self.url,
+            json={"query": query, "variables": variables or {}},
+            headers={"x-api-key": self.api_key},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("errors"):
+            raise RuntimeError(json.dumps(payload["errors"], indent=2))
+        return payload["data"]
+
+
+def stable_fixture_id(prefix: str, dataset_name: str, split: str, row_index: int) -> str:
+    digest = hashlib.sha256(f"{dataset_name}:{split}:{row_index}".encode("utf-8")).hexdigest()
+    return f"{prefix}-{digest[:16]}"
+
+
+def label_name_for(row: dict[str, Any], label_names: list[str] | tuple[str, ...]) -> str | None:
+    label = row.get("label")
+    if label is None:
+        return None
+    try:
+        return label_names[int(label)]
+    except (IndexError, TypeError, ValueError):
+        return str(label)
+
+
+def normalized_label(value: Any) -> int | str | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def resolve_label_names(dataset: Any, dataset_name: str) -> list[str] | tuple[str, ...]:
+    label_feature = getattr(dataset, "features", {}).get("label")
+    names = getattr(label_feature, "names", None)
+    if names:
+        return list(names)
+    if dataset_name == DEFAULT_DATASET:
+        return AG_NEWS_LABELS
+    return ()
+
+
+def load_rows(dataset_name: str, split: str, start: int, limit: int) -> tuple[Any, list[dict[str, Any]]]:
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "The Hugging Face 'datasets' package is required. "
+            "Install the full Plexus dependencies or run the scoring integration Compose profile."
+        ) from exc
+
+    dataset = load_dataset(dataset_name, split=f"{split}[{start}:{start + limit}]")
+    return dataset, [dict(row) for row in dataset]
+
+
+def create_item(client: GraphQLClient, input_doc: dict[str, Any]) -> dict[str, Any]:
+    return client.execute(
+        """
+        mutation SeedFixtureItem($input: CreateItemInput!) {
+            createItem(input: $input) {
+                id
+                accountId
+                scoreId
+                externalId
+                text
+                metadata
+                isEvaluation
+                createdByType
+                createdAt
+                updatedAt
+            }
+        }
+        """,
+        {"input": input_doc},
+    )["createItem"]
+
+
+def create_identifier(client: GraphQLClient, input_doc: dict[str, Any]) -> dict[str, Any]:
+    return client.execute(
+        """
+        mutation SeedFixtureIdentifier($input: CreateIdentifierInput!) {
+            createIdentifier(input: $input) {
+                itemId
+                name
+                value
+                accountId
+                position
+                createdAt
+                updatedAt
+            }
+        }
+        """,
+        {"input": input_doc},
+    )["createIdentifier"]
+
+
+def verify_fixture(client: GraphQLClient, fixture: SeededFixture, account_id: str) -> None:
+    item = client.execute(
+        """
+        query VerifyFixtureItem($id: ID!, $accountId: String!, $value: String!) {
+            getItem(id: $id) {
+                id
+                accountId
+                externalId
+                text
+                metadata
+            }
+            listIdentifierByAccountIdAndValue(
+                accountId: $accountId,
+                value: {eq: $value},
+                limit: 1
+            ) {
+                items {
+                    itemId
+                    name
+                    value
+                    accountId
+                }
+                nextToken
+            }
+        }
+        """,
+        {"id": fixture.id, "accountId": account_id, "value": fixture.identifier_value},
+    )
+    if not item.get("getItem"):
+        raise RuntimeError(f"Fixture item was not readable after seed: {fixture.id}")
+    identifiers = item["listIdentifierByAccountIdAndValue"]["items"]
+    if not identifiers or identifiers[0]["itemId"] != fixture.id:
+        raise RuntimeError(f"Fixture identifier was not readable after seed: {fixture.identifier_value}")
+
+
+def seed_fixtures(
+    *,
+    client: GraphQLClient,
+    account_id: str,
+    score_id: str | None,
+    dataset_name: str,
+    split: str,
+    start: int,
+    limit: int,
+    prefix: str,
+    identifier_name: str,
+    verify: bool,
+) -> list[SeededFixture]:
+    dataset, rows = load_rows(dataset_name, split, start, limit)
+    label_names = resolve_label_names(dataset, dataset_name)
+
+    seeded: list[SeededFixture] = []
+    for offset, row in enumerate(rows):
+        row_index = start + offset
+        text = row.get("text")
+        if not isinstance(text, str) or not text.strip():
+            continue
+
+        item_id = stable_fixture_id(prefix, dataset_name, split, row_index)
+        external_id = f"{item_id}-external"
+        identifier_value = f"{item_id}-identifier"
+        label = normalized_label(row.get("label"))
+        label_name = label_name_for({**row, "label": label}, label_names)
+        metadata = {
+            "source": "private-graphql-proxy-fixture",
+            "dataset": dataset_name,
+            "split": split,
+            "row_index": row_index,
+            "label": label,
+            "label_name": label_name,
+        }
+        item_input = {
+            "id": item_id,
+            "accountId": account_id,
+            "externalId": external_id,
+            "text": text,
+            "metadata": metadata,
+            "evaluationId": "prediction-default",
+            "isEvaluation": False,
+            "createdByType": "prediction",
+        }
+        if score_id:
+            item_input["scoreId"] = score_id
+
+        create_item(client, item_input)
+        create_identifier(
+            client,
+            {
+                "itemId": item_id,
+                "name": identifier_name,
+                "value": identifier_value,
+                "accountId": account_id,
+                "position": offset,
+            },
+        )
+
+        fixture = SeededFixture(
+            id=item_id,
+            external_id=external_id,
+            identifier_name=identifier_name,
+            identifier_value=identifier_value,
+            label=label,
+            label_name=label_name,
+            row_index=row_index,
+            text_preview=text[:120],
+        )
+        if verify:
+            verify_fixture(client, fixture, account_id)
+        seeded.append(fixture)
+
+    return seeded
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed Hugging Face text-classification rows as private proxy Items."
+    )
+    parser.add_argument("--proxy-url", default=os.getenv("PLEXUS_API_URL", "http://localhost:18080/graphql"))
+    parser.add_argument("--api-key", default=os.getenv("PLEXUS_API_KEY", "local-smoke-key"))
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--score-id")
+    parser.add_argument("--dataset", default=os.getenv("PLEXUS_PROXY_FIXTURE_DATASET", DEFAULT_DATASET))
+    parser.add_argument("--split", default=os.getenv("PLEXUS_PROXY_FIXTURE_SPLIT", DEFAULT_SPLIT))
+    parser.add_argument("--start", type=int, default=int(os.getenv("PLEXUS_PROXY_FIXTURE_START", "0")))
+    parser.add_argument("--limit", type=int, default=int(os.getenv("PLEXUS_PROXY_FIXTURE_LIMIT", "5")))
+    parser.add_argument("--prefix", default=os.getenv("PLEXUS_PROXY_FIXTURE_PREFIX", DEFAULT_PREFIX))
+    parser.add_argument("--identifier-name", default=DEFAULT_IDENTIFIER_NAME)
+    parser.add_argument("--no-verify", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    client = GraphQLClient(args.proxy_url, args.api_key)
+    fixtures = seed_fixtures(
+        client=client,
+        account_id=args.account_id,
+        score_id=args.score_id,
+        dataset_name=args.dataset,
+        split=args.split,
+        start=args.start,
+        limit=args.limit,
+        prefix=args.prefix,
+        identifier_name=args.identifier_name,
+        verify=not args.no_verify,
+    )
+    json.dump({"items": [fixture.as_dict() for fixture in fixtures]}, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/private-graphql-proxy/tests/test_scoring_integration.py
+++ b/services/private-graphql-proxy/tests/test_scoring_integration.py
@@ -259,9 +259,63 @@ def test_real_prediction_reads_seeded_postgres_items_through_proxy():
     predictions = parse_prediction_json(predict_result.stdout)
     assert len(predictions) == len(seeded_items)
     assert {result["item_id"] for result in predictions} == {item["id"] for item in seeded_items}
+    predictions_by_item = {result["item_id"]: result for result in predictions}
     for result in predictions:
         assert result["scores"], result
         assert result["scores"][0]["name"] == score
+        assert result["scores"][0]["score_result_id"], result
+
+    for item in seeded_items:
+        result = predictions_by_item[item["id"]]
+        score_data = result["scores"][0]
+        score_result_check = execute(
+            """
+            query VerifyPredictionScoreResult($scoreResultId: ID!, $itemId: String!) {
+                getScoreResult(id: $scoreResultId) {
+                    id
+                    itemId
+                    accountId
+                    scorecardId
+                    scoreId
+                    scoreVersionId
+                    value
+                    explanation
+                    type
+                    status
+                    code
+                }
+                listScoreResultByItemId(itemId: $itemId, limit: 10) {
+                    items {
+                        id
+                        itemId
+                        scoreId
+                        value
+                        type
+                        status
+                    }
+                    nextToken
+                }
+            }
+            """,
+            {
+                "scoreResultId": score_data["score_result_id"],
+                "itemId": item["id"],
+            },
+        )
+        persisted = score_result_check["data"]["getScoreResult"]
+        assert persisted["id"] == score_data["score_result_id"]
+        assert persisted["itemId"] == item["id"]
+        assert persisted["accountId"] == account_id
+        assert persisted["value"] == str(score_data["value"])
+        assert persisted["type"] == "prediction"
+        assert persisted["status"] == "COMPLETED"
+        by_item_ids = {
+            row["id"]
+            for row in score_result_check["data"]["listScoreResultByItemId"]["items"]
+        }
+        assert score_data["score_result_id"] in by_item_ids
+        assert "getScoreResult" in score_result_check["extensions"]["proxy"]["private"]
+        assert "listScoreResultByItemId" in score_result_check["extensions"]["proxy"]["private"]
 
     debug_response = requests.get(
         f"{proxy_base_url()}/debug/upstream-requests",

--- a/services/private-graphql-proxy/tests/test_scoring_integration.py
+++ b/services/private-graphql-proxy/tests/test_scoring_integration.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import pytest
+import requests
+
+
+pytestmark = pytest.mark.integration
+
+
+PRIVATE_ROOT_PREFIXES = (
+    "getItem",
+    "listItem",
+    "createItem",
+    "updateItem",
+    "deleteItem",
+    "getIdentifier",
+    "listIdentifier",
+    "createIdentifier",
+    "updateIdentifier",
+    "deleteIdentifier",
+    "getScoreResult",
+    "listScoreResult",
+    "createScoreResult",
+    "updateScoreResult",
+    "deleteScoreResult",
+    "getFeedbackItem",
+    "listFeedbackItem",
+    "createFeedbackItem",
+    "updateFeedbackItem",
+    "deleteFeedbackItem",
+)
+
+
+def proxy_url() -> str:
+    return os.getenv("PLEXUS_API_URL", "http://localhost:18080/graphql")
+
+
+def proxy_api_key() -> str:
+    return os.getenv("PLEXUS_API_KEY", "local-smoke-key")
+
+
+def proxy_base_url() -> str:
+    parsed = urlparse(proxy_url())
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def proxy_headers() -> dict[str, str]:
+    return {"x-api-key": proxy_api_key()}
+
+
+def execute(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+    response = requests.post(
+        proxy_url(),
+        json={"query": query, "variables": variables or {}},
+        headers=proxy_headers(),
+        timeout=60,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    assert "errors" not in payload, payload
+    return payload
+
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        pytest.skip(f"missing {name}")
+    return value
+
+
+def resolve_account_id(account_key: str) -> str:
+    payload = execute(
+        """
+        query ResolveAccount($key: String!) {
+            listAccountByKey(key: $key) {
+                items {
+                    id
+                    key
+                    name
+                }
+                nextToken
+            }
+        }
+        """,
+        {"key": account_key},
+    )
+    items = payload["data"]["listAccountByKey"]["items"]
+    assert items, f"no account found for PLEXUS_ACCOUNT_KEY={account_key}"
+    return items[0]["id"]
+
+
+def run_json_command(command: list[str], env: dict[str, str]) -> dict[str, Any]:
+    result = subprocess.run(
+        command,
+        env=env,
+        cwd=Path(__file__).resolve().parents[3],
+        text=True,
+        capture_output=True,
+        timeout=int(os.getenv("PLEXUS_PROXY_SCORING_TIMEOUT_SECONDS", "300")),
+    )
+    assert result.returncode == 0, (
+        "command failed\n"
+        f"command: {' '.join(command)}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def parse_prediction_json(stdout: str) -> list[dict[str, Any]]:
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(stdout):
+        if char != "[":
+            continue
+        try:
+            parsed, end = decoder.raw_decode(stdout[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, list) and not stdout[index + end :].strip():
+            return parsed
+    raise AssertionError(f"could not find JSON prediction array in stdout:\n{stdout}")
+
+
+def test_real_prediction_reads_seeded_postgres_items_through_proxy():
+    account_key = required_env("PLEXUS_ACCOUNT_KEY")
+    scorecard = required_env("PLEXUS_PROXY_SCORING_SCORECARD")
+    score = required_env("PLEXUS_PROXY_SCORING_SCORE")
+    fixture_limit = int(os.getenv("PLEXUS_PROXY_SCORING_FIXTURE_LIMIT", "3"))
+    fixture_dataset = os.getenv("PLEXUS_PROXY_SCORING_DATASET", "fancyzhx/ag_news")
+    fixture_split = os.getenv("PLEXUS_PROXY_SCORING_SPLIT", "test")
+    fixture_start = int(os.getenv("PLEXUS_PROXY_SCORING_START", "0"))
+
+    account_id = os.getenv("PLEXUS_PROXY_SCORING_ACCOUNT_ID") or resolve_account_id(account_key)
+    score_id = os.getenv("PLEXUS_PROXY_SCORING_SCORE_ID")
+    repo_root = Path(__file__).resolve().parents[3]
+
+    common_env = os.environ.copy()
+    common_env["PYTHONPATH"] = f"{repo_root}:{repo_root / 'services/private-graphql-proxy'}"
+    common_env["PLEXUS_API_URL"] = proxy_url()
+    common_env["PLEXUS_API_KEY"] = proxy_api_key()
+    common_env["PLEXUS_ACCOUNT_KEY"] = account_key
+    common_env.pop("NEXT_PUBLIC_PLEXUS_API_URL", None)
+    common_env.pop("NEXT_PUBLIC_PLEXUS_API_KEY", None)
+
+    seed_output = run_json_command(
+        [
+            sys.executable,
+            str(repo_root / "services/private-graphql-proxy/scripts/seed_huggingface_items.py"),
+            "--proxy-url",
+            proxy_url(),
+            "--api-key",
+            proxy_api_key(),
+            "--account-id",
+            account_id,
+            "--dataset",
+            fixture_dataset,
+            "--split",
+            fixture_split,
+            "--start",
+            str(fixture_start),
+            "--limit",
+            str(fixture_limit),
+            "--prefix",
+            os.getenv("PLEXUS_PROXY_SCORING_FIXTURE_PREFIX", "proxy-scoring-ag-news"),
+            *(["--score-id", score_id] if score_id else []),
+        ],
+        common_env,
+    )
+    seeded_items = seed_output["items"]
+    assert len(seeded_items) == fixture_limit
+
+    first_identifier = seeded_items[0]["identifierValue"]
+    verification = execute(
+        """
+        query VerifySeededPrivateRows($itemId: ID!, $accountId: String!, $identifierValue: String!) {
+            getItem(id: $itemId) {
+                id
+                accountId
+                text
+                metadata
+            }
+            listIdentifierByAccountIdAndValue(
+                accountId: $accountId,
+                value: {eq: $identifierValue},
+                limit: 1
+            ) {
+                items {
+                    itemId
+                    name
+                    value
+                    accountId
+                }
+                nextToken
+            }
+            listItemByAccountIdAndUpdatedAt(
+                accountId: $accountId,
+                sortDirection: DESC,
+                limit: 10
+            ) {
+                items {
+                    id
+                    accountId
+                    externalId
+                }
+                nextToken
+            }
+        }
+        """,
+        {
+            "itemId": seeded_items[0]["id"],
+            "accountId": account_id,
+            "identifierValue": first_identifier,
+        },
+    )
+    assert verification["data"]["getItem"]["id"] == seeded_items[0]["id"]
+    assert verification["data"]["listIdentifierByAccountIdAndValue"]["items"][0]["itemId"] == seeded_items[0]["id"]
+    assert "getItem" in verification["extensions"]["proxy"]["private"]
+    assert "listIdentifierByAccountIdAndValue" in verification["extensions"]["proxy"]["private"]
+    assert "listItemByAccountIdAndUpdatedAt" in verification["extensions"]["proxy"]["private"]
+
+    with tempfile.TemporaryDirectory(prefix="plexus-proxy-scorecards-") as cache_dir:
+        predict_env = common_env.copy()
+        predict_env["SCORECARD_CACHE_DIR"] = cache_dir
+        predict_result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "plexus",
+                "predict",
+                "--scorecard",
+                scorecard,
+                "--score",
+                score,
+                "--items",
+                ",".join(item["identifierValue"] for item in seeded_items),
+                "--format",
+                "json",
+            ],
+            cwd=repo_root,
+            env=predict_env,
+            text=True,
+            capture_output=True,
+            timeout=int(os.getenv("PLEXUS_PROXY_SCORING_TIMEOUT_SECONDS", "300")),
+        )
+    assert predict_result.returncode == 0, (
+        "plexus predict failed\n"
+        f"stdout:\n{predict_result.stdout}\n"
+        f"stderr:\n{predict_result.stderr}"
+    )
+    predictions = parse_prediction_json(predict_result.stdout)
+    assert len(predictions) == len(seeded_items)
+    assert {result["item_id"] for result in predictions} == {item["id"] for item in seeded_items}
+    for result in predictions:
+        assert result["scores"], result
+        assert result["scores"][0]["name"] == score
+
+    debug_response = requests.get(
+        f"{proxy_base_url()}/debug/upstream-requests",
+        timeout=30,
+    )
+    debug_response.raise_for_status()
+    upstream_requests = debug_response.json()
+    assert upstream_requests, "expected at least one forwarded control-plane read"
+    for request in upstream_requests:
+        forwarded_roots = request["root_fields"]
+        assert forwarded_roots
+        for root in forwarded_roots:
+            assert not root.startswith(PRIVATE_ROOT_PREFIXES), request


### PR DESCRIPTION
## Summary

Adds the private GraphQL proxy prototype under `services/private-graphql-proxy` and wires the first scoring integration around the real `plexus predict` command.

The proxy keeps private `Item`, `Identifier`, `ScoreResult`, and `FeedbackItem` operations in local PostgreSQL while forwarding only allowlisted control-plane reads to AppSync with PostgreSQL-backed caching.

## What changed

- Added the containerized private GraphQL proxy service with PostgreSQL private storage and control-plane response caching.
- Added AG News fixture seeding through the proxy for local `Item` and `Identifier` rows.
- Added a full Docker Compose scoring integration profile that runs the normal Plexus Python CLI against the proxy via `PLEXUS_API_URL`.
- Updated `plexus predict` to persist successful predictions as `ScoreResult` records through the configured GraphQL client.
- Tightened the scoring integration test so it fails unless `plexus predict` creates and can read back local PostgreSQL `ScoreResult` rows.
- Recorded Kanbus work in `plx-295044`, `plx-4308cc`, and `plx-440ee6`.

## Verification

- `PYTHONPATH=$PWD:$PWD/services/private-graphql-proxy /tmp/plexus-private-graphql-proxy-venv/bin/python -m pytest services/private-graphql-proxy/tests/test_app_routing.py services/private-graphql-proxy/tests/test_smoke_proxy.py -q`
- `docker run --rm -v /Users/ryan/Projects/Plexus-private-graphql-proxy-prototype:/workspace -w /workspace private-graphql-proxy-scoring-integration pytest -o addopts='' plexus/cli/prediction/predictions_test.py::TestPredictImpl -q`
- `docker compose -f services/private-graphql-proxy/docker-compose.smoke.yml --profile scoring-integration up --build --abort-on-container-exit --exit-code-from scoring-integration scoring-integration`

Real scoring smoke used `suco_home_improvement / blind_transfer_ai` with one AG News fixture item. It predicted `Yes`, created local `ScoreResult` `5ec666bd-6a48-40e3-a0a7-bebb0e037e53`, and proxy diagnostics showed 8 upstream control-plane reads with 0 private roots forwarded.

## Notes

- No production private table writes are performed by the smoke test. Production AppSync is used for read-only control-plane data.
- The integration test requires real upstream credentials and model provider credentials in the local environment; it skips/fails accordingly outside that configured smoke environment.
