### PR TITLE
Fix TaskDispatcher DynamoDB stream mapping

### DIFF
--- a/dashboard/amplify/backend.ts
+++ b/dashboard/amplify/backend.ts
@@ -46,11 +46,12 @@ if (getResourceByShareTokenFunction) {
 // Enable streams on tables for metrics aggregation
 const taskTable = backend.data.resources.tables.Task;
 const taskCfnTable = taskTable.node.defaultChild as dynamodb.CfnTable;
-if (taskCfnTable) {
-    taskCfnTable.streamSpecification = {
-        streamViewType: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES
-    };
+if (!taskCfnTable) {
+    throw new Error('TaskDispatcher requires access to the Task table CloudFormation resource.');
 }
+taskCfnTable.streamSpecification = {
+    streamViewType: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES
+};
 
 const itemTable = backend.data.resources.tables.Item;
 const itemCfnTable = itemTable.node.defaultChild as dynamodb.CfnTable;
@@ -130,6 +131,7 @@ const taskDispatcherStack = new TaskDispatcherStack(
     'TaskDispatcher',
     {
         taskTable,
+        taskTableStreamArn: taskCfnTable.attrStreamArn,
         celeryAwsAccessKeyId: requireTaskDispatcherEnv('CELERY_AWS_ACCESS_KEY_ID'),
         celeryAwsSecretAccessKey: requireTaskDispatcherEnv('CELERY_AWS_SECRET_ACCESS_KEY'),
         celeryAwsRegion: requireTaskDispatcherEnv('CELERY_AWS_REGION_NAME'),

--- a/dashboard/amplify/functions/taskDispatcher/resource.ts
+++ b/dashboard/amplify/functions/taskDispatcher/resource.ts
@@ -4,17 +4,14 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { cpSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import * as path from 'path';
-import { createRequire } from 'module';
 import { execFileSync } from 'child_process';
-import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-import { DynamoEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
-import { StartingPosition } from 'aws-cdk-lib/aws-lambda';
 import { Policy, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { ITable } from 'aws-cdk-lib/aws-dynamodb';
 
 // Interface for TaskDispatcher stack props
 interface TaskDispatcherStackProps extends StackProps {
   taskTable: ITable;
+  taskTableStreamArn: string;
   celeryAwsAccessKeyId?: string;
   celeryAwsSecretAccessKey?: string;
   celeryAwsRegion?: string;
@@ -172,16 +169,14 @@ export class TaskDispatcherStack extends Stack {
     // Attach the policy to the Lambda function
     this.taskDispatcherFunction.role?.attachInlinePolicy(policy);
 
-    // Create event source mapping
-    const eventSource = new DynamoEventSource(props.taskTable, {
-      startingPosition: StartingPosition.LATEST,
+    new lambda.CfnEventSourceMapping(this, 'TaskDispatcherEventSourceMapping', {
+      functionName: this.taskDispatcherFunction.functionName,
+      eventSourceArn: props.taskTableStreamArn,
+      startingPosition: 'LATEST',
       batchSize: 1,
-      retryAttempts: 3,
-      enabled: true
+      maximumRetryAttempts: 3,
+      enabled: true,
     });
-
-    // Add the event source to the Lambda function
-    this.taskDispatcherFunction.addEventSource(eventSource);
 
     new CfnOutput(this, 'TaskDispatcherFunctionArn', {
       value: this.taskDispatcherFunction.functionArn,


### PR DESCRIPTION
## Summary
- Wire TaskDispatcher Lambda event source mapping directly to the generated Task table stream ARN.
- Fail deployment if the Task table CloudFormation resource cannot be resolved.
- Keep the dispatch path as DynamoDB Task stream -> TaskDispatcher Lambda -> Celery `plexus.execute_command`.

## Why
Production Task rows were created but remained `status=PENDING` and `dispatchStatus=PENDING`, while the Celery command worker was healthy. That points to the Task stream dispatcher not receiving/claiming Task inserts.

## Verification
- `/Users/ryan/miniconda3/bin/python -m pytest dashboard/amplify/functions/taskDispatcher/index_test.py -q`
- `npm run typecheck -- --pretty false`

## Production validation after deploy
- Rerun `scripts/report_dispatch_canary.py --dispatch-mode celery`.
- Rerun `scripts/preprod_dispatch_canaries.py remote-evaluation-task`.
- Confirm fresh tasks move out of `PENDING/PENDING` and TaskDispatcher logs include successful Celery task IDs.
