### PR TITLE
Fix Console worker image publish for execute_tactus runtime

### DIFF
--- a/dashboard/amplify/functions/consoleRunWorker/Dockerfile
+++ b/dashboard/amplify/functions/consoleRunWorker/Dockerfile
@@ -10,11 +10,11 @@ WORKDIR /var/task
 # Copy repository so the worker can import Plexus source directly.
 COPY . /workspace
 
-# The Console agent's model-facing dispatcher imports the repo's MCP tool modules
-# in-process. Fail the image build if those modules are missing from the context.
-RUN test -f /workspace/MCP/tools/scorecard/scorecards.py && \
-    test -f /workspace/MCP/tools/evaluation/evaluations.py && \
-    test -f /workspace/MCP/tools/chat/chats.py
+# The Console agent's model-facing runtime depends on MCP execute_tactus modules.
+# Fail the image build if those modules are missing from the context.
+RUN test -f /workspace/MCP/tools/tactus_runtime/execute.py && \
+    test -f /workspace/MCP/tools/tactus_runtime/_item_helpers.py && \
+    test -f /workspace/MCP/server.py
 
 # Required for git-based dependencies (for example openai-cost-calculator).
 RUN apt-get update && apt-get install -y --no-install-recommends git && \

--- a/dashboard/amplify/functions/consoleRunWorker/test_docker_context.py
+++ b/dashboard/amplify/functions/consoleRunWorker/test_docker_context.py
@@ -20,5 +20,6 @@ def test_console_worker_dockerfile_verifies_mcp_tool_modules():
     ).read_text()
 
     assert "PYTHONPATH=/workspace:/workspace/MCP" in dockerfile
-    assert "test -f /workspace/MCP/tools/scorecard/scorecards.py" in dockerfile
-    assert "test -f /workspace/MCP/tools/evaluation/evaluations.py" in dockerfile
+    assert "test -f /workspace/MCP/tools/tactus_runtime/execute.py" in dockerfile
+    assert "test -f /workspace/MCP/tools/tactus_runtime/_item_helpers.py" in dockerfile
+    assert "test -f /workspace/MCP/server.py" in dockerfile

--- a/project/events/2026-05-06T17:43:38.270Z__7691e4d5-2379-4c6e-b162-8267a11ae6e4.json
+++ b/project/events/2026-05-06T17:43:38.270Z__7691e4d5-2379-4c6e-b162-8267a11ae6e4.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "7691e4d5-2379-4c6e-b162-8267a11ae6e4",
+  "issue_id": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T17:43:38.270Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "CI publish job fails on main before updating CONSOLE_WORKER_IMAGE_URI because Dockerfile guard checks deleted MCP module paths. Update guard to validate current MCP runtime files and verify the publish workflow can complete branch env var update.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-b7030f92-0508-4982-a1f3-3c67781a8a72",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix Console Worker CI image publish failure on main"
+  }
+}

--- a/project/events/2026-05-06T17:43:41.946Z__9890f08c-89ab-4880-9d47-272ea913dacb.json
+++ b/project/events/2026-05-06T17:43:41.946Z__9890f08c-89ab-4880-9d47-272ea913dacb.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "9890f08c-89ab-4880-9d47-272ea913dacb",
+  "issue_id": "plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T17:43:41.946Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Document failing main run, failing step, and exact Dockerfile path check mismatch.",
+    "issue_type": "sub-task",
+    "labels": [],
+    "parent": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+    "priority": 1,
+    "status": "open",
+    "title": "Capture failing CI evidence and root cause"
+  }
+}

--- a/project/events/2026-05-06T17:43:41.976Z__c271edf4-3a2b-4ab1-8ea1-40169ce9a3c2.json
+++ b/project/events/2026-05-06T17:43:41.976Z__c271edf4-3a2b-4ab1-8ea1-40169ce9a3c2.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c271edf4-3a2b-4ab1-8ea1-40169ce9a3c2",
+  "issue_id": "plx-d75e54fb-4073-4f99-97e9-de694dc76af0",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T17:43:41.976Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Replace stale MCP path checks with current runtime module checks and run local docker build verification.",
+    "issue_type": "sub-task",
+    "labels": [],
+    "parent": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+    "priority": 1,
+    "status": "open",
+    "title": "Patch console worker Dockerfile guard and validate locally"
+  }
+}

--- a/project/events/2026-05-06T17:43:44.350Z__86414f83-3c59-4b32-842b-0e128fafe87a.json
+++ b/project/events/2026-05-06T17:43:44.350Z__86414f83-3c59-4b32-842b-0e128fafe87a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "86414f83-3c59-4b32-842b-0e128fafe87a",
+  "issue_id": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T17:43:44.350Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T17:43:44.366Z__d7101375-e69c-4f4e-a8ff-4bc92c715c1c.json
+++ b/project/events/2026-05-06T17:43:44.366Z__d7101375-e69c-4f4e-a8ff-4bc92c715c1c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d7101375-e69c-4f4e-a8ff-4bc92c715c1c",
+  "issue_id": "plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T17:43:44.366Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T17:43:44.379Z__c107a8fd-795c-40c5-a5bb-ebccbcd5b9d1.json
+++ b/project/events/2026-05-06T17:43:44.379Z__c107a8fd-795c-40c5-a5bb-ebccbcd5b9d1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c107a8fd-795c-40c5-a5bb-ebccbcd5b9d1",
+  "issue_id": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T17:43:44.379Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "9c030269-00b1-4ab6-8ac6-97dcbf64378b"
+  }
+}

--- a/project/events/2026-05-06T17:43:44.392Z__a4e6495f-6ae2-4478-bf98-bca4a0892494.json
+++ b/project/events/2026-05-06T17:43:44.392Z__a4e6495f-6ae2-4478-bf98-bca4a0892494.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a4e6495f-6ae2-4478-bf98-bca4a0892494",
+  "issue_id": "plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T17:43:44.392Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "2548b2d4-999d-4dd8-afb9-c03fb201f5bd"
+  }
+}

--- a/project/events/2026-05-06T17:51:12.473Z__b5eae368-5ffb-4400-9c9d-23d00220ddab.json
+++ b/project/events/2026-05-06T17:51:12.473Z__b5eae368-5ffb-4400-9c9d-23d00220ddab.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b5eae368-5ffb-4400-9c9d-23d00220ddab",
+  "issue_id": "plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T17:51:12.473Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "7b14806b-d9c1-46bd-a247-642e34f39653"
+  }
+}

--- a/project/events/2026-05-06T17:51:16.747Z__2c32cf0f-8ae9-4c80-8782-8cbe31ee5ca2.json
+++ b/project/events/2026-05-06T17:51:16.747Z__2c32cf0f-8ae9-4c80-8782-8cbe31ee5ca2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2c32cf0f-8ae9-4c80-8782-8cbe31ee5ca2",
+  "issue_id": "plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T17:51:16.747Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "d9e50abb-264f-45a4-9258-9d3958873d54"
+  }
+}

--- a/project/events/2026-05-06T17:51:16.770Z__0434acf6-d292-430d-bc0c-77c9208bb1b0.json
+++ b/project/events/2026-05-06T17:51:16.770Z__0434acf6-d292-430d-bc0c-77c9208bb1b0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0434acf6-d292-430d-bc0c-77c9208bb1b0",
+  "issue_id": "plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T17:51:16.770Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-06T17:51:16.787Z__8bd33b35-e07d-452a-8b22-b095f931bbd1.json
+++ b/project/events/2026-05-06T17:51:16.787Z__8bd33b35-e07d-452a-8b22-b095f931bbd1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8bd33b35-e07d-452a-8b22-b095f931bbd1",
+  "issue_id": "plx-d75e54fb-4073-4f99-97e9-de694dc76af0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T17:51:16.787Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T17:51:16.803Z__275b8cf0-c248-4c26-a7fc-fd326e9e5ed9.json
+++ b/project/events/2026-05-06T17:51:16.803Z__275b8cf0-c248-4c26-a7fc-fd326e9e5ed9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "275b8cf0-c248-4c26-a7fc-fd326e9e5ed9",
+  "issue_id": "plx-d75e54fb-4073-4f99-97e9-de694dc76af0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T17:51:16.803Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "bc81707b-4fed-4304-8b38-2464fc0d2031"
+  }
+}

--- a/project/events/2026-05-06T17:51:16.830Z__60c6dc9a-b14c-420d-b26b-c4a92d301823.json
+++ b/project/events/2026-05-06T17:51:16.830Z__60c6dc9a-b14c-420d-b26b-c4a92d301823.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "60c6dc9a-b14c-420d-b26b-c4a92d301823",
+  "issue_id": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T17:51:16.830Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "79cd2a47-6d5a-4cb2-a606-dfdde56ba4c2"
+  }
+}

--- a/project/events/2026-05-06T17:51:20.965Z__7d78a9c6-b235-4740-a276-798b398db375.json
+++ b/project/events/2026-05-06T17:51:20.965Z__7d78a9c6-b235-4740-a276-798b398db375.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7d78a9c6-b235-4740-a276-798b398db375",
+  "issue_id": "plx-d75e54fb-4073-4f99-97e9-de694dc76af0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T17:51:20.965Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-06T17:51:20.983Z__02b0c229-b3f0-4b9e-ba04-84722991f6bf.json
+++ b/project/events/2026-05-06T17:51:20.983Z__02b0c229-b3f0-4b9e-ba04-84722991f6bf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "02b0c229-b3f0-4b9e-ba04-84722991f6bf",
+  "issue_id": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T17:51:20.983Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "71c4af9c-c522-4111-bd95-06847a5717c9"
+  }
+}

--- a/project/events/2026-05-06T19:54:09.687Z__6fe5aded-cb75-4e90-8fa3-2e9f06b21138.json
+++ b/project/events/2026-05-06T19:54:09.687Z__6fe5aded-cb75-4e90-8fa3-2e9f06b21138.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6fe5aded-cb75-4e90-8fa3-2e9f06b21138",
+  "issue_id": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T19:54:09.687Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a.json
+++ b/project/issues/plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a.json
@@ -1,0 +1,37 @@
+{
+  "id": "plx-553add3c-787f-4ca9-afdc-e8c5abc76c3a",
+  "title": "Capture failing CI evidence and root cause",
+  "description": "Document failing main run, failing step, and exact Dockerfile path check mismatch.",
+  "type": "sub-task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "2548b2d4-999d-4dd8-afb9-c03fb201f5bd",
+      "author": "derek",
+      "text": "Gathered evidence from GitHub Actions and Dockerfile. Next: finalize root-cause note and close this sub-task.",
+      "created_at": "2026-05-06T17:43:44.392771343Z"
+    },
+    {
+      "id": "7b14806b-d9c1-46bd-a247-642e34f39653",
+      "author": "derek",
+      "text": "Root cause confirmed from run 25446922375: Publish Console Worker Image failed during docker build at Dockerfile line 15 because it checked removed MCP files (scorecards.py, evaluations.py, chats.py). Since that step failed, branch env var update and release trigger steps were skipped for main.",
+      "created_at": "2026-05-06T17:51:12.473881070Z"
+    },
+    {
+      "id": "d9e50abb-264f-45a4-9258-9d3958873d54",
+      "author": "derek",
+      "text": "RCA complete.",
+      "created_at": "2026-05-06T17:51:16.738246433Z"
+    }
+  ],
+  "created_at": "2026-05-06T17:43:41.946564121Z",
+  "updated_at": "2026-05-06T17:51:16.765030182Z",
+  "closed_at": "2026-05-06T17:51:16.765030182Z",
+  "custom": {}
+}

--- a/project/issues/plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0.json
+++ b/project/issues/plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0.json
@@ -1,0 +1,37 @@
+{
+  "id": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "title": "Fix Console Worker CI image publish failure on main",
+  "description": "CI publish job fails on main before updating CONSOLE_WORKER_IMAGE_URI because Dockerfile guard checks deleted MCP module paths. Update guard to validate current MCP runtime files and verify the publish workflow can complete branch env var update.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b7030f92-0508-4982-a1f3-3c67781a8a72",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "9c030269-00b1-4ab6-8ac6-97dcbf64378b",
+      "author": "derek",
+      "text": "Started on branch feature/console-worker-ci-image-guard-fix. Confirmed main run 25446922375 failed in Publish Console Worker Image before branch env var update, leaving CONSOLE_WORKER_IMAGE_URI stale on main.",
+      "created_at": "2026-05-06T17:43:44.379595027Z"
+    },
+    {
+      "id": "79cd2a47-6d5a-4cb2-a606-dfdde56ba4c2",
+      "author": "derek",
+      "text": "Implementation in progress on feature/console-worker-ci-image-guard-fix. Fix is in Dockerfile and test_docker_context.py; pending PR/CI rerun to confirm publish job updates main branch CONSOLE_WORKER_IMAGE_URI.",
+      "created_at": "2026-05-06T17:51:16.822395829Z"
+    },
+    {
+      "id": "71c4af9c-c522-4111-bd95-06847a5717c9",
+      "author": "derek",
+      "text": "Sub-task plx-d75e54 closed after code patch + targeted test pass.",
+      "created_at": "2026-05-06T17:51:20.979076593Z"
+    }
+  ],
+  "created_at": "2026-05-06T17:43:38.270474511Z",
+  "updated_at": "2026-05-06T17:51:20.979076593Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0.json
+++ b/project/issues/plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0.json
@@ -3,7 +3,7 @@
   "title": "Fix Console Worker CI image publish failure on main",
   "description": "CI publish job fails on main before updating CONSOLE_WORKER_IMAGE_URI because Dockerfile guard checks deleted MCP module paths. Update guard to validate current MCP runtime files and verify the publish workflow can complete branch env var update.",
   "type": "task",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 1,
   "assignee": null,
   "creator": null,
@@ -31,7 +31,7 @@
     }
   ],
   "created_at": "2026-05-06T17:43:38.270474511Z",
-  "updated_at": "2026-05-06T17:51:20.979076593Z",
-  "closed_at": null,
+  "updated_at": "2026-05-06T19:54:09.686997799Z",
+  "closed_at": "2026-05-06T19:54:09.686997799Z",
   "custom": {}
 }

--- a/project/issues/plx-d75e54fb-4073-4f99-97e9-de694dc76af0.json
+++ b/project/issues/plx-d75e54fb-4073-4f99-97e9-de694dc76af0.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-d75e54fb-4073-4f99-97e9-de694dc76af0",
+  "title": "Patch console worker Dockerfile guard and validate locally",
+  "description": "Replace stale MCP path checks with current runtime module checks and run local docker build verification.",
+  "type": "sub-task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-7240082e-6d88-4d46-b1ba-c16e1af7acc0",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "bc81707b-4fed-4304-8b38-2464fc0d2031",
+      "author": "derek",
+      "text": "Patched Dockerfile guard to current execute_tactus-era files: MCP/tools/tactus_runtime/execute.py, MCP/tools/tactus_runtime/_item_helpers.py, and MCP/server.py. Updated docker context test assertions accordingly. Validation: pytest dashboard/amplify/functions/consoleRunWorker/test_docker_context.py passed (2 tests).",
+      "created_at": "2026-05-06T17:51:16.801131480Z"
+    }
+  ],
+  "created_at": "2026-05-06T17:43:41.975922299Z",
+  "updated_at": "2026-05-06T17:51:20.964187157Z",
+  "closed_at": "2026-05-06T17:51:20.964187157Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
This PR promotes the Console worker image build fix from develop to main so production can publish a worker image that contains the current Console chat runtime.

## Problem
Production main deployed infrastructure, but the Console responder Lambda image is pinned to an older staging-built ECR digest. That image contains the old built-in Console procedure with an empty tool list, so the chat agent has no execute_tactus tool.

The main CI image publish job is failing before it can build a replacement image because the Console worker Dockerfile still checks for removed legacy MCP modules:
- MCP/tools/scorecard/scorecards.py
- MCP/tools/evaluation/evaluations.py
- MCP/tools/chat/chats.py

## What changed
- Updates the Console worker Dockerfile guard to verify the current execute_tactus runtime modules instead:
  - MCP/tools/tactus_runtime/execute.py
  - MCP/tools/tactus_runtime/_item_helpers.py
  - MCP/server.py
- Updates the Docker context test assertions to match the current runtime dependency.

## Verification target
After merge, the Publish Console Worker Image job should build and push a new plexus-console-run-worker image for the main SHA, update Amplify main CONSOLE_WORKER_IMAGE_URI, and trigger an Amplify release.

Production Console chat should then log execute_tactus tool registration instead of Tactus reporting that the assistant has no tools.