### PR TITLE
Promote Console prediction execute_tactus contract

### DIFF
--- a/MCP/README.md
+++ b/MCP/README.md
@@ -47,8 +47,8 @@ Run a local prediction:
 
 ```lua
 return plexus.score.predict{
-  scorecard_name = "Quality Assurance v1.0",
-  score_name = "Compliance Check",
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
   item_id = "item-123",
   yaml = true,
 }

--- a/MCP/plexus_fastmcp_server.py
+++ b/MCP/plexus_fastmcp_server.py
@@ -412,9 +412,9 @@ mcp = FastMCP(
     Predict on an item:
     ```
     return plexus.score.predict({
-      scorecard_name = "My Scorecard",
-      score_name     = "My Score",
-      item_id        = "abc-123"
+      scorecard_identifier = "My Scorecard",
+      score_identifier     = "My Score",
+      item_id              = "abc-123"
     })
     ```
 

--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -1760,10 +1760,12 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
             return [_sanitize_dec(v) for v in obj]
         return obj
 
-    scorecard_name = args.get("scorecard_name") or args.get("scorecard")
-    score_name = args.get("score_name") or args.get("score")
-    if not scorecard_name or not score_name:
-        raise ValueError("plexus.score.predict requires scorecard_name and score_name")
+    scorecard_identifier = args.get("scorecard_identifier")
+    score_identifier = args.get("score_identifier")
+    if not scorecard_identifier or not score_identifier:
+        raise ValueError(
+            "plexus.score.predict requires scorecard_identifier and score_identifier"
+        )
 
     item_id = args.get("item_id") or args.get("id") or args.get("item")
     item_ids_raw = args.get("item_ids")
@@ -1783,17 +1785,22 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
     client = create_client()
     if not client:
         raise RuntimeError("plexus.score.predict: could not create dashboard client")
+    account_id = None if yaml_mode else _resolve_runtime_account_id(
+        client, args, "plexus.score.predict"
+    )
 
     if yaml_mode:
         scorecard_id = "yaml-mode-scorecard"
-        resolved_score: dict[str, Any] = {"id": "yaml-mode-score", "name": str(score_name),
-                                           "key": str(score_name).lower().replace(" ", "-"),
+        resolved_score: dict[str, Any] = {"id": "yaml-mode-score", "name": str(score_identifier),
+                                           "key": str(score_identifier).lower().replace(" ", "-"),
                                            "championVersionId": "yaml-mode-version"}
     else:
-        scorecard_id_resolved = resolve_scorecard_identifier(client, str(scorecard_name))
+        scorecard_id_resolved = resolve_scorecard_identifier(
+            client, str(scorecard_identifier)
+        )
         if not scorecard_id_resolved:
             raise ValueError(
-                f"plexus.score.predict: scorecard {scorecard_name!r} not found"
+                f"plexus.score.predict: scorecard {scorecard_identifier!r} not found"
             )
         scorecard_id = scorecard_id_resolved
         sc_result = client.execute(
@@ -1809,14 +1816,14 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
         scorecard_data = sc_result.get("getScorecard")
         if not scorecard_data:
             raise ValueError(
-                f"plexus.score.predict: could not load scorecard {scorecard_name!r}"
+                f"plexus.score.predict: could not load scorecard {scorecard_identifier!r}"
             )
 
         try:
             from plexus.cli.shared.identifier_resolution import (
                 resolve_score_identifier as _rsi,
             )
-            resolved_score_id = _rsi(client, scorecard_id, str(score_name))
+            resolved_score_id = _rsi(client, scorecard_id, str(score_identifier))
         except Exception:
             resolved_score_id = None
 
@@ -1825,10 +1832,10 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
             for sc in section.get("scores", {}).get("items", []):
                 if (
                     (resolved_score_id and sc.get("id") == resolved_score_id)
-                    or sc.get("id") == str(score_name)
-                    or sc.get("externalId") == str(score_name)
-                    or sc.get("key") == str(score_name)
-                    or sc.get("name") == str(score_name)
+                    or sc.get("id") == str(score_identifier)
+                    or sc.get("externalId") == str(score_identifier)
+                    or sc.get("key") == str(score_identifier)
+                    or sc.get("name") == str(score_identifier)
                 ):
                     resolved_score = sc
                     break
@@ -1836,8 +1843,8 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
                 break
         if not resolved_score:
             raise ValueError(
-                f"plexus.score.predict: score {score_name!r} not found in "
-                f"scorecard {scorecard_name!r}"
+                f"plexus.score.predict: score {score_identifier!r} not found in "
+                f"scorecard {scorecard_identifier!r}"
             )
 
     resolved_version = version if not latest else None
@@ -1857,20 +1864,9 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
 
     if not yaml_mode:
         try:
-            import os as _os
             from plexus.cli.shared.identifier_resolution import (
                 resolve_item_identifier as _rii,
             )
-            from plexus.dashboard.api.models.account import Account as _Account
-            account_id = None
-            try:
-                ak = _os.getenv("PLEXUS_ACCOUNT_KEY")
-                if ak:
-                    acc = _Account.list_by_key(key=ak, client=client)
-                    if acc:
-                        account_id = acc.id
-            except Exception:
-                pass
             resolved_ids = []
             for raw_id in target_item_ids:
                 try:
@@ -1887,27 +1883,29 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
         from plexus.scores.Scorecard import Scorecard
         with open(yaml_path, "r") as f:
             sc_cfg = _yaml.safe_load(f.read())
-        scorecard_instance = Scorecard({"name": scorecard_name, "sections": [{"name": "Custom", "scores": [sc_cfg]}]})
+        scorecard_instance = Scorecard({"name": scorecard_identifier, "sections": [{"name": "Custom", "scores": [sc_cfg]}]})
         scorecard_instance.yaml_only = True
     elif yaml_mode:
         from plexus.cli.evaluation.evaluations import load_scorecard_from_yaml_files
-        scorecard_instance = load_scorecard_from_yaml_files(str(scorecard_name), score_names=[str(score_name)])
+        scorecard_instance = load_scorecard_from_yaml_files(
+            str(scorecard_identifier), score_names=[str(score_identifier)]
+        )
         scorecard_instance.yaml_only = True
     else:
         from plexus.cli.evaluation.evaluations import load_scorecard_from_api
         scorecard_instance = load_scorecard_from_api(
-            str(scorecard_name), score_names=[str(score_name)],
+            str(scorecard_identifier), score_names=[str(score_identifier)],
             use_cache=not no_cache, specific_version=resolved_version
         )
 
-    resolved_score_name = str(score_name)
+    resolved_score_name = str(score_identifier)
     if hasattr(scorecard_instance, "scores") and isinstance(scorecard_instance.scores, list):
         for s in scorecard_instance.scores:
             sn = s.get("name")
             if sn and (
-                sn == str(score_name) or str(s.get("id", "")) == str(score_name)
-                or str(s.get("key", "")) == str(score_name)
-                or str(s.get("externalId", "")) == str(score_name)
+                sn == str(score_identifier) or str(s.get("id", "")) == str(score_identifier)
+                or str(s.get("key", "")) == str(score_identifier)
+                or str(s.get("externalId", "")) == str(score_identifier)
             ):
                 resolved_score_name = sn
                 break
@@ -1962,7 +1960,7 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
 
                 if score_result_obj is None:
                     if results and any(isinstance(v, Score.Result) and v.value == "SKIPPED" for v in results.values()):
-                        return {"item_id": target_id, "scores": [{"name": score_name, "value": None,
+                        return {"item_id": target_id, "scores": [{"name": score_identifier, "value": None,
                                 "explanation": "Not applicable — unmet dependency conditions", "cost": {}}]}
                     return {"item_id": target_id, "error": f"No result for score {resolved_score_name!r}"}
 
@@ -1977,7 +1975,7 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
                     costs = score_result_obj.metadata.get("cost", {})
 
                 prediction_result: dict = {"item_id": target_id, "scores": [{
-                    "name": score_name, "value": score_result_obj.value,
+                    "name": score_identifier, "value": score_result_obj.value,
                     "explanation": explanation, "cost": costs
                 }]}
                 if include_trace:
@@ -1987,7 +1985,7 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
                     prediction_result["scores"][0]["trace"] = trace
             except Exception as exc:
                 prediction_result = {"item_id": target_id, "scores": [{
-                    "name": score_name, "value": "ERROR",
+                    "name": score_identifier, "value": "ERROR",
                     "explanation": f"Prediction failed: {exc}",
                     "error_details": {"error_message": str(exc), "error_type": type(exc).__name__,
                                       "traceback": _traceback.format_exc()},
@@ -2009,8 +2007,8 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
     prediction_results_list = _run_async_from_sync(_gather_all())
     return _sanitize_dec({
         "success": True,
-        "scorecard_name": scorecard_name,
-        "score_name": score_name,
+        "scorecard_identifier": scorecard_identifier,
+        "score_identifier": score_identifier,
         "scorecard_id": scorecard_id,
         "score_id": resolved_score["id"],
         "item_count": len(target_item_ids),
@@ -6469,7 +6467,11 @@ return item{ id = "item_1007" }
 
 4) Run a single prediction:
 ```tactus
-return predict{ score_id = "score_compliance_tone", item_id = "item_1007" }
+return predict{
+  scorecard_identifier = "My Scorecard",
+  score_identifier = "Compliance Tone",
+  item_id = "item_1007",
+}
 ```
 
 5) Run a bounded synchronous evaluation:

--- a/MCP/tools/tactus_runtime/execute_test.py
+++ b/MCP/tools/tactus_runtime/execute_test.py
@@ -959,6 +959,9 @@ async def test_execute_tactus_tool_description_contains_curated_examples() -> No
         "Human.approve",
     ):
         assert term in description, f"description missing curated term: {term!r}"
+    assert "scorecard_identifier = \"My Scorecard\"" in description
+    assert "score_identifier = \"Compliance Tone\"" in description
+    assert "predict{ score_id" not in description
 
 
 def test_execute_tactus_description_constant_includes_themed_doc_pointers() -> None:
@@ -1278,6 +1281,216 @@ async def test_execute_tactus_runs_canonical_helper_call_through_host_module() -
     }
     assert result["ok"] is True
     assert result["api_calls"] == ["plexus.score.info"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tactus_score_predict_uses_canonical_identifiers(
+    monkeypatch,
+) -> None:
+    mcp = FastMCP("test-execute-tactus-predict-canonical")
+    seen: dict[str, Any] = {}
+
+    def fake_score_predict(args):
+        seen.update(args)
+        return {"success": True, "predictions": [{"item_id": args["item_id"]}]}
+
+    monkeypatch.setattr(execute, "_default_score_predict", fake_score_predict)
+
+    result = await execute._execute_tactus_tool(
+        (
+            'return plexus.score.predict({ scorecard_identifier = "card", '
+            'score_identifier = "score", item_id = "item-1" })'
+        ),
+        mcp,
+        runtime_context={"account_id": "acct-console"},
+    )
+
+    assert result["ok"] is True
+    assert result["value"] == {
+        "success": True,
+        "predictions": [{"item_id": "item-1"}],
+    }
+    assert result["api_calls"] == ["plexus.score.predict"]
+    assert seen["scorecard_identifier"] == "card"
+    assert seen["score_identifier"] == "score"
+    assert seen["item_id"] == "item-1"
+    assert seen["account_id"] == "acct-console"
+
+
+def test_default_score_predict_requires_canonical_identifier_fields() -> None:
+    with pytest.raises(
+        ValueError,
+        match="scorecard_identifier and score_identifier",
+    ):
+        execute._default_score_predict({"item_id": "item-1"})
+
+    with pytest.raises(
+        ValueError,
+        match="scorecard_identifier and score_identifier",
+    ):
+        execute._default_score_predict(
+            {"scorecard": "card", "score": "score", "item_id": "item-1"}
+        )
+
+
+def test_default_score_predict_requires_account_context(monkeypatch) -> None:
+    fake_client = SimpleNamespace(
+        context=SimpleNamespace(account_id=None, account_key=None)
+    )
+
+    monkeypatch.setattr(
+        "plexus.cli.shared.client_utils.create_client", lambda: fake_client
+    )
+    monkeypatch.setattr(
+        "plexus.cli.report.utils.resolve_account_id_for_command",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("default account resolver should not run")
+        ),
+    )
+
+    with pytest.raises(execute.AccountContextRequired, match="requires account context"):
+        execute._default_score_predict(
+            {
+                "scorecard_identifier": "card",
+                "score_identifier": "score",
+                "item_id": "external-item",
+            }
+        )
+
+
+def test_default_score_predict_uses_account_context_for_item_resolution(
+    monkeypatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        def __init__(self):
+            self.context = SimpleNamespace(account_id=None, account_key=None)
+
+        def execute(self, query):
+            if "getScorecard" in query:
+                return {
+                    "getScorecard": {
+                        "id": "sc-id",
+                        "name": "PolicyPoint - Non-Sales",
+                        "sections": {
+                            "items": [
+                                {
+                                    "id": "section-1",
+                                    "scores": {
+                                        "items": [
+                                            {
+                                                "id": "score-id",
+                                                "name": "Acknowledges Before Redirecting",
+                                                "key": "acknowledges-before-redirecting",
+                                                "externalId": "48849",
+                                                "championVersionId": "version-1",
+                                                "isDisabled": False,
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            if "getItem" in query:
+                return {
+                    "getItem": {
+                        "id": "item-internal",
+                        "text": "hello",
+                        "description": "",
+                        "metadata": {},
+                        "attachedFiles": None,
+                        "externalId": "311432364",
+                        "createdAt": "2026-05-07T00:00:00Z",
+                        "updatedAt": "2026-05-07T00:00:00Z",
+                    }
+                }
+            raise AssertionError(query)
+
+    class FakeScorecard:
+        scores = [
+            {
+                "id": "score-id",
+                "name": "Acknowledges Before Redirecting",
+                "key": "acknowledges-before-redirecting",
+                "externalId": "48849",
+            }
+        ]
+
+        def build_dependency_graph(self, names):
+            captured["dependency_names"] = names
+            return {}, {"Acknowledges Before Redirecting": "score-id"}
+
+        async def score_entire_text(self, **kwargs):
+            captured["score_kwargs"] = kwargs
+            return {
+                "score-id": SimpleNamespace(
+                    value="No",
+                    explanation="prediction explanation",
+                    cost={},
+                    metadata={},
+                )
+            }
+
+    fake_client = FakeClient()
+
+    monkeypatch.setattr(
+        "plexus.cli.shared.client_utils.create_client", lambda: fake_client
+    )
+    monkeypatch.setattr(
+        "plexus.cli.scorecard.scorecards.resolve_scorecard_identifier",
+        lambda client, identifier: f"sc:{identifier}",
+    )
+    monkeypatch.setattr(
+        "plexus.cli.shared.identifier_resolution.resolve_score_identifier",
+        lambda client, scorecard_id, identifier: f"score:{identifier}",
+    )
+
+    def fake_resolve_item_identifier(client, identifier, account_id=None):
+        captured["item_resolution"] = {
+            "identifier": identifier,
+            "account_id": account_id,
+        }
+        return "item-internal"
+
+    monkeypatch.setattr(
+        "plexus.cli.shared.identifier_resolution.resolve_item_identifier",
+        fake_resolve_item_identifier,
+    )
+    monkeypatch.setattr(
+        "plexus.cli.evaluation.evaluations.load_scorecard_from_api",
+        lambda *args, **kwargs: FakeScorecard(),
+    )
+    monkeypatch.setattr(
+        "plexus.dashboard.api.models.item.Item.from_dict",
+        lambda item_data, client: SimpleNamespace(id=item_data["id"]),
+    )
+
+    result = execute._default_score_predict(
+        {
+            "scorecard_identifier": "PolicyPoint - Non-Sales",
+            "score_identifier": "48849",
+            "item_id": "311432364",
+            "account_id": "acct-console",
+        }
+    )
+
+    assert fake_client.context.account_id == "acct-console"
+    assert captured["item_resolution"] == {
+        "identifier": "311432364",
+        "account_id": "acct-console",
+    }
+    assert captured["dependency_names"] == ["Acknowledges Before Redirecting"]
+    assert captured["score_kwargs"]["subset_of_score_names"] == [
+        "Acknowledges Before Redirecting"
+    ]
+    assert result["success"] is True
+    assert result["scorecard_identifier"] == "PolicyPoint - Non-Sales"
+    assert result["score_identifier"] == "48849"
+    assert result["predictions"][0]["item_id"] == "item-internal"
+    assert result["predictions"][0]["scores"][0]["value"] == "No"
 
 
 @pytest.mark.asyncio
@@ -2009,6 +2222,11 @@ def test_evaluation_run_async_creates_handle_and_records_budget() -> None:
         "status_url": "https://example.test/evaluations/eval-1",
         "created_at": "2026-04-29T00:00:00Z",
         "parent_trace_id": "trace-1",
+        "dispatch_result": {
+            "status": "dispatched",
+            "evaluation_id": "eval-1",
+            "dashboard_url": "https://example.test/evaluations/eval-1",
+        },
         "child_budget": budget,
     }
     assert seen_args == {

--- a/documentation/agent/evaluation-feedback/evaluation-alignment.md
+++ b/documentation/agent/evaluation-feedback/evaluation-alignment.md
@@ -358,8 +358,8 @@ Test specific items using local YAML to validate behavior:
 ```lua
 # ✅ Test single item with local YAML
 return plexus.score.predict{
-  scorecard_name = "Quality Assurance v1.0",
-  score_name = "Compliance Check",
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
   item_id = "88ed6e27-b5ae-4641-b024-d47f4c6ba631",
   yaml = true,          -- REQUIRED: Use local YAML
   include_input = true,
@@ -369,8 +369,8 @@ return plexus.score.predict{
 
 # ✅ Test multiple items with local YAML
 return plexus.score.predict{
-  scorecard_name = "Quality Assurance v1.0",
-  score_name = "Compliance Check",
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
   item_ids = "item1,item2,item3",
   yaml = true, -- REQUIRED: Use local YAML
   output_format = "yaml",

--- a/documentation/agent/evaluation-feedback/feedback-alignment.md
+++ b/documentation/agent/evaluation-feedback/feedback-alignment.md
@@ -117,8 +117,8 @@ Test current configuration on items with known ground-truth:
 
 ```lua
 return plexus.score.predict{
-  scorecard_name = "Quality Assurance v1.0",
-  score_name = "Compliance Check",
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
   item_id = "88ed6e27-b5ae-4641-b024-d47f4c6ba631",
   output_format = "yaml",
   include_input = true,
@@ -130,8 +130,8 @@ Test multiple related items:
 
 ```lua
 return plexus.score.predict{
-  scorecard_name = "Quality Assurance v1.0",
-  score_name = "Compliance Check",
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
   item_ids = "item1,item2,item3,item4,item5",
   output_format = "yaml",
   yaml = true, -- LOCAL YAML ONLY
@@ -149,8 +149,8 @@ Test configuration changes:
 
 ```lua
 return plexus.score.predict{
-  scorecard_name = "Quality Assurance v1.0",
-  score_name = "Compliance Check",
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
   item_ids = "known_problematic_items",
   output_format = "yaml",
   yaml = true,
@@ -232,8 +232,8 @@ return plexus.evaluation.run{
 ### 4. Testing (LOCAL ONLY)
 ```lua
 return plexus.score.predict{
-  scorecard_name = "Quality Assurance v1.0",
-  score_name = "Compliance Check",
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
   item_ids = "problematic_item_ids_from_feedback",
   output_format = "yaml",
   include_input = true,
@@ -249,8 +249,8 @@ return plexus.score.predict{
 ### 6. Validation (LOCAL ONLY)
 ```lua
 return plexus.score.predict{
-  scorecard_name = "Quality Assurance v1.0",
-  score_name = "Compliance Check",
+  scorecard_identifier = "Quality Assurance v1.0",
+  score_identifier = "Compliance Check",
   item_ids = "same_test_items",
   output_format = "yaml",
   yaml = true,

--- a/plexus/cli/procedure/builtin_procedures.py
+++ b/plexus/cli/procedure/builtin_procedures.py
@@ -26,7 +26,7 @@ def _procedures_root() -> Path:
 def _build_console_chat_config(tac_source: str) -> Dict[str, Any]:
     return {
         "name": "Console Chat Agent",
-        "version": "1.6.2",
+        "version": "1.6.3",
         "class": "Tactus",
         "description": "General-purpose Console chat procedure for /lab/console.",
         "params": {
@@ -79,6 +79,14 @@ def _build_console_chat_config(tac_source: str) -> Dict[str, Any]:
                     "- For status follow-up, prefer durable task_id/report_id from recent conversation over in-memory handles.\n"
                     "- For report `block_config.scorecard`, pass a resolved scorecard UUID. If the user gives a name or partial name, first call `plexus.scorecards.search`, choose the intended match, and use the returned `scorecard.id`; do not pass guessed names or display casing.\n"
                     "- Use bracket indexing for execute_tactus results, e.g. h[\"id\"], not h.id.\n\n"
+                    "PREDICTION REQUESTS (HARD RULES):\n"
+                    "- When the user asks to run a prediction on an item, use `plexus.score.predict`.\n"
+                    "- Do not use report or evaluation APIs for a single-item prediction.\n"
+                    "- Use prior turns for continuity: if the conversation already contains the item, score, and scorecard, run the prediction immediately.\n"
+                    "- If the user provides numeric scorecard or score references, resolve them first with `plexus.scorecards.info` and `plexus.score.info` as needed.\n"
+                    "- Once item_id, scorecard_identifier, and score_identifier are known, do not ask for another confirmation.\n"
+                    "- Canonical prediction call:\n"
+                    "  return plexus.score.predict({ scorecard_identifier = \"My Scorecard\", score_identifier = \"My Score\", item_id = \"item-or-external-id\" })\n\n"
                     "DOCUMENTATION (USE BEFORE ANSWERING \"HOW DOES X WORK?\" QUESTIONS):\n"
                     "  -- The agent knowledge base lives at `plexus.docs.*`. Always consult it\n"
                     "  -- before explaining Plexus runtime behavior, YAML formats, or workflows.\n"

--- a/plexus/cli/procedure/test_builtin_procedures.py
+++ b/plexus/cli/procedure/test_builtin_procedures.py
@@ -70,11 +70,24 @@ def test_builtin_console_procedure_prompt_teaches_report_dispatch_contract():
     assert "Do not use `plexus.procedure.optimize` to run a report" in system_prompt
 
 
+def test_builtin_console_procedure_prompt_teaches_prediction_contract():
+    yaml_text = get_builtin_procedure_yaml(CONSOLE_CHAT_BUILTIN_ID)
+    parsed = yaml.safe_load(yaml_text)
+    system_prompt = parsed["agents"]["assistant"]["system_prompt"]
+
+    assert "PREDICTION REQUESTS (HARD RULES)" in system_prompt
+    assert "use `plexus.score.predict`" in system_prompt
+    assert "Do not use report or evaluation APIs for a single-item prediction" in system_prompt
+    assert "scorecard_identifier = \"My Scorecard\"" in system_prompt
+    assert "score_identifier = \"My Score\"" in system_prompt
+    assert "do not ask for another confirmation" in system_prompt
+
+
 def test_builtin_console_procedure_version_is_current():
     yaml_text = get_builtin_procedure_yaml(CONSOLE_CHAT_BUILTIN_ID)
     parsed = yaml.safe_load(yaml_text)
-    # Bumped when the report recipe changed to prefer resolved scorecard IDs.
-    assert parsed["version"] == "1.6.2"
+    # Bumped when the prediction contract changed to canonical identifiers.
+    assert parsed["version"] == "1.6.3"
 
 
 def test_is_builtin_procedure_id():

--- a/project/events/2026-05-07T16:06:34.386Z__a68ecc7f-0f11-4212-970c-78189a27a416.json
+++ b/project/events/2026-05-07T16:06:34.386Z__a68ecc7f-0f11-4212-970c-78189a27a416.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "a68ecc7f-0f11-4212-970c-78189a27a416",
+  "issue_id": "plx-15a93667-6264-44a5-a7bf-096978ffc197",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T16:06:34.386Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "As a Console user, I want prediction requests to run once item, score, and scorecard are known, so that the assistant does not fail on its own documented execute_tactus example.\n\nFeature: Console score prediction\n\nScenario: Run prediction with resolved identifiers\nGiven a Console conversation has an item id, scorecard identifier, and score identifier\nWhen the assistant calls plexus.score.predict through execute_tactus\nThen the call uses scorecard_identifier and score_identifier and returns a structured prediction result.\n\nScenario: Missing prediction context is actionable\nGiven a prediction request lacks required score or scorecard context\nWhen execute_tactus validates the request\nThen it returns a structured error naming scorecard_identifier and score_identifier.\n\nDefinition of Done:\n- Runtime score prediction accepts the canonical identifier argument names.\n- Console prompt teaches the canonical prediction recipe and no repeated confirmation once identifiers are known.\n- Runtime account context is used for item resolution.\n- Focused tests and the failing-session smoke call pass.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-b953e903-b4e7-446c-affc-36850cc6b59b",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix Console prediction execute_tactus contract"
+  }
+}

--- a/project/events/2026-05-07T16:06:37.009Z__9dcb6460-34ca-4053-890f-089b4a083093.json
+++ b/project/events/2026-05-07T16:06:37.009Z__9dcb6460-34ca-4053-890f-089b4a083093.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9dcb6460-34ca-4053-890f-089b4a083093",
+  "issue_id": "plx-15a93667-6264-44a5-a7bf-096978ffc197",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T16:06:37.009Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T16:17:41.236Z__7ce50b5f-5c2b-4672-a05f-857b92bd2a85.json
+++ b/project/events/2026-05-07T16:17:41.236Z__7ce50b5f-5c2b-4672-a05f-857b92bd2a85.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7ce50b5f-5c2b-4672-a05f-857b92bd2a85",
+  "issue_id": "plx-15a93667-6264-44a5-a7bf-096978ffc197",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T16:17:41.236Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "740c2106-1d53-4443-b5e6-0d23c7a81405"
+  }
+}

--- a/project/events/2026-05-07T16:41:09.232Z__47ae1457-4371-4d3c-a72b-d7e919463145.json
+++ b/project/events/2026-05-07T16:41:09.232Z__47ae1457-4371-4d3c-a72b-d7e919463145.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "47ae1457-4371-4d3c-a72b-d7e919463145",
+  "issue_id": "plx-15a93667-6264-44a5-a7bf-096978ffc197",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T16:41:09.232Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-15a93667-6264-44a5-a7bf-096978ffc197.json
+++ b/project/issues/plx-15a93667-6264-44a5-a7bf-096978ffc197.json
@@ -3,7 +3,7 @@
   "title": "Fix Console prediction execute_tactus contract",
   "description": "As a Console user, I want prediction requests to run once item, score, and scorecard are known, so that the assistant does not fail on its own documented execute_tactus example.\n\nFeature: Console score prediction\n\nScenario: Run prediction with resolved identifiers\nGiven a Console conversation has an item id, scorecard identifier, and score identifier\nWhen the assistant calls plexus.score.predict through execute_tactus\nThen the call uses scorecard_identifier and score_identifier and returns a structured prediction result.\n\nScenario: Missing prediction context is actionable\nGiven a prediction request lacks required score or scorecard context\nWhen execute_tactus validates the request\nThen it returns a structured error naming scorecard_identifier and score_identifier.\n\nDefinition of Done:\n- Runtime score prediction accepts the canonical identifier argument names.\n- Console prompt teaches the canonical prediction recipe and no repeated confirmation once identifiers are known.\n- Runtime account context is used for item resolution.\n- Focused tests and the failing-session smoke call pass.",
   "type": "bug",
-  "status": "in_progress",
+  "status": "closed",
   "priority": 1,
   "assignee": null,
   "creator": null,
@@ -19,7 +19,7 @@
     }
   ],
   "created_at": "2026-05-07T16:06:34.386032Z",
-  "updated_at": "2026-05-07T16:17:41.235996Z",
-  "closed_at": null,
+  "updated_at": "2026-05-07T16:41:09.231705Z",
+  "closed_at": "2026-05-07T16:41:09.231705Z",
   "custom": {}
 }

--- a/project/issues/plx-15a93667-6264-44a5-a7bf-096978ffc197.json
+++ b/project/issues/plx-15a93667-6264-44a5-a7bf-096978ffc197.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-15a93667-6264-44a5-a7bf-096978ffc197",
+  "title": "Fix Console prediction execute_tactus contract",
+  "description": "As a Console user, I want prediction requests to run once item, score, and scorecard are known, so that the assistant does not fail on its own documented execute_tactus example.\n\nFeature: Console score prediction\n\nScenario: Run prediction with resolved identifiers\nGiven a Console conversation has an item id, scorecard identifier, and score identifier\nWhen the assistant calls plexus.score.predict through execute_tactus\nThen the call uses scorecard_identifier and score_identifier and returns a structured prediction result.\n\nScenario: Missing prediction context is actionable\nGiven a prediction request lacks required score or scorecard context\nWhen execute_tactus validates the request\nThen it returns a structured error naming scorecard_identifier and score_identifier.\n\nDefinition of Done:\n- Runtime score prediction accepts the canonical identifier argument names.\n- Console prompt teaches the canonical prediction recipe and no repeated confirmation once identifiers are known.\n- Runtime account context is used for item resolution.\n- Focused tests and the failing-session smoke call pass.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b953e903-b4e7-446c-affc-36850cc6b59b",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "740c2106-1d53-4443-b5e6-0d23c7a81405",
+      "author": "ryan",
+      "text": "Implemented canonical prediction contract in runtime and Console prompt. Focused tests pass, and real smoke call for PolicyPoint - Non-Sales / Acknowledges Before Redirecting / item 311432364 returned ok=true via plexus.score.predict with scorecard_identifier and score_identifier.",
+      "created_at": "2026-05-07T16:17:41.235996Z"
+    }
+  ],
+  "created_at": "2026-05-07T16:06:34.386032Z",
+  "updated_at": "2026-05-07T16:17:41.235996Z",
+  "closed_at": null,
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Standardizes `plexus.score.predict` on `scorecard_identifier` / `score_identifier` / `item_id`.
- Threads Console account context into prediction item resolution so chat-driven predictions do not depend on local account env vars.
- Updates Console prompt/tool docs/tests to stop teaching the old prediction argument shape and avoid unnecessary reconfirmation once identifiers are known.
- Closes the Kanbus task for the Console prediction contract fix.

## Validation
- `/Users/ryan/miniconda3/bin/python -m pytest plexus/cli/procedure/test_builtin_procedures.py -q`
- `/Users/ryan/miniconda3/bin/python -m pytest plexus/cli/procedure/test_mcp_transport.py -q`
- `/Users/ryan/miniconda3/bin/python -m pytest MCP/tools/tactus_runtime/execute_test.py -q`
- Real `execute_tactus` smoke for `plexus.score.predict({ scorecard_identifier = "PolicyPoint - Non-Sales", score_identifier = "Acknowledges Before Redirecting", item_id = "311432364" })` returned `ok=true`.
- `develop` CI green: https://github.com/AnthusAI/Plexus/actions/runs/25509326767
