### PR TITLE
Fix Console execute_tactus account context and errors

### DIFF
--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -58,7 +58,12 @@ PLEXUS_PROCEDURE_RUN_LOG_DIR_DEFAULT = os.path.join(
 
 
 def _resolve_trace_dir() -> str:
-    return os.environ.get("PLEXUS_TACTUS_TRACE_DIR", PLEXUS_TACTUS_TRACE_DIR_DEFAULT)
+    configured = os.environ.get("PLEXUS_TACTUS_TRACE_DIR")
+    if configured:
+        return configured
+    if os.environ.get("AWS_LAMBDA_FUNCTION_NAME") or os.environ.get("LAMBDA_TASK_ROOT"):
+        return os.path.join("/tmp", "tactus_traces")
+    return PLEXUS_TACTUS_TRACE_DIR_DEFAULT
 
 
 def _resolve_procedure_run_log_dir() -> str:
@@ -1307,7 +1312,6 @@ def _default_feedback_alignment(args: dict[str, Any]) -> dict[str, Any]:
     """
 
     from plexus.cli.feedback.feedback_service import FeedbackService
-    from plexus.cli.report.utils import resolve_account_id_for_command
     from plexus.cli.shared.client_utils import create_client
     from plexus.cli.shared.memoized_resolvers import (
         memoized_resolve_score_identifier,
@@ -1327,7 +1331,9 @@ def _default_feedback_alignment(args: dict[str, Any]) -> dict[str, Any]:
         raise RuntimeError(
             "plexus.feedback.alignment: could not create dashboard client"
         )
-    account_id = resolve_account_id_for_command(client, None)
+    account_id = _resolve_runtime_account_id(
+        client, args, "plexus.feedback.alignment"
+    )
     scorecard_id = memoized_resolve_scorecard_identifier(client, str(scorecard_name))
     if not scorecard_id:
         raise ValueError(
@@ -1364,7 +1370,6 @@ def _default_feedback_finder(args: dict[str, Any]) -> dict[str, Any]:
     """
 
     from plexus.cli.feedback.feedback_service import FeedbackService
-    from plexus.cli.report.utils import resolve_account_id_for_command
     from plexus.cli.shared.client_utils import create_client
     from plexus.cli.shared.memoized_resolvers import (
         memoized_resolve_score_identifier,
@@ -1382,7 +1387,7 @@ def _default_feedback_finder(args: dict[str, Any]) -> dict[str, Any]:
     prioritize_edit_comments = bool(args.get("prioritize_edit_comments", True))
 
     client = create_client()
-    account_id = resolve_account_id_for_command(client, None)
+    account_id = _resolve_runtime_account_id(client, args, "plexus.feedback.find")
     scorecard_id = memoized_resolve_scorecard_identifier(client, scorecard_name)
     score_id = memoized_resolve_score_identifier(client, scorecard_id, score_name)
 
@@ -3983,6 +3988,8 @@ def _structured_error(
     error: dict[str, Any] = {
         "code": code,
         "message": message,
+        "type": type(exc).__name__ if exc is not None else None,
+        "retryable": False,
         "traceback": None,
         "tactus_lineno": _user_tactus_lineno(raw_lineno),
     }
@@ -4013,6 +4020,121 @@ class BudgetExceeded(RuntimeError):
 
 class ChildBudgetRequired(ValueError):
     """Raised when async work is spawned without an explicit child budget."""
+
+
+class AccountContextRequired(ValueError):
+    """Raised when a runtime API needs an account but none is bound."""
+
+
+_RUNTIME_API_ERROR_KEY = "__execute_tactus_runtime_error__"
+
+
+def _exception_error_code(exc: BaseException) -> str:
+    if isinstance(exc, AccountContextRequired):
+        return "account_context_required"
+    if isinstance(exc, BudgetExceeded):
+        return "budget_exceeded"
+    if isinstance(exc, ChildBudgetRequired):
+        return "child_budget_required"
+    if isinstance(exc, RequiresHandleProtocol):
+        return "requires_handle_protocol"
+    if isinstance(exc, ValueError):
+        return "invalid_request"
+    return "runtime_api_error"
+
+
+def _runtime_api_error_value(namespace: str, method: str, exc: BaseException) -> dict[str, Any]:
+    api_call = f"plexus.{namespace}.{method}"
+    message = str(exc) or f"{api_call} failed"
+    return {
+        _RUNTIME_API_ERROR_KEY: True,
+        "api_call": api_call,
+        "error": _structured_error(
+            _exception_error_code(exc),
+            f"{api_call} failed: {message}",
+            exc,
+        ),
+    }
+
+
+def _extract_runtime_api_error(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        try:
+            value = _jsonable(value)
+        except Exception:
+            return None
+    if isinstance(value, dict) and value.get(_RUNTIME_API_ERROR_KEY):
+        error = value.get("error")
+        return error if isinstance(error, dict) else None
+    return None
+
+
+def _context_account_id(context: dict[str, Any] | None) -> str | None:
+    if not isinstance(context, dict):
+        return None
+    account_id = context.get("account_id") or context.get("accountId")
+    if account_id is None:
+        return None
+    account_id = str(account_id).strip()
+    return account_id or None
+
+
+def _merge_runtime_context_args(
+    args: dict[str, Any], runtime_context: dict[str, Any] | None
+) -> dict[str, Any]:
+    if not isinstance(args, dict):
+        args = {}
+    merged = dict(args)
+    if not any(merged.get(key) for key in ("account", "account_id", "accountId")):
+        account_id = _context_account_id(runtime_context)
+        if account_id:
+            merged["account_id"] = account_id
+    return merged
+
+
+def _resolve_runtime_account_id(
+    client: Any,
+    args: dict[str, Any],
+    api_name: str,
+) -> str:
+    account_id = args.get("account_id") or args.get("accountId")
+    if account_id:
+        account_id = str(account_id).strip()
+        if account_id:
+            if getattr(client, "context", None) is not None:
+                try:
+                    client.context.account_id = account_id
+                except Exception:
+                    pass
+            return account_id
+
+    account_identifier = args.get("account")
+    if account_identifier:
+        from plexus.cli.report.utils import resolve_account_id_for_command
+
+        return resolve_account_id_for_command(client, str(account_identifier))
+
+    context = getattr(client, "context", None)
+    if context is not None:
+        existing_account_id = getattr(context, "account_id", None)
+        if existing_account_id:
+            return str(existing_account_id)
+        if not getattr(context, "account_key", None):
+            raise AccountContextRequired(
+                f"{api_name} requires account context. Console calls must pass the "
+                "triggering ChatMessage accountId into execute_tactus, or local calls "
+                "must provide account/account_id or configure PLEXUS_ACCOUNT_KEY."
+            )
+
+    from plexus.cli.report.utils import resolve_account_id_for_command
+
+    try:
+        return resolve_account_id_for_command(client, None)
+    except Exception as exc:
+        raise AccountContextRequired(
+            f"{api_name} could not resolve an account from the current runtime context. "
+            "Pass account/account_id explicitly or configure PLEXUS_ACCOUNT_KEY."
+        ) from exc
 
 
 class BudgetSpec:
@@ -4990,15 +5112,23 @@ class _Namespace:
         dispatcher: Callable[[str, str, Any], Any],
         name: str,
         methods: set[str],
+        *,
+        catch_runtime_errors: bool = False,
     ) -> None:
         self._dispatcher = dispatcher
         self._name = name
+        self._catch_runtime_errors = catch_runtime_errors
         for method_name in methods:
             setattr(self, method_name, self._make_call(method_name))
 
     def _make_call(self, method_name: str) -> Callable[[Any], Any]:
         def call(args: Any = None) -> Any:
-            return self._dispatcher(self._name, method_name, args)
+            try:
+                return self._dispatcher(self._name, method_name, args)
+            except Exception as exc:
+                if not self._catch_runtime_errors:
+                    raise
+                return _runtime_api_error_value(self._name, method_name, exc)
 
         return call
 
@@ -5047,11 +5177,15 @@ class PlexusRuntimeModule:
         procedure_runner: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
         procedure_optimize: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
         stream_handler: _MCPStreamEmitter | None = None,
+        runtime_context: dict[str, Any] | None = None,
+        catch_runtime_errors: bool = False,
     ) -> None:
         self._mcp = mcp
         self._trace_id = trace_id or str(uuid.uuid4())
         self._docs_dir = docs_dir if docs_dir is not None else PLEXUS_DOCS_DIR
         self._budget = budget if budget is not None else BudgetGate()
+        self._runtime_context = dict(runtime_context or {})
+        self._catch_runtime_errors = catch_runtime_errors
         self._handle_store = (
             handle_store if handle_store is not None else _default_handle_store()
         )
@@ -5189,9 +5323,28 @@ class PlexusRuntimeModule:
         for namespace_name, method_name in DIRECT_HANDLERS.keys():
             methods_by_namespace.setdefault(namespace_name, set()).add(method_name)
         for namespace, methods in methods_by_namespace.items():
-            setattr(self, namespace, _Namespace(self._call, namespace, methods))
-        self.docs = _Namespace(self._call_docs, "docs", {"list", "get"})
-        self.api = _Namespace(self._call_api, "api", {"list"})
+            setattr(
+                self,
+                namespace,
+                _Namespace(
+                    self._call,
+                    namespace,
+                    methods,
+                    catch_runtime_errors=self._catch_runtime_errors,
+                ),
+            )
+        self.docs = _Namespace(
+            self._call_docs,
+            "docs",
+            {"list", "get"},
+            catch_runtime_errors=self._catch_runtime_errors,
+        )
+        self.api = _Namespace(
+            self._call_api,
+            "api",
+            {"list"},
+            catch_runtime_errors=self._catch_runtime_errors,
+        )
 
     @property
     def api_calls(self) -> list[str]:
@@ -5330,7 +5483,7 @@ class PlexusRuntimeModule:
         self._budget.check_before("feedback", method)
         self._record_api_call("feedback", method)
         try:
-            parsed = _args(args)
+            parsed = _merge_runtime_context_args(_args(args), self._runtime_context)
             if method == "find":
                 return self._feedback_finder(parsed)
             if method == "latest_update":
@@ -5931,6 +6084,7 @@ def _run_tactus_sync(
     procedure_runner: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
     stream_handler: _MCPStreamEmitter | None = None,
     score_info: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    runtime_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     gate = budget if budget is not None else BudgetGate()
 
@@ -5967,6 +6121,8 @@ def _run_tactus_sync(
                 procedure_runner=procedure_runner,
                 stream_handler=stream_handler,
                 score_info=score_info,
+                runtime_context=runtime_context,
+                catch_runtime_errors=True,
             )
             runtime.register_python_module("plexus", plexus)
             if stream_handler is not None:
@@ -6031,16 +6187,28 @@ def _run_tactus_sync(
                 )
             else:
                 ok = bool(runtime_result.get("success"))
-                value = runtime_result.get("result")
+                value = _jsonable(runtime_result.get("result"))
                 if ok:
-                    envelope = _response_envelope(
-                        ok=True,
-                        value=value,
-                        trace_id=trace_id,
-                        api_calls=api_calls,
-                        started_at=started_mono,
-                        budget=gate,
-                    )
+                    runtime_api_error = _extract_runtime_api_error(value)
+                    if runtime_api_error is not None:
+                        envelope = _response_envelope(
+                            ok=False,
+                            value=None,
+                            trace_id=trace_id,
+                            api_calls=api_calls,
+                            started_at=started_mono,
+                            error=runtime_api_error,
+                            budget=gate,
+                        )
+                    else:
+                        envelope = _response_envelope(
+                            ok=True,
+                            value=value,
+                            trace_id=trace_id,
+                            api_calls=api_calls,
+                            started_at=started_mono,
+                            budget=gate,
+                        )
                 else:
                     message = str(
                         runtime_result.get("error") or "Tactus execution failed"
@@ -6145,6 +6313,7 @@ async def _execute_tactus_tool(
     report_runner: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
     procedure_runner: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
     score_info: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    runtime_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     store = trace_store if trace_store is not None else _default_trace_store()
     started_mono = time.monotonic()
@@ -6202,6 +6371,7 @@ async def _execute_tactus_tool(
                     procedure_runner=procedure_runner,
                     stream_handler=stream_handler,
                     score_info=score_info,
+                    runtime_context=runtime_context,
                 )
             )
             if stream_handler is None:

--- a/MCP/tools/tactus_runtime/execute_test.py
+++ b/MCP/tools/tactus_runtime/execute_test.py
@@ -1791,6 +1791,16 @@ def test_default_trace_store_honours_env_override(monkeypatch, tmp_path) -> None
     assert store.directory == str(target)
 
 
+def test_default_trace_store_uses_lambda_writable_tmp(monkeypatch) -> None:
+    monkeypatch.delenv("PLEXUS_TACTUS_TRACE_DIR", raising=False)
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "console-chat-responder")
+
+    store = execute._default_trace_store()
+
+    assert isinstance(store, execute.FileTactusTraceStore)
+    assert store.directory == "/tmp/tactus_traces"
+
+
 def test_default_budget_spec_uses_initiative_defaults() -> None:
     spec = execute.BudgetSpec()
 
@@ -3612,6 +3622,92 @@ def test_default_feedback_finder_chains_through_resolvers_and_service(
     assert kwargs["prioritize_edit_comments"] is False
 
 
+def test_default_feedback_alignment_uses_explicit_runtime_account(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    class FakeFeedbackService:
+        @staticmethod
+        async def summarize_feedback(**kwargs):
+            captured["summary_kwargs"] = kwargs
+            return SimpleNamespace(stub_summary_result=True)
+
+        @staticmethod
+        def format_summary_result_as_dict(result):
+            captured["formatted_from"] = result
+            return {"summary": {"total": 3}}
+
+    fake_client = SimpleNamespace(
+        context=SimpleNamespace(account_id=None, account_key=None)
+    )
+
+    monkeypatch.setattr(
+        "plexus.cli.shared.client_utils.create_client", lambda: fake_client
+    )
+    monkeypatch.setattr(
+        "plexus.cli.report.utils.resolve_account_id_for_command",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("default account resolver should not run")
+        ),
+    )
+    monkeypatch.setattr(
+        "plexus.cli.shared.memoized_resolvers.memoized_resolve_scorecard_identifier",
+        lambda client, name: f"sc:{name}",
+    )
+    monkeypatch.setattr(
+        "plexus.cli.shared.memoized_resolvers.memoized_resolve_score_identifier",
+        lambda client, scorecard_id, score_name: f"sn:{scorecard_id}:{score_name}",
+    )
+    monkeypatch.setattr(
+        "plexus.cli.feedback.feedback_service.FeedbackService",
+        FakeFeedbackService,
+    )
+
+    result = execute._default_feedback_alignment(
+        {
+            "scorecard_name": "IA Call Center - Universal Pilot",
+            "score_name": "Professionalism Manners",
+            "account_id": "acct-console",
+            "days": 14,
+        }
+    )
+
+    assert result == {"summary": {"total": 3}}
+    assert fake_client.context.account_id == "acct-console"
+    kwargs = captured["summary_kwargs"]
+    assert kwargs["account_id"] == "acct-console"
+    assert kwargs["scorecard_name"] == "IA Call Center - Universal Pilot"
+    assert kwargs["score_name"] == "Professionalism Manners"
+    assert kwargs["days"] == 14
+
+
+def test_default_feedback_alignment_requires_account_context_without_null_key(
+    monkeypatch,
+) -> None:
+    fake_client = SimpleNamespace(
+        context=SimpleNamespace(account_id=None, account_key=None)
+    )
+
+    monkeypatch.setattr(
+        "plexus.cli.shared.client_utils.create_client", lambda: fake_client
+    )
+    monkeypatch.setattr(
+        "plexus.cli.report.utils.resolve_account_id_for_command",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("must not resolve default account with a null key")
+        ),
+    )
+
+    with pytest.raises(execute.AccountContextRequired, match="requires account context"):
+        execute._default_feedback_alignment(
+            {
+                "scorecard_name": "IA Call Center - Universal Pilot",
+                "score_name": "Professionalism Manners",
+            }
+        )
+
+
 @pytest.mark.asyncio
 async def test_execute_tactus_runs_feedback_find_through_direct_finder() -> None:
     mcp = FastMCP("test-execute-tactus-feedback-direct")
@@ -3656,6 +3752,48 @@ async def test_execute_tactus_runs_feedback_find_through_direct_finder() -> None
 
 
 @pytest.mark.asyncio
+async def test_execute_tactus_injects_runtime_account_into_feedback_handler() -> None:
+    mcp = FastMCP("test-execute-tactus-feedback-context")
+    seen_args: dict = {}
+
+    def fake_finder(args: dict) -> dict:
+        seen_args.update(args)
+        return {"context": {"account_id": args.get("account_id")}, "feedback_items": []}
+
+    result = await execute._execute_tactus_tool(
+        'feedback{ scorecard_name = "x", score_name = "y" }',
+        mcp,
+        feedback_finder=fake_finder,
+        runtime_context={"account_id": "acct-console"},
+    )
+
+    assert result["ok"] is True
+    assert result["value"]["context"]["account_id"] == "acct-console"
+    assert seen_args["account_id"] == "acct-console"
+
+
+@pytest.mark.asyncio
+async def test_execute_tactus_direct_handler_exception_is_structured() -> None:
+    mcp = FastMCP("test-execute-tactus-feedback-handler-error")
+
+    def fake_finder(_args: dict) -> dict:
+        raise RuntimeError("original handler failure")
+
+    result = await execute._execute_tactus_tool(
+        'feedback{ scorecard_name = "x", score_name = "y" }',
+        mcp,
+        feedback_finder=fake_finder,
+    )
+
+    assert result["ok"] is False
+    assert result["value"] is None
+    assert result["error"]["code"] == "runtime_api_error"
+    assert result["error"]["type"] == "RuntimeError"
+    assert "original handler failure" in result["error"]["message"]
+    assert "Sandbox error:" not in result["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_execute_tactus_feedback_find_missing_args_surfaces_as_tactus_error() -> (
     None
 ):
@@ -3667,7 +3805,7 @@ async def test_execute_tactus_feedback_find_missing_args_surfaces_as_tactus_erro
     )
 
     assert result["ok"] is False
-    assert result["error"]["code"] == "tactus_execution_failed"
+    assert result["error"]["code"] == "invalid_request"
     assert "scorecard_name and score_name" in result["error"]["message"]
 
 

--- a/plexus/cli/procedure/mcp_transport.py
+++ b/plexus/cli/procedure/mcp_transport.py
@@ -842,6 +842,7 @@ class EmbeddedMCPServer:
                         trace_store=_et_trace_store,
                         handle_store=_et_handle_store,
                         budget=_et_budget,
+                        runtime_context=self.experiment_context,
                     )
 
                 logger.info("Registered execute_tactus in embedded MCP transport")

--- a/plexus/cli/procedure/test_mcp_transport.py
+++ b/plexus/cli/procedure/test_mcp_transport.py
@@ -9,6 +9,8 @@ a separate server process.
 import pytest
 import asyncio
 import json
+import os
+import sys
 from unittest.mock import Mock, patch
 from plexus.cli.procedure.mcp_transport import (
     _advance_task_to_stage_by_name,
@@ -248,6 +250,62 @@ class TestEmbeddedMCPServer:
             content_text = result["content"][0]["text"]
             response_data = json.loads(content_text)
             assert "Logged message at info level" in response_data["message"]
+
+    @pytest.mark.asyncio
+    async def test_execute_tactus_receives_experiment_context(self, monkeypatch):
+        """Console account context should be passed into nested execute_tactus."""
+        project_root = os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        )
+        mcp_path = os.path.join(project_root, "MCP")
+        if mcp_path not in sys.path:
+            sys.path.insert(0, mcp_path)
+
+        from tools.tactus_runtime import execute as tactus_execute
+
+        captured: dict = {}
+
+        async def fake_execute_tactus_tool(
+            tactus,
+            mcp,
+            *,
+            ctx=None,
+            trace_store=None,
+            handle_store=None,
+            budget=None,
+            runtime_context=None,
+            **_kwargs,
+        ):
+            captured["tactus"] = tactus
+            captured["runtime_context"] = runtime_context
+            return {
+                "ok": True,
+                "value": {"seen_account": runtime_context.get("account_id")},
+                "error": None,
+                "cost": {},
+                "trace_id": "trace-1",
+                "partial": False,
+                "api_calls": [],
+            }
+
+        monkeypatch.setattr(
+            tactus_execute, "_execute_tactus_tool", fake_execute_tactus_tool
+        )
+
+        server = EmbeddedMCPServer(
+            {"procedure_id": "proc-1", "account_id": "acct-console"}
+        )
+        server.register_plexus_tools([])
+        await server.transport.initialize({"name": "Test"})
+
+        result = await server.transport.call_tool(
+            "execute_tactus", {"tactus": "return 1"}
+        )
+
+        response_data = json.loads(result["content"][0]["text"])
+        assert response_data["value"]["seen_account"] == "acct-console"
+        assert captured["tactus"] == "return 1"
+        assert captured["runtime_context"]["account_id"] == "acct-console"
     
     @pytest.mark.asyncio
     async def test_connection_context_manager(self, server):

--- a/project/events/2026-05-06T22:41:23.702Z__56d84e16-c548-48e1-8f7e-e7a149a0c599.json
+++ b/project/events/2026-05-06T22:41:23.702Z__56d84e16-c548-48e1-8f7e-e7a149a0c599.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "56d84e16-c548-48e1-8f7e-e7a149a0c599",
+  "issue_id": "plx-53ac80b9-5f13-49ae-9a03-71608fd39d82",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T22:41:23.702Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "# Fix Console execute_tactus account context and structured errors\n\nAs a Console chat agent, I want execute_tactus calls to inherit the triggering chat message account and return structured failures, so that I can run Plexus APIs from Lambda and iteratively recover from errors.\n\nFeature: Console execute_tactus account and error handling\n\nScenario: Console feedback alignment uses the chat account\nGiven a Console chat message has accountId acct-console\nWhen the assistant calls execute_tactus with plexus.feedback.alignment for a scorecard and score\nThen the Plexus runtime resolves account operations using acct-console\nAnd it does not issue a GraphQL account-key lookup with key null\n\nScenario: Missing account context is actionable\nGiven execute_tactus runs a feedback API without an explicit account context\nWhen the runtime cannot resolve an account\nThen the tool response has ok false\nAnd error.code is account_context_required\nAnd error.message explains that Console account context or an explicit account is required\n\nScenario: Runtime exceptions remain visible\nGiven a direct Plexus runtime handler raises a Python exception\nWhen execute_tactus catches the failure\nThen the caller receives ok false\nAnd error.message includes the original exception message\nAnd the response is not a blank Sandbox error.\n\nDefinition of Done:\n- Console embedded execute_tactus passes experiment_context account_id into the Tactus runtime.\n- feedback.alignment and feedback.find prefer explicit runtime account context and fail clearly without it.\n- Python handler failures are converted into structured execute_tactus envelopes.\n- Lambda trace persistence uses a writable/default-safe path and cannot mask tool output.\n- Focused unit and console runtime tests pass.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-7c2c6ba8-226d-4b51-b922-e4f8075503fc",
+    "priority": 0,
+    "status": "open",
+    "title": "Fix Console execute_tactus account context and structured errors"
+  }
+}

--- a/project/events/2026-05-06T22:41:28.057Z__2693f23e-4c7b-412f-a9d2-f7a0e9355074.json
+++ b/project/events/2026-05-06T22:41:28.057Z__2693f23e-4c7b-412f-a9d2-f7a0e9355074.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2693f23e-4c7b-412f-a9d2-f7a0e9355074",
+  "issue_id": "plx-53ac80b9-5f13-49ae-9a03-71608fd39d82",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T22:41:28.057Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T22:41:28.078Z__fb8c583e-9913-4c9b-8929-8d638ff7e453.json
+++ b/project/events/2026-05-06T22:41:28.078Z__fb8c583e-9913-4c9b-8929-8d638ff7e453.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "fb8c583e-9913-4c9b-8929-8d638ff7e453",
+  "issue_id": "plx-53ac80b9-5f13-49ae-9a03-71608fd39d82",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T22:41:28.078Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "caba7a5f-b001-4c39-875b-cdea1c94c382"
+  }
+}

--- a/project/events/2026-05-06T22:48:32.817Z__759c793b-15d5-41c1-a1bc-8883001f8cad.json
+++ b/project/events/2026-05-06T22:48:32.817Z__759c793b-15d5-41c1-a1bc-8883001f8cad.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "759c793b-15d5-41c1-a1bc-8883001f8cad",
+  "issue_id": "plx-53ac80b9-5f13-49ae-9a03-71608fd39d82",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T22:48:32.817Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "136db29e-08e6-41d7-86ca-97ff372ee62f"
+  }
+}

--- a/project/events/2026-05-06T22:49:13.327Z__6d06262c-f6d4-4789-be86-996904e7130c.json
+++ b/project/events/2026-05-06T22:49:13.327Z__6d06262c-f6d4-4789-be86-996904e7130c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6d06262c-f6d4-4789-be86-996904e7130c",
+  "issue_id": "plx-53ac80b9-5f13-49ae-9a03-71608fd39d82",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T22:49:13.327Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "78c3992b-d78b-4e5d-84fb-88b5abede1bb"
+  }
+}

--- a/project/issues/plx-53ac80b9-5f13-49ae-9a03-71608fd39d82.json
+++ b/project/issues/plx-53ac80b9-5f13-49ae-9a03-71608fd39d82.json
@@ -22,10 +22,16 @@
       "author": "ryan",
       "text": "Implemented account-context propagation into embedded execute_tactus, explicit account resolution for feedback alignment/find, structured runtime error envelopes for Lua-hosted direct handler failures, and Lambda /tmp trace default. Focused tests are green: execute_tactus suite 121 passed; MCP transport/console/procedure compatibility 75 passed; git diff --check passed.",
       "created_at": "2026-05-06T22:48:32.817356Z"
+    },
+    {
+      "id": "78c3992b-d78b-4e5d-84fb-88b5abede1bb",
+      "author": "ryan",
+      "text": "Opened PR into develop: https://github.com/AnthusAI/Plexus/pull/311. Branch pushed: codex/console-execute-tactus-account-errors at commit 704614c7.",
+      "created_at": "2026-05-06T22:49:13.327430Z"
     }
   ],
   "created_at": "2026-05-06T22:41:23.702375Z",
-  "updated_at": "2026-05-06T22:48:32.817356Z",
+  "updated_at": "2026-05-06T22:49:13.327430Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-53ac80b9-5f13-49ae-9a03-71608fd39d82.json
+++ b/project/issues/plx-53ac80b9-5f13-49ae-9a03-71608fd39d82.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-53ac80b9-5f13-49ae-9a03-71608fd39d82",
+  "title": "Fix Console execute_tactus account context and structured errors",
+  "description": "# Fix Console execute_tactus account context and structured errors\n\nAs a Console chat agent, I want execute_tactus calls to inherit the triggering chat message account and return structured failures, so that I can run Plexus APIs from Lambda and iteratively recover from errors.\n\nFeature: Console execute_tactus account and error handling\n\nScenario: Console feedback alignment uses the chat account\nGiven a Console chat message has accountId acct-console\nWhen the assistant calls execute_tactus with plexus.feedback.alignment for a scorecard and score\nThen the Plexus runtime resolves account operations using acct-console\nAnd it does not issue a GraphQL account-key lookup with key null\n\nScenario: Missing account context is actionable\nGiven execute_tactus runs a feedback API without an explicit account context\nWhen the runtime cannot resolve an account\nThen the tool response has ok false\nAnd error.code is account_context_required\nAnd error.message explains that Console account context or an explicit account is required\n\nScenario: Runtime exceptions remain visible\nGiven a direct Plexus runtime handler raises a Python exception\nWhen execute_tactus catches the failure\nThen the caller receives ok false\nAnd error.message includes the original exception message\nAnd the response is not a blank Sandbox error.\n\nDefinition of Done:\n- Console embedded execute_tactus passes experiment_context account_id into the Tactus runtime.\n- feedback.alignment and feedback.find prefer explicit runtime account context and fail clearly without it.\n- Python handler failures are converted into structured execute_tactus envelopes.\n- Lambda trace persistence uses a writable/default-safe path and cannot mask tool output.\n- Focused unit and console runtime tests pass.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 0,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-7c2c6ba8-226d-4b51-b922-e4f8075503fc",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "caba7a5f-b001-4c39-875b-cdea1c94c382",
+      "author": "ryan",
+      "text": "Started on clean branch codex/console-execute-tactus-account-errors from origin/develop. Scope is account context propagation into embedded execute_tactus, actionable feedback account errors, structured direct-handler exception envelopes, and Lambda-safe trace writes.",
+      "created_at": "2026-05-06T22:41:28.077892Z"
+    },
+    {
+      "id": "136db29e-08e6-41d7-86ca-97ff372ee62f",
+      "author": "ryan",
+      "text": "Implemented account-context propagation into embedded execute_tactus, explicit account resolution for feedback alignment/find, structured runtime error envelopes for Lua-hosted direct handler failures, and Lambda /tmp trace default. Focused tests are green: execute_tactus suite 121 passed; MCP transport/console/procedure compatibility 75 passed; git diff --check passed.",
+      "created_at": "2026-05-06T22:48:32.817356Z"
+    }
+  ],
+  "created_at": "2026-05-06T22:41:23.702375Z",
+  "updated_at": "2026-05-06T22:48:32.817356Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- passes the Console chat experiment context into embedded `execute_tactus` so nested Plexus runtime calls receive the triggering `account_id`
- makes `plexus.feedback.alignment` / `plexus.feedback.find` prefer explicit runtime account context and fail with `account_context_required` instead of GraphQL `key=null`
- converts Lua-hosted direct handler exceptions into structured `ok=false` execute_tactus envelopes instead of blank `Sandbox error:` responses
- defaults Tactus trace files to `/tmp/tactus_traces` in Lambda so trace persistence cannot fail on `/workspace/tmp`

## Production failure addressed
Console session `55f31221-1e9d-4b09-af3e-db3a4035c9f9` reached `execute_tactus`, but `plexus.feedback.alignment` lost the Console account context and tried to resolve a default account with `key=null`. The useful GraphQL error was then hidden behind an opaque sandbox failure.

## Tests
- `/Users/ryan/miniconda3/bin/python -m pytest MCP/tools/tactus_runtime/execute_test.py -q`
- `/Users/ryan/miniconda3/bin/python -m pytest plexus/cli/procedure/test_mcp_transport.py plexus/console/test_chat_runtime.py plexus/cli/procedure/test_procedure_executor_compat.py -q`
- `git diff --check`

Kanbus: plx-53ac80