### PR TITLE
Fix Amplify Task table stream lookup

### DIFF
--- a/dashboard/amplify/backend.ts
+++ b/dashboard/amplify/backend.ts
@@ -45,13 +45,16 @@ if (getResourceByShareTokenFunction) {
 
 // Enable streams on tables for metrics aggregation
 const taskTable = backend.data.resources.tables.Task;
-const taskCfnTable = taskTable.node.defaultChild as dynamodb.CfnTable;
-if (!taskCfnTable) {
-    throw new Error('TaskDispatcher requires access to the Task table CloudFormation resource.');
+const taskAmplifyTable = amplifyDynamoDbTables.Task;
+if (!taskAmplifyTable) {
+    throw new Error('TaskDispatcher requires access to the generated Task table resource.');
 }
-taskCfnTable.streamSpecification = {
+taskAmplifyTable.streamSpecification = {
     streamViewType: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES
 };
+if (!taskTable.tableStreamArn) {
+    throw new Error('TaskDispatcher requires the Task table stream ARN.');
+}
 
 const itemTable = backend.data.resources.tables.Item;
 const itemCfnTable = itemTable.node.defaultChild as dynamodb.CfnTable;
@@ -131,7 +134,7 @@ const taskDispatcherStack = new TaskDispatcherStack(
     'TaskDispatcher',
     {
         taskTable,
-        taskTableStreamArn: taskCfnTable.attrStreamArn,
+        taskTableStreamArn: taskTable.tableStreamArn,
         celeryAwsAccessKeyId: requireTaskDispatcherEnv('CELERY_AWS_ACCESS_KEY_ID'),
         celeryAwsSecretAccessKey: requireTaskDispatcherEnv('CELERY_AWS_SECRET_ACCESS_KEY'),
         celeryAwsRegion: requireTaskDispatcherEnv('CELERY_AWS_REGION_NAME'),


### PR DESCRIPTION
## Summary
Fixes the CDK assembly error from the production deployment of the TaskDispatcher stream mapping change.

## What changed
- Stop assuming `backend.data.resources.tables.Task.node.defaultChild` is the DynamoDB `CfnTable`.
- Use Amplify's generated `amplifyDynamoDbTables.Task` wrapper to enable the Task table stream.
- Pass `taskTable.tableStreamArn` into the TaskDispatcher event source mapping.

## Why
The previous production deployment failed during CDK assembly with:

```text
TaskDispatcher requires access to the Task table CloudFormation resource.
```

Amplify exposes generated table overrides through `backend.data.resources.cfnResources.amplifyDynamoDbTables`; `node.defaultChild` is not reliable for these generated table resources in production synth.

## Verification
- `/Users/ryan/miniconda3/bin/python -m pytest dashboard/amplify/functions/taskDispatcher/index_test.py -q`
- `npm run typecheck -- --pretty false`

## Production validation after deployment
Rerun the dispatch canaries and confirm fresh report/evaluation tasks move out of `PENDING/PENDING` and are consumed by the production command worker.
