### PR TITLE
Fix Console report dispatch handling

### DIFF
--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -3235,6 +3235,13 @@ def _build_report_config_command(configuration_id: str, parameters: dict[str, An
     return " ".join(shlex.quote(str(part)) for part in parts)
 
 
+def _normalize_report_block_config(block_class: Any, block_config: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(block_config or {})
+    if str(block_class) == "FeedbackAlignment" and "memory_analysis" not in normalized:
+        normalized["memory_analysis"] = False
+    return normalized
+
+
 def _default_report_runner(args: dict[str, Any]) -> dict[str, Any]:
     """Dispatch report.run async.
 
@@ -3309,7 +3316,7 @@ def _default_report_runner(args: dict[str, Any]) -> dict[str, Any]:
 
     from plexus.reports.service import run_block_cached
 
-    block_config = args.get("block_config") or {}
+    block_config = _normalize_report_block_config(block_class, args.get("block_config") or {})
     cache_key = args.get("cache_key")
     ttl_hours = args.get("ttl_hours") if args.get("ttl_hours") is not None else 24
     fresh = bool(args.get("fresh", False))
@@ -3425,7 +3432,7 @@ def _default_report_runner_sync(args: dict[str, Any]) -> dict[str, Any]:
 
     output_data, log_output, was_cached = run_block_cached(
         block_class=str(block_class),
-        block_config=args.get("block_config") or {},
+        block_config=_normalize_report_block_config(block_class, args.get("block_config") or {}),
         account_id=account_id,
         client=client,
         cache_key=cache_key,
@@ -3800,6 +3807,8 @@ def _public_handle(record: dict[str, Any]) -> dict[str, Any]:
     }
     if record.get("child_budget") is not None:
         public["child_budget"] = record.get("child_budget")
+    if record.get("dispatch_result") is not None:
+        public["dispatch_result"] = record.get("dispatch_result")
     return public
 
 

--- a/MCP/tools/tactus_runtime/execute_test.py
+++ b/MCP/tools/tactus_runtime/execute_test.py
@@ -64,6 +64,7 @@ class _MemoryHandleStore(execute.TactusHandleStore):
             "status_url": dispatch_result.get("dashboard_url"),
             "created_at": record["created_at"],
             "parent_trace_id": parent_trace_id,
+            "dispatch_result": dispatch_result,
         }
         if child_budget is not None:
             public["child_budget"] = child_budget
@@ -2795,6 +2796,69 @@ def test_default_report_runner_uses_remote_dispatch_by_default(monkeypatch) -> N
     }
 
 
+def test_default_report_runner_disables_feedback_alignment_memory_by_default(monkeypatch) -> None:
+    captured: dict = {}
+    client = object()
+
+    def fake_run_block_cached(**kwargs):
+        captured.update(kwargs)
+        return ({"status": "dispatched", "cache_key": "report-cache", "task_id": "task-1"}, None, False)
+
+    monkeypatch.setattr(
+        "plexus.cli.report.utils.resolve_account_id_for_command",
+        lambda _client, _account: "acct-1",
+    )
+    monkeypatch.setattr("plexus.cli.shared.client_utils.create_client", lambda: client)
+    monkeypatch.setattr("plexus.reports.service.run_block_cached", fake_run_block_cached)
+    monkeypatch.delenv("PLEXUS_DISPATCH_MODE", raising=False)
+
+    result = execute._default_report_runner(
+        {
+            "block_class": "FeedbackAlignment",
+            "cache_key": "report-cache",
+            "block_config": {"scorecard": "Suco - Home Improvement", "days": 30},
+        }
+    )
+
+    assert result["task_id"] == "task-1"
+    assert captured["block_config"] == {
+        "scorecard": "Suco - Home Improvement",
+        "days": 30,
+        "memory_analysis": False,
+    }
+
+
+def test_default_report_runner_preserves_explicit_feedback_alignment_memory(monkeypatch) -> None:
+    captured: dict = {}
+    client = object()
+
+    def fake_run_block_cached(**kwargs):
+        captured.update(kwargs)
+        return ({"status": "dispatched", "cache_key": "report-cache", "task_id": "task-1"}, None, False)
+
+    monkeypatch.setattr(
+        "plexus.cli.report.utils.resolve_account_id_for_command",
+        lambda _client, _account: "acct-1",
+    )
+    monkeypatch.setattr("plexus.cli.shared.client_utils.create_client", lambda: client)
+    monkeypatch.setattr("plexus.reports.service.run_block_cached", fake_run_block_cached)
+    monkeypatch.delenv("PLEXUS_DISPATCH_MODE", raising=False)
+
+    execute._default_report_runner(
+        {
+            "block_class": "FeedbackAlignment",
+            "cache_key": "report-cache",
+            "block_config": {
+                "scorecard": "Suco - Home Improvement",
+                "days": 30,
+                "memory_analysis": True,
+            },
+        }
+    )
+
+    assert captured["block_config"]["memory_analysis"] is True
+
+
 def test_default_report_runner_requires_account_context_without_null_key(monkeypatch) -> None:
     fake_client = SimpleNamespace(
         context=SimpleNamespace(account_id=None, account_key=None)
@@ -3214,6 +3278,7 @@ async def test_execute_tactus_report_run_async_returns_handle() -> None:
     assert result["ok"] is True
     assert result["value"]["kind"] == "report"
     assert result["value"]["id"] == "handle-1"
+    assert result["value"]["dispatch_result"]["task_id"] == "task-1"
     assert result["api_calls"] == ["plexus.report.run"]
     assert result["cost"]["tool_calls"] == 3
 

--- a/plexus/cli/procedure/builtin_procedures.py
+++ b/plexus/cli/procedure/builtin_procedures.py
@@ -26,7 +26,7 @@ def _procedures_root() -> Path:
 def _build_console_chat_config(tac_source: str) -> Dict[str, Any]:
     return {
         "name": "Console Chat Agent",
-        "version": "1.6.0",
+        "version": "1.6.2",
         "class": "Tactus",
         "description": "General-purpose Console chat procedure for /lab/console.",
         "params": {
@@ -77,6 +77,7 @@ def _build_console_chat_config(tac_source: str) -> Dict[str, Any]:
                     "- Do not use `plexus.procedure.optimize` to run a report; that starts an optimizer procedure only.\n"
                     "- Return and mention durable ids from report dispatch: task_id, report_id when present, and handle_id.\n"
                     "- For status follow-up, prefer durable task_id/report_id from recent conversation over in-memory handles.\n"
+                    "- For report `block_config.scorecard`, pass a resolved scorecard UUID. If the user gives a name or partial name, first call `plexus.scorecards.search`, choose the intended match, and use the returned `scorecard.id`; do not pass guessed names or display casing.\n"
                     "- Use bracket indexing for execute_tactus results, e.g. h[\"id\"], not h.id.\n\n"
                     "DOCUMENTATION (USE BEFORE ANSWERING \"HOW DOES X WORK?\" QUESTIONS):\n"
                     "  -- The agent knowledge base lives at `plexus.docs.*`. Always consult it\n"
@@ -111,9 +112,10 @@ def _build_console_chat_config(tac_source: str) -> Dict[str, Any]:
                     "  return plexus.feedback.alignment({ scorecard_name = \"My Scorecard\", score_name = \"My Score\", days = 30 })\n\n"
                     "WRITE / TRIGGER OPERATIONS:\n"
                     "  -- Run a persisted Feedback Alignment report for a whole scorecard (async):\n"
+                    "  -- If the user gave a scorecard name, first resolve it with `plexus.scorecards.search`, then use the returned scorecard.id below.\n"
                     "  local h = plexus.report.run({\n"
                     "    block_class = \"FeedbackAlignment\",\n"
-                    "    block_config = { scorecard = \"Suco - Home Improvement\", days = 30 },\n"
+                    "    block_config = { scorecard = \"<resolved-scorecard-uuid>\", days = 30, memory_analysis = false },\n"
                     "    cache_key = \"console-feedback-alignment:<unique>\",\n"
                     "    ttl_hours = 24,\n"
                     "    async = true,\n"

--- a/plexus/cli/procedure/test_builtin_procedures.py
+++ b/plexus/cli/procedure/test_builtin_procedures.py
@@ -62,6 +62,9 @@ def test_builtin_console_procedure_prompt_teaches_report_dispatch_contract():
     assert "REPORT REQUESTS (HARD RULES)" in system_prompt
     assert "plexus.report.run" in system_prompt
     assert "FeedbackAlignment" in system_prompt
+    assert "memory_analysis = false" in system_prompt
+    assert "pass a resolved scorecard UUID" in system_prompt
+    assert "use the returned `scorecard.id`" in system_prompt
     assert "task_id = h[\"dispatch_result\"]" in system_prompt
     assert "Do not use `plexus.feedback.alignment` to run a report" in system_prompt
     assert "Do not use `plexus.procedure.optimize` to run a report" in system_prompt
@@ -70,8 +73,8 @@ def test_builtin_console_procedure_prompt_teaches_report_dispatch_contract():
 def test_builtin_console_procedure_version_is_current():
     yaml_text = get_builtin_procedure_yaml(CONSOLE_CHAT_BUILTIN_ID)
     parsed = yaml.safe_load(yaml_text)
-    # Bumped when the prompt added the docs.* discovery guidance.
-    assert parsed["version"] == "1.6.0"
+    # Bumped when the report recipe changed to prefer resolved scorecard IDs.
+    assert parsed["version"] == "1.6.2"
 
 
 def test_is_builtin_procedure_id():

--- a/plexus/cli/shared/CommandTasks.py
+++ b/plexus/cli/shared/CommandTasks.py
@@ -37,6 +37,13 @@ def _should_append_task_id_arg(args: List[str]) -> bool:
     """Return whether a CLI command accepts the generic --task-id option."""
     if len(args) >= 2 and args[0] == "procedure" and args[1] == "run":
         return False
+    if (
+        len(args) >= 3
+        and args[0] == "feedback"
+        and args[1] == "report"
+        and args[2] == "run-programmatic-block"
+    ):
+        return False
     return True
 
 

--- a/plexus/cli/shared/command_tasks_test.py
+++ b/plexus/cli/shared/command_tasks_test.py
@@ -5,5 +5,14 @@ def test_should_not_append_task_id_to_procedure_run_command():
     assert _should_append_task_id_arg(["procedure", "run", "proc-1"]) is False
 
 
+def test_should_not_append_task_id_to_programmatic_report_block_command():
+    assert (
+        _should_append_task_id_arg(
+            ["feedback", "report", "run-programmatic-block", "--payload-base64", "abc123"]
+        )
+        is False
+    )
+
+
 def test_should_append_task_id_to_evaluation_command():
     assert _should_append_task_id_arg(["evaluate", "accuracy", "--scorecard", "Card"]) is True

--- a/plexus/reports/blocks/feedback_scope_resolver.py
+++ b/plexus/reports/blocks/feedback_scope_resolver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from plexus.dashboard.api.models.score import Score
 from plexus.dashboard.api.models.scorecard import Scorecard
@@ -18,7 +18,90 @@ class ResolvedScoreRef:
     external_id: Optional[str] = None
 
 
-async def resolve_scorecard(api_client, scorecard_identifier: str) -> Scorecard:
+def _casefold_identifier(value: str) -> str:
+    return str(value or "").strip().casefold()
+
+
+def _client_account_id(api_client: Any) -> Optional[str]:
+    context = getattr(api_client, "context", None)
+    account_id = getattr(context, "account_id", None)
+    if isinstance(account_id, str) and account_id.strip():
+        return account_id.strip()
+    account_key = getattr(context, "account_key", None)
+    if isinstance(account_key, str) and account_key.strip() and hasattr(api_client, "_resolve_account_id"):
+        try:
+            return str(api_client._resolve_account_id())
+        except Exception:
+            return None
+    return None
+
+
+async def _find_scorecard_by_case_insensitive_name(
+    api_client,
+    scorecard_name: str,
+    *,
+    account_id: Optional[str] = None,
+) -> Optional[Scorecard]:
+    normalized_name = _casefold_identifier(scorecard_name)
+    if not normalized_name:
+        return None
+
+    filter_arg = {}
+    scoped_account_id = account_id or _client_account_id(api_client)
+    if scoped_account_id:
+        filter_arg = {"accountId": {"eq": scoped_account_id}}
+
+    query = """
+    query ListScorecardsForCaseInsensitiveName(
+        $filter: ModelScorecardFilterInput
+        $limit: Int
+        $nextToken: String
+    ) {
+        listScorecards(filter: $filter, limit: $limit, nextToken: $nextToken) {
+            items {
+                id
+                name
+                key
+                externalId
+                accountId
+                description
+            }
+            nextToken
+        }
+    }
+    """
+    matches: List[Scorecard] = []
+    next_token = None
+    while True:
+        result = await asyncio.to_thread(
+            api_client.execute,
+            query,
+            {"filter": filter_arg or None, "limit": 1000, "nextToken": next_token},
+        )
+        page = result.get("listScorecards") or {}
+        for row in page.get("items") or []:
+            if _casefold_identifier(row.get("name")) == normalized_name:
+                matches.append(Scorecard.from_dict(row, api_client))
+        next_token = page.get("nextToken")
+        if not next_token:
+            break
+
+    if not matches:
+        return None
+    if len(matches) > 1:
+        match_ids = ", ".join(f"{match.name} ({match.id})" for match in matches)
+        raise ValueError(
+            f"Scorecard name '{scorecard_name}' matched multiple scorecards case-insensitively: {match_ids}."
+        )
+    return matches[0]
+
+
+async def resolve_scorecard(
+    api_client,
+    scorecard_identifier: str,
+    *,
+    account_id: Optional[str] = None,
+) -> Scorecard:
     scorecard = None
     if looks_like_uuid(scorecard_identifier):
         try:
@@ -41,6 +124,12 @@ async def resolve_scorecard(api_client, scorecard_identifier: str) -> Scorecard:
                     break
             except Exception:
                 continue
+    if not scorecard:
+        scorecard = await _find_scorecard_by_case_insensitive_name(
+            api_client,
+            scorecard_identifier,
+            account_id=account_id,
+        )
     if not scorecard:
         raise ValueError(f"Scorecard not found for identifier '{scorecard_identifier}'.")
     return scorecard

--- a/plexus/reports/blocks/feedback_scope_resolver_test.py
+++ b/plexus/reports/blocks/feedback_scope_resolver_test.py
@@ -29,6 +29,82 @@ async def test_resolve_scorecard_accepts_hyphenated_name():
 
 
 @pytest.mark.asyncio
+async def test_resolve_scorecard_accepts_case_insensitive_name_with_account_scope():
+    client = MagicMock()
+    client.execute.return_value = {
+        "listScorecards": {
+            "items": [
+                {
+                    "id": "sc-mel",
+                    "name": "Selectquote - MEL HRA v1.0",
+                    "key": "selectquote_mel_hra",
+                    "externalId": "1461",
+                    "accountId": "acct-1",
+                    "description": None,
+                }
+            ],
+            "nextToken": None,
+        }
+    }
+
+    with (
+        patch("plexus.reports.blocks.feedback_scope_resolver.Scorecard.get_by_key", side_effect=ValueError("missing")),
+        patch("plexus.reports.blocks.feedback_scope_resolver.Scorecard.get_by_name", side_effect=ValueError("missing")),
+        patch("plexus.reports.blocks.feedback_scope_resolver.Scorecard.get_by_external_id", side_effect=ValueError("missing")),
+    ):
+        resolved = await resolve_scorecard(
+            client,
+            "SelectQuote - MEL HRA v1.0",
+            account_id="acct-1",
+        )
+
+    assert resolved.id == "sc-mel"
+    assert resolved.name == "Selectquote - MEL HRA v1.0"
+    variables = client.execute.call_args.args[1]
+    assert variables["filter"] == {"accountId": {"eq": "acct-1"}}
+
+
+@pytest.mark.asyncio
+async def test_resolve_scorecard_rejects_ambiguous_case_insensitive_names():
+    client = MagicMock()
+    client.execute.return_value = {
+        "listScorecards": {
+            "items": [
+                {
+                    "id": "sc-1",
+                    "name": "Selectquote - MEL HRA v1.0",
+                    "key": "one",
+                    "externalId": "1",
+                    "accountId": "acct-1",
+                    "description": None,
+                },
+                {
+                    "id": "sc-2",
+                    "name": "SELECTQUOTE - MEL HRA V1.0",
+                    "key": "two",
+                    "externalId": "2",
+                    "accountId": "acct-1",
+                    "description": None,
+                },
+            ],
+            "nextToken": None,
+        }
+    }
+
+    with (
+        patch("plexus.reports.blocks.feedback_scope_resolver.Scorecard.get_by_key", side_effect=ValueError("missing")),
+        patch("plexus.reports.blocks.feedback_scope_resolver.Scorecard.get_by_name", side_effect=ValueError("missing")),
+        patch("plexus.reports.blocks.feedback_scope_resolver.Scorecard.get_by_external_id", side_effect=ValueError("missing")),
+    ):
+        with pytest.raises(ValueError, match="matched multiple scorecards"):
+            await resolve_scorecard(
+                client,
+                "SelectQuote - MEL HRA v1.0",
+                account_id="acct-1",
+            )
+
+
+@pytest.mark.asyncio
 async def test_resolve_score_for_scorecard_uuid_success():
     client = MagicMock()
     client.execute.return_value = {

--- a/plexus/reports/service.py
+++ b/plexus/reports/service.py
@@ -475,6 +475,12 @@ def _instantiate_and_run_block(
     block_display_name = block_def.get("block_name", class_name) # Use provided name or class name
 
     logger.info(f"Instantiating block: {class_name} with config: {block_config}")
+    report_account_id = (report_params or {}).get("account_id")
+    if report_account_id:
+        try:
+            api_client.context.account_id = str(report_account_id)
+        except Exception:
+            logger.debug("Unable to apply report account context to API client", exc_info=True)
 
     if class_name not in BLOCK_CLASSES:
         error_msg = f"Block class '{class_name}' not found or not registered. Available: {list(BLOCK_CLASSES.keys())}"
@@ -1098,6 +1104,10 @@ def run_programmatic_block_and_persist(
         report_params=report_params,
         api_client=client,
     )
+    block_failed = output_data is None or (
+        isinstance(output_data, dict)
+        and bool(output_data.get("error"))
+    )
     failure_output = (
         output_data
         if output_data is not None
@@ -1112,7 +1122,7 @@ def run_programmatic_block_and_persist(
     )
     error_message = (
         _summarize_error_message(failure_output, f"Block {block_class} failed.")
-        if output_data is None
+        if block_failed
         else None
     )
 
@@ -1125,7 +1135,7 @@ def run_programmatic_block_and_persist(
             log_output,
             account_id,
             client,
-            success=output_data is not None,
+            success=not block_failed,
             error_message=error_message,
         )
     except Exception as exc:
@@ -1133,8 +1143,8 @@ def run_programmatic_block_and_persist(
         if persist_required:
             raise
 
-    if output_data is None:
-        return None, log_output
+    if block_failed:
+        return None, log_output or error_message
 
     return output_data, log_output
 

--- a/plexus/reports/test_programmatic_report_tasks.py
+++ b/plexus/reports/test_programmatic_report_tasks.py
@@ -232,3 +232,32 @@ def test_run_programmatic_block_and_persist_uses_concise_failure_message(
         mock_persist_block_result.call_args.kwargs["error_message"]
         == "Error running block FeedbackContradictions (FeedbackContradictions): Score not found"
     )
+
+
+@patch("plexus.reports.service._persist_block_result")
+@patch("plexus.reports.service._instantiate_and_run_block")
+def test_run_programmatic_block_and_persist_treats_error_payload_as_failure(
+    mock_instantiate_and_run_block,
+    mock_persist_block_result,
+):
+    mock_instantiate_and_run_block.return_value = (
+        {"error": "Scorecard not found for identifier 'SelectQuote'.", "scores": []},
+        "Scorecard not found for identifier 'SelectQuote'.",
+        None,
+    )
+
+    output, log_output = run_programmatic_block_and_persist(
+        cache_key="cache-key",
+        block_class="FeedbackAlignment",
+        block_config={"scorecard": "SelectQuote"},
+        account_id="acct-1",
+        client=MagicMock(),
+    )
+
+    assert output is None
+    assert "Scorecard not found" in log_output
+    assert mock_persist_block_result.call_args.kwargs["success"] is False
+    assert (
+        mock_persist_block_result.call_args.kwargs["error_message"]
+        == "Scorecard not found for identifier 'SelectQuote'."
+    )

--- a/project/events/2026-05-07T12:15:00.845Z__231a0159-96e2-4b44-8902-41415c7ce68b.json
+++ b/project/events/2026-05-07T12:15:00.845Z__231a0159-96e2-4b44-8902-41415c7ce68b.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "231a0159-96e2-4b44-8902-41415c7ce68b",
+  "issue_id": "plx-55a63c67-5265-46b9-abb9-7f8a400a82b4",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T12:15:00.845Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 0,
+    "status": "open",
+    "title": "Fix Console execute_tactus report dispatch IDs"
+  }
+}

--- a/project/events/2026-05-07T12:15:03.426Z__35743c4a-264f-43ff-a508-8b582833cf59.json
+++ b/project/events/2026-05-07T12:15:03.426Z__35743c4a-264f-43ff-a508-8b582833cf59.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "35743c4a-264f-43ff-a508-8b582833cf59",
+  "issue_id": "plx-55a63c67-5265-46b9-abb9-7f8a400a82b4",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T12:15:03.426Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T12:15:03.426Z__a08ed150-d6fb-4dca-b7e2-d020309070b9.json
+++ b/project/events/2026-05-07T12:15:03.426Z__a08ed150-d6fb-4dca-b7e2-d020309070b9.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "a08ed150-d6fb-4dca-b7e2-d020309070b9",
+  "issue_id": "plx-55a63c67-5265-46b9-abb9-7f8a400a82b4",
+  "event_type": "field_updated",
+  "occurred_at": "2026-05-07T12:15:03.426Z",
+  "actor_id": "ryan",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "",
+        "to": "Console report dispatch must return durable task/report identifiers and command worker must run programmatic report block commands without unsupported generic --task-id."
+      }
+    }
+  }
+}

--- a/project/events/2026-05-07T13:15:30.591Z__aec9a974-ed40-4aa8-8e91-b8d6fd8a621e.json
+++ b/project/events/2026-05-07T13:15:30.591Z__aec9a974-ed40-4aa8-8e91-b8d6fd8a621e.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "aec9a974-ed40-4aa8-8e91-b8d6fd8a621e",
+  "issue_id": "plx-4c85985c-acba-4c77-a4e1-ca80b7dad7c4",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T13:15:30.591Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "FeedbackAlignment reports currently require exact scorecard identifiers in block_config.scorecard. In production Console testing, the agent found scorecard 'Selectquote - MEL HRA v1.0' via search but then passed display casing as 'SelectQuote - MEL HRA v1.0', causing persisted reports whose ReportBlock preview only said 'Scorecard not found'. Follow-up: make the report block scorecard resolver more tolerant and consistent with scorecard search results, preferably accepting UUID/key/externalId and reasonable exact-name casing variants through one resolver path. Do not add broad fallback behavior; define one canonical resolution path and test it.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 2,
+    "status": "open",
+    "title": "Make FeedbackAlignment report scorecard lookup tolerant"
+  }
+}

--- a/project/events/2026-05-07T13:15:45.225Z__4919c501-4b11-4e40-834a-411396d1a3d7.json
+++ b/project/events/2026-05-07T13:15:45.225Z__4919c501-4b11-4e40-834a-411396d1a3d7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4919c501-4b11-4e40-834a-411396d1a3d7",
+  "issue_id": "plx-55a63c67-5265-46b9-abb9-7f8a400a82b4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T13:15:45.225Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "62702c33-3280-4f86-b1f3-1427563d8ca0"
+  }
+}

--- a/project/events/2026-05-07T13:15:55.057Z__0e5741a5-6811-444a-bc5c-8245e0aab056.json
+++ b/project/events/2026-05-07T13:15:55.057Z__0e5741a5-6811-444a-bc5c-8245e0aab056.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0e5741a5-6811-444a-bc5c-8245e0aab056",
+  "issue_id": "plx-4c85985c-acba-4c77-a4e1-ca80b7dad7c4",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T13:15:55.057Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T13:20:41.950Z__e8e03fd2-dea3-4b70-b134-96de408c1b91.json
+++ b/project/events/2026-05-07T13:20:41.950Z__e8e03fd2-dea3-4b70-b134-96de408c1b91.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e8e03fd2-dea3-4b70-b134-96de408c1b91",
+  "issue_id": "plx-4c85985c-acba-4c77-a4e1-ca80b7dad7c4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T13:20:41.950Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "c15a5ae3-8614-476d-94e8-1c11511be028"
+  }
+}

--- a/project/events/2026-05-07T13:20:41.969Z__99302ffe-dcc1-4943-a6e0-6517cabff678.json
+++ b/project/events/2026-05-07T13:20:41.969Z__99302ffe-dcc1-4943-a6e0-6517cabff678.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "99302ffe-dcc1-4943-a6e0-6517cabff678",
+  "issue_id": "plx-55a63c67-5265-46b9-abb9-7f8a400a82b4",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T13:20:41.969Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "ff432ddd-495a-4fcc-9b3d-cf91096bdb44"
+  }
+}

--- a/project/issues/plx-4c85985c-acba-4c77-a4e1-ca80b7dad7c4.json
+++ b/project/issues/plx-4c85985c-acba-4c77-a4e1-ca80b7dad7c4.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-4c85985c-acba-4c77-a4e1-ca80b7dad7c4",
+  "title": "Make FeedbackAlignment report scorecard lookup tolerant",
+  "description": "FeedbackAlignment reports currently require exact scorecard identifiers in block_config.scorecard. In production Console testing, the agent found scorecard 'Selectquote - MEL HRA v1.0' via search but then passed display casing as 'SelectQuote - MEL HRA v1.0', causing persisted reports whose ReportBlock preview only said 'Scorecard not found'. Follow-up: make the report block scorecard resolver more tolerant and consistent with scorecard search results, preferably accepting UUID/key/externalId and reasonable exact-name casing variants through one resolver path. Do not add broad fallback behavior; define one canonical resolution path and test it.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "c15a5ae3-8614-476d-94e8-1c11511be028",
+      "author": "ryan",
+      "text": "Implemented the narrow version now: scorecard name resolution keeps exact ID/key/name/externalId lookup first, then performs an account-scoped case-insensitive name match. Added tests for successful case-insensitive match and ambiguous duplicate protection. Real smoke against production data resolved 'SelectQuote - MEL HRA v1.0' to 'Selectquote - MEL HRA v1.0' and persisted a FeedbackAlignment report.",
+      "created_at": "2026-05-07T13:20:41.950781Z"
+    }
+  ],
+  "created_at": "2026-05-07T13:15:30.590937Z",
+  "updated_at": "2026-05-07T13:20:41.950781Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-55a63c67-5265-46b9-abb9-7f8a400a82b4.json
+++ b/project/issues/plx-55a63c67-5265-46b9-abb9-7f8a400a82b4.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-55a63c67-5265-46b9-abb9-7f8a400a82b4",
+  "title": "Fix Console execute_tactus report dispatch IDs",
+  "description": "Console report dispatch must return durable task/report identifiers and command worker must run programmatic report block commands without unsupported generic --task-id.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 0,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "62702c33-3280-4f86-b1f3-1427563d8ca0",
+      "author": "ryan",
+      "text": "Production Console session 13f2722d showed report dispatch is now reaching execute_tactus and creating ProgrammaticReportBlock tasks. The first two FeedbackAlignment tasks completed as persisted error reports due exact scorecard identifier mismatch. The ID-based tasks dispatched but omitted memory_analysis=false and entered the slow memory-analysis path. A patched no-memory smoke completed, but execute_tactus spent about 157s in Lambda before creating the durable task, so next focus is keeping async report dispatch lightweight before it touches report execution imports/cache scans.",
+      "created_at": "2026-05-07T13:15:45.224580Z"
+    },
+    {
+      "id": "ff432ddd-495a-4fcc-9b3d-cf91096bdb44",
+      "author": "ryan",
+      "text": "Also tightened Console report instructions to resolve scorecards before report dispatch and pass scorecard UUIDs in block_config.scorecard. Programmatic report persistence now treats top-level block error payloads as failed report-block results so parameter errors are visible as failures instead of ok/error-preview reports.",
+      "created_at": "2026-05-07T13:20:41.969613Z"
+    }
+  ],
+  "created_at": "2026-05-07T12:15:00.844478Z",
+  "updated_at": "2026-05-07T13:20:41.969613Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- return durable dispatch_result/task IDs from execute_tactus report handles
- avoid unsupported --task-id injection for programmatic report block worker commands
- default FeedbackAlignment report dispatch to memory_analysis=false
- teach Console report requests to resolve scorecards and pass scorecard UUIDs
- make FeedbackAlignment scorecard name resolution case-insensitive after exact lookup fails
- persist top-level report-block error payloads as failed results instead of ok/error-preview reports

## Tests
- /Users/ryan/miniconda3/bin/python -m pytest plexus/cli/shared/command_tasks_test.py plexus/cli/procedure/test_builtin_procedures.py::test_builtin_console_procedure_prompt_teaches_report_dispatch_contract plexus/cli/procedure/test_builtin_procedures.py::test_builtin_console_procedure_version_is_current MCP/tools/tactus_runtime/execute_test.py::test_execute_tactus_report_run_async_returns_handle MCP/tools/tactus_runtime/execute_test.py::test_execute_tactus_report_run_async_remote_dispatch_when_mode_celery MCP/tools/tactus_runtime/execute_test.py::test_default_report_runner_disables_feedback_alignment_memory_by_default MCP/tools/tactus_runtime/execute_test.py::test_default_report_runner_preserves_explicit_feedback_alignment_memory plexus/reports/blocks/feedback_scope_resolver_test.py plexus/reports/test_programmatic_report_tasks.py plexus/reports/tests/test_service_output_compaction.py -q
- Real smoke: FeedbackAlignment with scorecard `SelectQuote - MEL HRA v1.0`, days=1, memory_analysis=false resolved and persisted a report successfully

## Kanbus
- plx-55a63c
- plx-4c8598