### PR TITLE
Fix Console Tactus read-only home failure

### DIFF
--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -459,7 +459,6 @@ def _default_scorecards_list(args: dict[str, Any]) -> Any:
     from plexus.cli.shared.memoized_resolvers import (
         memoized_resolve_scorecard_identifier,
     )
-    from shared.utils import get_default_account_id
 
     identifier = args.get("identifier") or args.get("name") or args.get("key")
     next_token = args.get("next_token") or args.get("nextToken")
@@ -506,9 +505,8 @@ def _default_scorecards_list(args: dict[str, Any]) -> Any:
             return items
 
     filter_parts: list[str] = []
-    default_account_id = get_default_account_id()
-    if default_account_id:
-        filter_parts.append(f'accountId: {{ eq: "{default_account_id}" }}')
+    account_id = _resolve_runtime_account_id(client, args, "plexus.scorecards.list")
+    filter_parts.append(f'accountId: {{ eq: "{account_id}" }}')
     if identifier:
         ident = str(identifier)
         if " " in ident or not ident.islower():
@@ -627,7 +625,6 @@ def _default_scorecards_search(args: dict[str, Any]) -> dict[str, Any]:
     from rapidfuzz import fuzz, process
 
     from plexus.cli.shared.client_utils import create_client
-    from shared.utils import get_default_account_id
 
     query = _search_query_string(args)
     if not query:
@@ -667,9 +664,8 @@ def _default_scorecards_search(args: dict[str, Any]) -> dict[str, Any]:
         raise RuntimeError("plexus.scorecards.search: could not create dashboard client")
 
     filter_parts: list[str] = []
-    default_account_id = get_default_account_id()
-    if default_account_id:
-        filter_parts.append(f'accountId: {{ eq: "{default_account_id}" }}')
+    account_id = _resolve_runtime_account_id(client, args, "plexus.scorecards.search")
+    filter_parts.append(f'accountId: {{ eq: "{account_id}" }}')
     filter_str = ", ".join(filter_parts)
     gql = (
         "query ListScorecardsForSearch { "
@@ -826,11 +822,7 @@ def _default_score_search(args: dict[str, Any]) -> dict[str, Any]:
         if one:
             scorecards = [one]
     else:
-        account_id = resolve_account_id_for_command(client, None)
-        if not account_id:
-            raise RuntimeError(
-                "plexus.score.search: no default account — is PLEXUS_ACCOUNT_KEY set?"
-            )
+        account_id = _resolve_runtime_account_id(client, args, "plexus.score.search")
         result = client.execute(
             f"""query ListScorecardsForScoreSearch {{
                 listScorecards(filter: {{ accountId: {{ eq: "{account_id}" }} }}, limit: {scorecard_fetch_limit}) {{
@@ -2714,7 +2706,6 @@ def _default_report_configurations_list(args: dict[str, Any]) -> Any:
     """Run plexus.report.configurations_list directly via dashboard GraphQL."""
 
     from plexus.cli.shared.client_utils import create_client
-    from shared.utils import get_default_account_id
 
     client = create_client()
     if not client:
@@ -2722,12 +2713,9 @@ def _default_report_configurations_list(args: dict[str, Any]) -> Any:
             "plexus.report.configurations_list: could not create dashboard client"
         )
 
-    account_id = get_default_account_id()
-    if not account_id:
-        raise RuntimeError(
-            "plexus.report.configurations_list: PLEXUS_ACCOUNT_KEY not set or "
-            "default account could not be resolved"
-        )
+    account_id = _resolve_runtime_account_id(
+        client, args, "plexus.report.configurations_list"
+    )
 
     query = (
         "query MyQuery { "
@@ -5407,7 +5395,7 @@ class PlexusRuntimeModule:
         self._budget.check_before("score", method)
         self._record_api_call("score", method)
         try:
-            parsed = _args(args)
+            parsed = _merge_runtime_context_args(_args(args), self._runtime_context)
             if method == "info":
                 return self._score_info(parsed)
             if method == "search":
@@ -5469,7 +5457,7 @@ class PlexusRuntimeModule:
         self._budget.check_before("scorecards", method)
         self._record_api_call("scorecards", method)
         try:
-            parsed = _args(args)
+            parsed = _merge_runtime_context_args(_args(args), self._runtime_context)
             if method == "list":
                 return self._scorecards_lister(parsed)
             if method == "search":
@@ -5589,7 +5577,8 @@ class PlexusRuntimeModule:
         self._budget.check_before("report", "configurations_list")
         self._record_api_call("report", "configurations_list")
         try:
-            return self._report_configurations_list(_args(args))
+            parsed = _merge_runtime_context_args(_args(args), self._runtime_context)
+            return self._report_configurations_list(parsed)
         finally:
             self._budget.record_after("report", "configurations_list")
 

--- a/MCP/tools/tactus_runtime/execute_test.py
+++ b/MCP/tools/tactus_runtime/execute_test.py
@@ -441,11 +441,14 @@ def test_default_scorecards_search_ranks_matches(monkeypatch) -> None:
     monkeypatch.setattr(
         "plexus.cli.shared.client_utils.create_client", lambda: FakeClient()
     )
-    monkeypatch.setattr(
-        "shared.utils.get_default_account_id", lambda: "00000000-0000-0000-0000-000000000001"
-    )
 
-    result = execute._default_scorecards_search({"query": "HCS medium", "limit": 5})
+    result = execute._default_scorecards_search(
+        {
+            "query": "HCS medium",
+            "limit": 5,
+            "account_id": "00000000-0000-0000-0000-000000000001",
+        }
+    )
     assert result["success"] is True
     assert result["count"] == 1
     assert result["matches"][0]["scorecard"]["id"] == "sc-a"
@@ -3769,6 +3772,31 @@ async def test_execute_tactus_injects_runtime_account_into_feedback_handler() ->
 
     assert result["ok"] is True
     assert result["value"]["context"]["account_id"] == "acct-console"
+    assert seen_args["account_id"] == "acct-console"
+
+
+def test_plexus_facade_injects_runtime_account_into_scorecard_search() -> None:
+    class FakeMCP:
+        async def call_tool(self, name, arguments):
+            raise AssertionError(
+                "scorecards.search must not loop back through MCP; got "
+                f"{name!r} with {arguments!r}"
+            )
+
+    seen_args: dict = {}
+
+    def fake_search(args: dict) -> dict:
+        seen_args.update(args)
+        return {"success": True, "matches": [], "account_id": args.get("account_id")}
+
+    facade = execute.PlexusRuntimeModule(
+        FakeMCP(),
+        scorecards_searcher=fake_search,
+        runtime_context={"account_id": "acct-console"},
+    )
+    result = facade.scorecards.search({"query": "IA Call Center"})
+
+    assert result["account_id"] == "acct-console"
     assert seen_args["account_id"] == "acct-console"
 
 

--- a/project/events/2026-05-07T00:38:52.021Z__39e2e7d4-ea30-4559-856a-c762912d2028.json
+++ b/project/events/2026-05-07T00:38:52.021Z__39e2e7d4-ea30-4559-856a-c762912d2028.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "39e2e7d4-ea30-4559-856a-c762912d2028",
+  "issue_id": "plx-58da7260-1ec3-43a5-ab56-2f0d96accb85",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T00:38:52.021Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-7c2c6ba8-226d-4b51-b922-e4f8075503fc",
+    "priority": 0,
+    "status": "open",
+    "title": "Fix production Console execute_tactus failure"
+  }
+}

--- a/project/events/2026-05-07T00:38:54.426Z__59a79af6-f13d-4566-8a3c-04718836b704.json
+++ b/project/events/2026-05-07T00:38:54.426Z__59a79af6-f13d-4566-8a3c-04718836b704.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "59a79af6-f13d-4566-8a3c-04718836b704",
+  "issue_id": "plx-58da7260-1ec3-43a5-ab56-2f0d96accb85",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T00:38:54.426Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T00:38:54.445Z__f0db42e9-ffb0-4a4d-9a82-2378076bbe20.json
+++ b/project/events/2026-05-07T00:38:54.445Z__f0db42e9-ffb0-4a4d-9a82-2378076bbe20.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f0db42e9-ffb0-4a4d-9a82-2378076bbe20",
+  "issue_id": "plx-58da7260-1ec3-43a5-ab56-2f0d96accb85",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T00:38:54.445Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "bf02cae3-f714-4e96-a714-53b83e64737a"
+  }
+}

--- a/project/events/2026-05-07T00:42:45.913Z__b866b62e-a131-4856-9ebc-7967f8776c09.json
+++ b/project/events/2026-05-07T00:42:45.913Z__b866b62e-a131-4856-9ebc-7967f8776c09.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b866b62e-a131-4856-9ebc-7967f8776c09",
+  "issue_id": "plx-58da7260-1ec3-43a5-ab56-2f0d96accb85",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T00:42:45.913Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "dbdc4fa9-57dd-4188-a44a-5095e7840fbc"
+  }
+}

--- a/project/issues/plx-58da7260-1ec3-43a5-ab56-2f0d96accb85.json
+++ b/project/issues/plx-58da7260-1ec3-43a5-ab56-2f0d96accb85.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-58da7260-1ec3-43a5-ab56-2f0d96accb85",
+  "title": "Fix production Console execute_tactus failure",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 0,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-7c2c6ba8-226d-4b51-b922-e4f8075503fc",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "bf02cae3-f714-4e96-a714-53b83e64737a",
+      "author": "ryan",
+      "text": "Investigating production Console conversation 55f31221-1e9d-4b09-af3e-db3a4035c9f9 for execute_tactus/tool failure after PR #312 deployment path.",
+      "created_at": "2026-05-07T00:38:54.445762Z"
+    },
+    {
+      "id": "dbdc4fa9-57dd-4188-a44a-5095e7840fbc",
+      "author": "ryan",
+      "text": "Diagnosis: production Console conversation 55f31221-1e9d-4b09-af3e-db3a4035c9f9 reached execute_tactus, but scorecards.search failed with [Errno 30] Read-only file system: /home/sbx_user1051. Root cause was embedded Tactus scorecard/report config helpers importing MCP shared.utils, which imports shared.setup and creates ~/.plexus/mcp-server.log. Fix removes that import path and resolves account from runtime context instead.",
+      "created_at": "2026-05-07T00:42:45.913425Z"
+    }
+  ],
+  "created_at": "2026-05-07T00:38:52.020616Z",
+  "updated_at": "2026-05-07T00:42:45.913425Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Fixes production Console execute_tactus failures where scorecard/report helper calls tried to import MCP shared setup and write to ~/.plexus under Lambda's read-only /home/sbx_user* path.
- Resolves account context from the embedded Tactus runtime for scorecards.list, scorecards.search, score.search, and report.configurations_list instead of importing shared.utils.
- Adds regression coverage for Console account injection into scorecard search.

## Production evidence
- Console session: 55f31221-1e9d-4b09-af3e-db3a4035c9f9
- Failing tool call: plexus.scorecards.search
- Error: [Errno 30] Read-only file system: '/home/sbx_user1051'

## Validation
- /Users/ryan/miniconda3/bin/python -m pytest MCP/tools/tactus_runtime/execute_test.py -q
- /Users/ryan/miniconda3/bin/python -m pytest plexus/console/test_chat_runtime.py -q
- git diff --check
- Lambda-style smoke with AWS_LAMBDA_FUNCTION_NAME set and HOME=/home/sbx_user1051 successfully ran plexus.scorecards.search.