### PR TITLE
Fix Console prediction API-only config loading

### DIFF
--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -1771,7 +1771,6 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
     item_ids_raw = args.get("item_ids")
     include_input = bool(args.get("include_input", False))
     include_trace = bool(args.get("include_trace", False))
-    no_cache = bool(args.get("no_cache", False))
     yaml_mode = bool(args.get("yaml", False))
     version = args.get("version") or args.get("version_id")
     latest = bool(args.get("latest", False))
@@ -1895,7 +1894,7 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
         from plexus.cli.evaluation.evaluations import load_scorecard_from_api
         scorecard_instance = load_scorecard_from_api(
             str(scorecard_identifier), score_names=[str(score_identifier)],
-            use_cache=not no_cache, specific_version=resolved_version
+            use_cache=False, specific_version=resolved_version
         )
 
     resolved_score_name = str(score_identifier)

--- a/MCP/tools/tactus_runtime/execute_test.py
+++ b/MCP/tools/tactus_runtime/execute_test.py
@@ -1459,9 +1459,13 @@ def test_default_score_predict_uses_account_context_for_item_resolution(
         "plexus.cli.shared.identifier_resolution.resolve_item_identifier",
         fake_resolve_item_identifier,
     )
+    def fake_load_scorecard_from_api(*args, **kwargs):
+        captured["load_scorecard_from_api"] = {"args": args, "kwargs": kwargs}
+        return FakeScorecard()
+
     monkeypatch.setattr(
         "plexus.cli.evaluation.evaluations.load_scorecard_from_api",
-        lambda *args, **kwargs: FakeScorecard(),
+        fake_load_scorecard_from_api,
     )
     monkeypatch.setattr(
         "plexus.dashboard.api.models.item.Item.from_dict",
@@ -1482,6 +1486,7 @@ def test_default_score_predict_uses_account_context_for_item_resolution(
         "identifier": "311432364",
         "account_id": "acct-console",
     }
+    assert captured["load_scorecard_from_api"]["kwargs"]["use_cache"] is False
     assert captured["dependency_names"] == ["Acknowledges Before Redirecting"]
     assert captured["score_kwargs"]["subset_of_score_names"] == [
         "Acknowledges Before Redirecting"

--- a/plexus/cli/evaluation/evaluations.py
+++ b/plexus/cli/evaluation/evaluations.py
@@ -1608,8 +1608,8 @@ def load_scorecard_from_api(scorecard_identifier: str, score_names=None, use_cac
         scorecard_identifier: A string that can identify the scorecard (id, key, name, etc.)
         score_names: Optional list of specific score names to load
         use_cache: Whether to prefer local cache files over API (default: False)
-                   When False, will always fetch from API but still write cache files
-                   When True, will check local cache first and only fetch missing configs
+                   When False, fetch from API and keep configurations in memory only
+                   When True, check local cache first and only fetch missing configs
         specific_version: Optional specific score version ID to use instead of champion version
         
     Returns:

--- a/plexus/cli/shared/fetch_score_configurations.py
+++ b/plexus/cli/shared/fetch_score_configurations.py
@@ -25,9 +25,9 @@ def fetch_score_configurations(
         target_scores: List of score objects to process
         cache_status: Either a dictionary mapping score IDs to their cache status (bool)
                      or a tuple of (cached_ids, uncached_ids) lists
-        use_cache: Whether to return configurations from cache (True) or use in-memory data (False)
+        use_cache: Whether to use local cache files.
                   When True: after fetching, load everything from cache files
-                  When False: return API results directly without loading from cache
+                  When False: return API results directly without reading or writing cache files
         
     Returns:
         Dictionary mapping score IDs to their parsed configurations
@@ -190,21 +190,22 @@ def fetch_score_configurations(
                 yaml.dump(ordered_config, rendered_config)
                 normalized_config_yaml = rendered_config.getvalue()
 
-                # Get the YAML file path
-                yaml_path = get_score_yaml_path(scorecard_name, score_name)
-                
-                # Write to file with proper formatting
-                with open(yaml_path, 'w') as f:
-                    f.write(normalized_config_yaml)
-                
-                # Keep the in-memory configuration identical to the cached YAML on disk.
+                if use_cache:
+                    # Get the YAML file path
+                    yaml_path = get_score_yaml_path(scorecard_name, score_name)
+
+                    # Write to file with proper formatting
+                    with open(yaml_path, 'w') as f:
+                        f.write(normalized_config_yaml)
+
+                    logging.info(f"==== CONFIGURATION SAVED ====")
+                    logging.info(f"Score: {score_name}")
+                    logging.info(f"Version: {champion_version_id}")
+                    logging.info(f"Saved to: {yaml_path}")
+                    logging.info(f"===============================")
+
+                # Keep the in-memory configuration identical to what cache mode writes.
                 configurations[score_id] = normalized_config_yaml
-                
-                logging.info(f"==== CONFIGURATION SAVED ====")
-                logging.info(f"Score: {score_name}")
-                logging.info(f"Version: {champion_version_id}")
-                logging.info(f"Saved to: {yaml_path}")
-                logging.info(f"===============================")
                 
             except Exception as e:
                 message = f"Error parsing YAML for score {score_name}: {str(e)}"

--- a/plexus/cli/shared/fetch_score_configurations_test.py
+++ b/plexus/cli/shared/fetch_score_configurations_test.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from ruamel.yaml import YAML
 
 from plexus.cli.shared import get_score_yaml_path
@@ -32,8 +30,14 @@ class _FakeClient:
         }
 
 
-def test_fetch_score_configurations_normalizes_in_memory_version(tmp_path, monkeypatch):
+def test_fetch_score_configurations_without_cache_is_api_only(tmp_path, monkeypatch):
     monkeypatch.setenv("SCORECARD_CACHE_DIR", str(tmp_path / "scorecards"))
+    monkeypatch.setattr(
+        "plexus.cli.shared.fetch_score_configurations.get_score_yaml_path",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("use_cache=False must not resolve or write score YAML paths")
+        ),
+    )
 
     configurations = fetch_score_configurations(
         client=_FakeClient(),
@@ -51,12 +55,34 @@ def test_fetch_score_configurations_normalizes_in_memory_version(tmp_path, monke
 
     parser = YAML(typ="safe")
     in_memory = parser.load(configurations["69e2adba-553e-49a3-9ede-7f9a679a08f3"])
+
+    assert in_memory["version"] == "score-version-db-123"
+    assert not (tmp_path / "scorecards").exists()
+
+
+def test_fetch_score_configurations_with_cache_writes_normalized_yaml(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCORECARD_CACHE_DIR", str(tmp_path / "scorecards"))
+
+    configurations = fetch_score_configurations(
+        client=_FakeClient(),
+        scorecard_data={"name": "SelectQuote HCS Medium-Risk"},
+        target_scores=[
+            {
+                "id": "69e2adba-553e-49a3-9ede-7f9a679a08f3",
+                "name": "Agent Misrepresentation",
+                "championVersionId": "score-version-db-123",
+            }
+        ],
+        cache_status={"69e2adba-553e-49a3-9ede-7f9a679a08f3": False},
+        use_cache=True,
+    )
+
+    parser = YAML(typ="safe")
+    in_memory = parser.load(configurations["69e2adba-553e-49a3-9ede-7f9a679a08f3"])
     on_disk = parser.load(
-        Path(
-            get_score_yaml_path(
-                "SelectQuote HCS Medium-Risk",
-                "Agent Misrepresentation",
-            )
+        get_score_yaml_path(
+            "SelectQuote HCS Medium-Risk",
+            "Agent Misrepresentation",
         ).read_text()
     )
 

--- a/plexus/cli/shared/iterative_config_fetching.py
+++ b/plexus/cli/shared/iterative_config_fetching.py
@@ -36,8 +36,8 @@ def iteratively_fetch_configurations(
         scorecard_data: The scorecard data containing name and other properties
         target_scores: List of score objects to process initially
         use_cache: Whether to use local cache files instead of always fetching from API
-                  When False, will always fetch from API but still write cache files
-                  When True, will check local cache first and only fetch missing configs
+                  When False, fetch from API and keep configurations in memory only
+                  When True, check local cache first and only fetch missing configs
         specific_version: Optional specific version ID to use instead of champion version
         
     Returns:
@@ -354,4 +354,4 @@ def iteratively_fetch_configurations(
                 logging.warning(f"Could not update version in configuration: {str(e)}")
     
     # Return all configurations
-    return configurations 
+    return configurations

--- a/plexus/tests/test_iterative_config_fetching.py
+++ b/plexus/tests/test_iterative_config_fetching.py
@@ -151,6 +151,35 @@ model: test-model
         # Verify fetch_score_configurations was called twice (once per iteration)
         assert mock_fetch_configurations.call_count == 2
 
+    def test_api_only_mode_propagates_to_configuration_fetches(self, mock_client, mock_check_cache):
+        """use_cache=False must keep the whole dependency fetch path API-only."""
+
+        with patch(
+            'plexus.cli.shared.iterative_config_fetching.fetch_score_configurations'
+        ) as mock_fetch:
+            def side_effect(client, scorecard_data, scores, cache_status, use_cache=False):
+                configs = {}
+                for score in scores:
+                    score_id = score.get('id')
+                    if score_id == 'score-with-deps-id':
+                        configs[score_id] = self.mock_score_config_with_deps
+                    elif score_id == 'dependency-score-id':
+                        configs[score_id] = self.mock_dependency_config
+                return configs
+
+            mock_fetch.side_effect = side_effect
+
+            result = iteratively_fetch_configurations(
+                mock_client,
+                self.mock_scorecard_data,
+                self.mock_target_scores,
+                use_cache=False
+            )
+
+        assert len(result) == 2
+        assert mock_fetch.call_count == 2
+        assert all(call.kwargs["use_cache"] is False for call in mock_fetch.call_args_list)
+
     def test_complete_structure_fetching(self, mock_client, mock_fetch_configurations, mock_check_cache):
         """Test that complete scorecard structure is fetched for dependency resolution."""
         

--- a/project/events/2026-05-07T18:39:43.968Z__6d6cec8f-b369-4d7a-b10b-af0716b56160.json
+++ b/project/events/2026-05-07T18:39:43.968Z__6d6cec8f-b369-4d7a-b10b-af0716b56160.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "6d6cec8f-b369-4d7a-b10b-af0716b56160",
+  "issue_id": "plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T18:39:43.968Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Console execute_tactus predictions fail in Lambda because API-loaded score configs are still written to the local scorecards cache when use_cache=false. Make non-cache GraphQL loading in-memory only and prove with read-only smoke.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Fix Console prediction API-only config loading"
+  }
+}

--- a/project/events/2026-05-07T18:39:46.028Z__85420999-b43e-4efc-bd12-8f092601d908.json
+++ b/project/events/2026-05-07T18:39:46.028Z__85420999-b43e-4efc-bd12-8f092601d908.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "85420999-b43e-4efc-bd12-8f092601d908",
+  "issue_id": "plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T18:39:46.028Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T18:45:08.553Z__4050c509-d067-4271-bb83-56b93c2973f4.json
+++ b/project/events/2026-05-07T18:45:08.553Z__4050c509-d067-4271-bb83-56b93c2973f4.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4050c509-d067-4271-bb83-56b93c2973f4",
+  "issue_id": "plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T18:45:08.553Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f.json
+++ b/project/issues/plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f",
+  "title": "Fix Console prediction API-only config loading",
+  "description": "Console execute_tactus predictions fail in Lambda because API-loaded score configs are still written to the local scorecards cache when use_cache=false. Make non-cache GraphQL loading in-memory only and prove with read-only smoke.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-07T18:39:43.966399Z",
+  "updated_at": "2026-05-07T18:45:08.552877Z",
+  "closed_at": "2026-05-07T18:45:08.552877Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- Makes GraphQL score config loading API-only when `use_cache=false`, avoiding local `scorecards/...` reads/writes.
- Forces `plexus.score.predict` in execute_tactus to use API-only config loading for non-YAML predictions.
- Adds regressions proving non-cache config fetching does not resolve/write YAML paths and prediction uses `use_cache=false`.
- Closes Kanbus bug `plx-6309a5`.

## Verification
- `/Users/ryan/miniconda3/bin/python -m pytest MCP/tools/tactus_runtime/execute_test.py -q` -> 130 passed
- `/Users/ryan/miniconda3/bin/python -m pytest plexus/tests/test_fetch_score_configurations.py plexus/tests/test_iterative_config_fetching.py plexus/cli/shared/fetch_score_configurations_test.py -q` -> 12 passed
- `/Users/ryan/miniconda3/bin/python -m pytest plexus/cli/procedure/test_builtin_procedures.py plexus/cli/procedure/test_mcp_transport.py -q` -> 39 passed
- Real read-only smoke from a chmod 555 temp cwd with `SCORECARD_CACHE_DIR` unset returned `ok=true` for PolicyPoint - Non-Sales / Acknowledges Before Redirecting / item 311432364 and did not create `scorecards/`.