### PR TITLE
Harden dispatch canary diagnostics and local-mode report checks

### DIFF
--- a/scripts/preprod_dispatch_canaries.py
+++ b/scripts/preprod_dispatch_canaries.py
@@ -221,16 +221,34 @@ def _process_is_running(pid: int) -> bool:
 def _wait_task(client: Any, task_id: str, timeout_seconds: int, poll_seconds: float) -> Any:
     from plexus.dashboard.api.models.task import Task
 
-    def poll() -> Any:
+    deadline = time.time() + timeout_seconds
+    last_snapshot: dict[str, Any] = {"id": task_id, "state": "not_observed"}
+
+    while time.time() < deadline:
         task = Task.get_by_id(task_id, client)
         status = str(getattr(task, "status", "") or "").upper()
+        dispatch_status = str(getattr(task, "dispatchStatus", "") or "").upper()
+        last_snapshot = {
+            "id": task_id,
+            "status": status or None,
+            "dispatchStatus": dispatch_status or None,
+            "updatedAt": getattr(task, "updatedAt", None),
+            "errorMessage": getattr(task, "errorMessage", None),
+            "workerNodeId": getattr(task, "workerNodeId", None),
+            "target": getattr(task, "target", None),
+            "type": getattr(task, "type", None),
+        }
         if status in TERMINAL_BAD:
             raise RuntimeError(
-                f"Task {task_id} failed: {getattr(task, 'errorMessage', None)}"
+                f"Task {task_id} failed. Last state: {_json(last_snapshot)}"
             )
-        return task if status in TERMINAL_OK else None
+        if status in TERMINAL_OK:
+            return task
+        time.sleep(poll_seconds)
 
-    return _wait_until(f"task {task_id}", timeout_seconds, poll_seconds, poll)
+    raise RuntimeError(
+        f"Timed out waiting for task {task_id}. Last state: {_json(last_snapshot)}"
+    )
 
 
 def _create_report_block_task(cache_key: str) -> dict[str, Any]:

--- a/scripts/report_dispatch_canary.py
+++ b/scripts/report_dispatch_canary.py
@@ -46,11 +46,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--poll-interval-seconds", type=float, default=5.0)
     parser.add_argument("--timeout-seconds", type=int, default=300)
     parser.add_argument("--child-budget-usd", type=float, default=0.20)
-    parser.add_argument("--child-budget-seconds", type=int, default=60)
+    parser.add_argument("--child-budget-seconds", type=int, default=180)
     parser.add_argument("--child-budget-depth", type=int, default=1)
     parser.add_argument("--child-budget-tool-calls", type=int, default=3)
     parser.add_argument("--parent-budget-usd", type=float, default=0.25)
-    parser.add_argument("--parent-budget-seconds", type=int, default=90)
+    parser.add_argument("--parent-budget-seconds", type=int, default=240)
     parser.add_argument("--parent-budget-depth", type=int, default=3)
     parser.add_argument("--parent-budget-tool-calls", type=int, default=50)
     return parser.parse_args()
@@ -126,6 +126,16 @@ def _safe_get(dct: Any, *keys: str) -> Any:
     return cur
 
 
+def _process_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
 async def _run_canary(args: argparse.Namespace) -> dict[str, Any]:
     # Keep process-level explicit env authoritative for dispatch behavior.
     dotenv_spec = importlib.util.find_spec("dotenv")
@@ -169,6 +179,18 @@ async def _run_canary(args: argparse.Namespace) -> dict[str, Any]:
             tool_calls=int(args.parent_budget_tool_calls),
         )
     )
+    if child_budget["wallclock_seconds"] > float(args.parent_budget_seconds):
+        raise CanaryError(
+            (
+                "Invalid canary budget: child wallclock_seconds exceeds parent wallclock budget "
+                f"({child_budget['wallclock_seconds']} > {args.parent_budget_seconds})."
+            ),
+            {
+                "dispatch_mode": args.dispatch_mode,
+                "child_budget": child_budget,
+                "parent_budget_seconds": args.parent_budget_seconds,
+            },
+        )
 
     run_id = str(uuid.uuid4())[:8]
     cache_key = (
@@ -210,12 +232,11 @@ async def _run_canary(args: argparse.Namespace) -> dict[str, Any]:
             diagnostics,
         )
 
-    task_id = _safe_get(status_result, "value", "dispatch_result", "task_id")
-    diagnostics["task_id"] = task_id
-    if not task_id:
+    dispatch_result = _safe_get(status_result, "value", "dispatch_result")
+    if not isinstance(dispatch_result, dict):
         raise CanaryError(
             (
-                "handle_status did not include dispatched task id. "
+                "handle_status did not include dispatch_result. "
                 f"status={json.dumps(status_result, default=str)}"
             ),
             diagnostics,
@@ -229,12 +250,87 @@ async def _run_canary(args: argparse.Namespace) -> dict[str, Any]:
     account_id = client._resolve_account_id()
 
     deadline = time.time() + args.timeout_seconds
+    report_id: Optional[str] = None
+    report_block_count = 0
+
+    if args.dispatch_mode == "local":
+        local_pid = dispatch_result.get("pid")
+        diagnostics["pid"] = local_pid
+        if not local_pid:
+            raise CanaryError(
+                (
+                    "Local dispatch did not return subprocess pid. "
+                    f"status={json.dumps(status_result, default=str)}"
+                ),
+                diagnostics,
+            )
+
+        while time.time() < deadline:
+            reports = Report.list_by_account_id(account_id, client, limit=50, max_items=250)
+            matched_report = None
+            for rep in reports:
+                params = rep.parameters if isinstance(rep.parameters, dict) else {}
+                if params.get("_cache_key") == cache_key:
+                    matched_report = rep
+                    break
+
+            if matched_report:
+                report_id = matched_report.id
+                blocks = ReportBlock.list_by_report_id(matched_report.id, client, limit=20, max_items=50)
+                report_block_count = len(blocks)
+                diagnostics.update({
+                    "report_id": report_id,
+                    "report_block_count": report_block_count,
+                })
+                if report_block_count > 0:
+                    return {
+                        "status": "ok",
+                        "dispatch_mode": args.dispatch_mode,
+                        "trace_id": trace_id,
+                        "handle_id": handle_id,
+                        "pid": local_pid,
+                        "report_id": report_id,
+                        "report_block_count": report_block_count,
+                        "cache_key": cache_key,
+                    }
+
+            if not _process_is_running(int(local_pid)):
+                latest_status = await _execute_tactus_tool(
+                    f'return handle_status{{ id = "{handle_id}" }}', mcp
+                )
+                diagnostics["latest_handle_status"] = latest_status
+                raise CanaryError(
+                    (
+                        "Local subprocess exited before report persistence. "
+                        f"pid={local_pid} trace_id={trace_id} handle_id={handle_id}"
+                    ),
+                    diagnostics,
+                )
+
+            await asyncio.sleep(args.poll_interval_seconds)
+
+        raise CanaryError(
+            (
+                "Timed out waiting for local report dispatch canary completion. "
+                f"trace_id={trace_id} handle_id={handle_id} pid={local_pid} report_id={report_id}"
+            ),
+            diagnostics,
+        )
+
+    task_id = dispatch_result.get("task_id")
+    diagnostics["task_id"] = task_id
+    if not task_id:
+        raise CanaryError(
+            (
+                "Remote dispatch did not include task_id. "
+                f"status={json.dumps(status_result, default=str)}"
+            ),
+            diagnostics,
+        )
     seen_pending = False
     seen_dispatched = False
     final_task_status: Optional[str] = None
     final_dispatch_status: Optional[str] = None
-    report_id: Optional[str] = None
-    report_block_count = 0
 
     while time.time() < deadline:
         task = Task.get_by_id(task_id, client)


### PR DESCRIPTION
## Summary
- improve scripts/preprod_dispatch_canaries.py timeout/failure diagnostics with last observed Task state
- fix scripts/report_dispatch_canary.py to support --dispatch-mode local (pid-based validation + report persistence)
- tune canary default budgets and add guard for invalid child>parent wallclock budget

## Why
Remote staging runs are currently stalling in PENDING/PENDING; this improves defect triage signal and ensures local-mode coverage is accurate.

## Validation
- python -m pytest MCP/tools/tactus_runtime/execute_test.py -k "dispatch_mode or report_runner or invalid" -q
- python -m pytest dashboard/amplify/functions/taskDispatcher/index_test.py -q
- python -m pytest plexus/cli/shared/command_dispatch_test.py -q
- python -m pytest plexus/cli/report/utils_test.py -q
- scripts/preprod_dispatch_canaries.py local scenarios
- scripts/report_dispatch_canary.py --dispatch-mode local
