### PR TITLE
Promote Console prediction API-only config loading

### DIFF
--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -1771,7 +1771,6 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
     item_ids_raw = args.get("item_ids")
     include_input = bool(args.get("include_input", False))
     include_trace = bool(args.get("include_trace", False))
-    no_cache = bool(args.get("no_cache", False))
     yaml_mode = bool(args.get("yaml", False))
     version = args.get("version") or args.get("version_id")
     latest = bool(args.get("latest", False))
@@ -1895,7 +1894,7 @@ def _default_score_predict(args: dict[str, Any]) -> dict[str, Any]:
         from plexus.cli.evaluation.evaluations import load_scorecard_from_api
         scorecard_instance = load_scorecard_from_api(
             str(scorecard_identifier), score_names=[str(score_identifier)],
-            use_cache=not no_cache, specific_version=resolved_version
+            use_cache=False, specific_version=resolved_version
         )
 
     resolved_score_name = str(score_identifier)

--- a/MCP/tools/tactus_runtime/execute_test.py
+++ b/MCP/tools/tactus_runtime/execute_test.py
@@ -1459,9 +1459,13 @@ def test_default_score_predict_uses_account_context_for_item_resolution(
         "plexus.cli.shared.identifier_resolution.resolve_item_identifier",
         fake_resolve_item_identifier,
     )
+    def fake_load_scorecard_from_api(*args, **kwargs):
+        captured["load_scorecard_from_api"] = {"args": args, "kwargs": kwargs}
+        return FakeScorecard()
+
     monkeypatch.setattr(
         "plexus.cli.evaluation.evaluations.load_scorecard_from_api",
-        lambda *args, **kwargs: FakeScorecard(),
+        fake_load_scorecard_from_api,
     )
     monkeypatch.setattr(
         "plexus.dashboard.api.models.item.Item.from_dict",
@@ -1482,6 +1486,7 @@ def test_default_score_predict_uses_account_context_for_item_resolution(
         "identifier": "311432364",
         "account_id": "acct-console",
     }
+    assert captured["load_scorecard_from_api"]["kwargs"]["use_cache"] is False
     assert captured["dependency_names"] == ["Acknowledges Before Redirecting"]
     assert captured["score_kwargs"]["subset_of_score_names"] == [
         "Acknowledges Before Redirecting"

--- a/dashboard/components/blocks/ScoreResultsReport.tsx
+++ b/dashboard/components/blocks/ScoreResultsReport.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import React from "react";
+import { downloadData } from "aws-amplify/storage";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
+
+import { parseOutputString } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { IdentifierDisplay } from "@/components/ui/identifier-display";
+import { ScoreResultTrace } from "@/components/ui/score-result-trace";
+
+import ReportBlock, { ReportBlockProps, type BlockComponent } from "./ReportBlock";
+
+interface ScoreResultRow {
+  input_identifier?: string;
+  resolved_item_id?: string;
+  item_identifiers?: Array<{ name: string; value: string; url?: string }> | null;
+  status?: string;
+  score_result_id?: string | null;
+  value?: string | null;
+  explanation?: string | null;
+  cost?: unknown;
+  trace?: unknown;
+  error?: string | null;
+}
+
+interface CostSummary {
+  totalCostUsd?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+}
+
+interface ScoreResultScoreSection {
+  score_id: string;
+  score_name: string;
+  results?: ScoreResultRow[];
+}
+
+interface ScoreResultsReportData {
+  report_type?: string;
+  block_title?: string;
+  block_description?: string;
+  scope?: "single_score" | "scorecard_all_scores";
+  scorecard_name?: string | null;
+  score_name?: string | null;
+  summary?: {
+    input_identifier_count?: number;
+    resolved_item_count?: number;
+    unresolved_identifier_count?: number;
+    scores_analyzed?: number;
+    total_predictions?: number;
+    successful_predictions?: number;
+    failed_predictions?: number;
+  };
+  scores?: ScoreResultScoreSection[];
+  unresolved_identifiers?: Array<{ input_identifier?: string; error?: string }>;
+  failed_predictions?: Array<{
+    input_identifier?: string;
+    score_name?: string;
+    error?: string;
+  }>;
+  error?: string;
+  output_compacted?: boolean;
+  output_attachment?: string;
+}
+
+const parseCostSummary = (value: unknown): CostSummary | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return { totalCostUsd: value };
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? { totalCostUsd: parsed } : null;
+  }
+  if (typeof value !== "object") return null;
+
+  const data = value as Record<string, unknown>;
+  const totalCostRaw = data.total_cost ?? data.totalCost ?? data.usd;
+  const promptTokensRaw = data.prompt_tokens ?? data.promptTokens;
+  const completionTokensRaw = data.completion_tokens ?? data.completionTokens;
+  const totalTokensRaw = data.total_tokens ?? data.totalTokens;
+
+  const toNumber = (input: unknown): number | undefined => {
+    if (typeof input === "number" && Number.isFinite(input)) return input;
+    if (typeof input === "string") {
+      const parsed = Number(input);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return undefined;
+  };
+
+  const promptTokens = toNumber(promptTokensRaw);
+  const completionTokens = toNumber(completionTokensRaw);
+  const totalTokens = toNumber(totalTokensRaw) ?? (
+    promptTokens !== undefined || completionTokens !== undefined
+      ? (promptTokens ?? 0) + (completionTokens ?? 0)
+      : undefined
+  );
+
+  return {
+    totalCostUsd: toNumber(totalCostRaw),
+    promptTokens,
+    completionTokens,
+    totalTokens,
+  };
+};
+
+const formatUsd = (value?: number): string | null => {
+  if (value === undefined || !Number.isFinite(value)) return null;
+  if (value === 0) return "$0.00";
+  if (Math.abs(value) < 0.01) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+};
+
+const formatTokenCount = (value?: number): string | null => {
+  if (value === undefined || !Number.isFinite(value)) return null;
+  return `${Math.round(value).toLocaleString()} tok`;
+};
+
+const ScoreResultsReport: React.FC<ReportBlockProps> = (props) => {
+  const [loadedOutput, setLoadedOutput] = React.useState<ScoreResultsReportData | null>(null);
+  const [attachmentLoadError, setAttachmentLoadError] = React.useState<string | null>(null);
+  const [expandedTraceKeys, setExpandedTraceKeys] = React.useState<Record<string, boolean>>({});
+
+  let parsedOutput: ScoreResultsReportData = {};
+  try {
+    parsedOutput =
+      typeof props.output === "string"
+        ? (parseOutputString(props.output) as ScoreResultsReportData)
+        : ((props.output || {}) as ScoreResultsReportData);
+  } catch {
+    parsedOutput = {};
+  }
+
+  const isCompacted = Boolean(parsedOutput?.output_compacted && parsedOutput?.output_attachment);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!isCompacted || !parsedOutput.output_attachment) {
+      setLoadedOutput(null);
+      setAttachmentLoadError(null);
+      return;
+    }
+
+    (async () => {
+      try {
+        const downloaded = await downloadData({
+          path: parsedOutput.output_attachment as string,
+          options: { bucket: "reportBlockDetails" },
+        }).result;
+        const text = await downloaded.body.text();
+        if (!cancelled) setLoadedOutput(parseOutputString(text) as ScoreResultsReportData);
+        if (!cancelled) setAttachmentLoadError(null);
+      } catch {
+        if (!cancelled) {
+          setAttachmentLoadError("Failed to load compacted output attachment.");
+          setLoadedOutput(null);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isCompacted, parsedOutput.output_attachment]);
+
+  const output = loadedOutput || parsedOutput;
+  const candidateTitle = output.block_title || props.name || "Score Results Report";
+  const blockTitle =
+    output.score_name && candidateTitle?.trim() === output.score_name?.trim()
+      ? "Score Results Report"
+      : candidateTitle;
+  const rawSubtitle = output.scorecard_name || undefined;
+  const subtitle = rawSubtitle && rawSubtitle !== blockTitle ? rawSubtitle : undefined;
+  const scores = Array.isArray(output.scores) ? output.scores : [];
+  const scoreResultCount = scores.reduce((count, score) => count + (score.results?.length ?? 0), 0);
+  const scoreCount = scores.length;
+  const promptTokenValues = scores.flatMap((score) =>
+    (score.results || [])
+      .map((row) => parseCostSummary(row.cost)?.promptTokens)
+      .filter((tokens): tokens is number => typeof tokens === "number" && Number.isFinite(tokens))
+  );
+  const completionTokenValues = scores.flatMap((score) =>
+    (score.results || [])
+      .map((row) => parseCostSummary(row.cost)?.completionTokens)
+      .filter((tokens): tokens is number => typeof tokens === "number" && Number.isFinite(tokens))
+  );
+  const totalPromptTokens = promptTokenValues.reduce((sum, value) => sum + value, 0);
+  const totalCompletionTokens = completionTokenValues.reduce((sum, value) => sum + value, 0);
+  const costValues = scores.flatMap((score) =>
+    (score.results || [])
+      .map((row) => parseCostSummary(row.cost)?.totalCostUsd)
+      .filter((cost): cost is number => typeof cost === "number" && Number.isFinite(cost))
+  );
+  const totalCostUsd = costValues.reduce((sum, value) => sum + value, 0);
+  const totalCostLabel = costValues.length > 0 ? (formatUsd(totalCostUsd) ?? "N/A") : "N/A";
+  const showInBlockHeaderRow = (() => {
+    const scorecard = output.scorecard_name?.trim();
+    const score = output.score_name?.trim();
+    if (!scorecard && !score) return false;
+    if (score) return false;
+    if (scorecard && scorecard !== blockTitle && scorecard !== subtitle) return true;
+    return false;
+  })();
+  const isLoadingCompactedOutput = isCompacted && !loadedOutput && !attachmentLoadError;
+  const hasResolvedData =
+    scores.length > 0 ||
+    Boolean(output.summary) ||
+    Boolean(output.error) ||
+    Boolean((output.unresolved_identifiers || []).length) ||
+    Boolean((output.failed_predictions || []).length);
+
+  if ((output.error || attachmentLoadError) && !isLoadingCompactedOutput) {
+    return (
+      <ReportBlock {...props} output={output} title={output.block_title || props.name || "Score Results Report"} subtitle={subtitle}>
+        <div className="p-4 text-sm text-red-600 dark:text-red-400" data-testid="score-results-report-error">
+          {output.error || attachmentLoadError}
+        </div>
+      </ReportBlock>
+    );
+  }
+
+  if (isLoadingCompactedOutput && !hasResolvedData) {
+    return (
+      <ReportBlock {...props} output={output} title={output.block_title || props.name || "Score Results Report"} subtitle={subtitle}>
+        <div className="p-4 text-sm text-muted-foreground" data-testid="score-results-report-loading">
+          Report block is loading detailed output.
+        </div>
+      </ReportBlock>
+    );
+  }
+
+  return (
+    <ReportBlock {...props} output={output} title={blockTitle} subtitle={subtitle}>
+      <div className="space-y-4" data-testid="score-results-report">
+        {showInBlockHeaderRow ? (
+          <div className="rounded-md bg-muted/40 px-3 py-2" data-testid="score-results-header-row">
+            <div className="text-sm font-semibold">{output.scorecard_name || "Scorecard"}</div>
+            {output.score_name ? <div className="text-xs text-muted-foreground">{output.score_name}</div> : null}
+          </div>
+        ) : null}
+        <div className="rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground" data-testid="score-results-summary">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+            {scoreCount > 1 ? <span>Scores: {scoreCount}</span> : null}
+            <span>Score Results: {scoreResultCount}</span>
+            {promptTokenValues.length > 0 ? <span>Input Tokens: {Math.round(totalPromptTokens).toLocaleString()}</span> : null}
+            {completionTokenValues.length > 0 ? <span>Output Tokens: {Math.round(totalCompletionTokens).toLocaleString()}</span> : null}
+            <span>Total Cost: {totalCostLabel}</span>
+          </div>
+        </div>
+
+        {(output.unresolved_identifiers || []).length > 0 ? (
+          <section data-testid="unresolved-identifiers" className="rounded-md bg-muted/40 p-3">
+            <div className="mb-2 text-sm font-medium">Unresolved Identifiers</div>
+            <ul className="space-y-1 text-xs">
+              {(output.unresolved_identifiers || []).map((entry, index) => (
+                <li key={`${entry.input_identifier || "unknown"}-${index}`}>
+                  <span className="font-medium">{entry.input_identifier || "Unknown"}:</span>{" "}
+                  {entry.error || "No item found"}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        {scores.map((score) => (
+          <section key={score.score_id} className="overflow-hidden rounded-md bg-muted/30" data-testid={`score-section-${score.score_id}`}>
+            <div className="bg-muted/40 px-3 py-2 text-sm font-semibold">{score.score_name}</div>
+            <div className="space-y-2 py-2">
+              {(score.results || []).map((row, rowIndex) => {
+                const key = `${score.score_id}-${row.input_identifier || "unknown"}-${rowIndex}`;
+                const traceExpanded = Boolean(expandedTraceKeys[key]);
+                const status = row.status || "unknown";
+                const cost = parseCostSummary(row.cost);
+                const usd = formatUsd(cost?.totalCostUsd);
+                const promptTokens = formatTokenCount(cost?.promptTokens);
+                const completionTokens = formatTokenCount(cost?.completionTokens);
+                return (
+                  <article key={key} className="rounded-md bg-card-light px-3 py-2" data-testid={`result-row-${key}`}>
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <Badge
+                          variant="secondary"
+                          className="bg-muted text-muted-foreground"
+                        >
+                          {row.value ?? (status === "failed" ? "Failed" : "N/A")}
+                        </Badge>
+                        {status !== "success" ? (
+                          <span className="text-xs text-muted-foreground">Status {status}</span>
+                        ) : null}
+                        {row.trace ? (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 px-1 text-xs"
+                            onClick={() =>
+                              setExpandedTraceKeys((current) => ({ ...current, [key]: !current[key] }))
+                            }
+                            data-testid={`trace-toggle-${key}`}
+                          >
+                            {traceExpanded ? <ChevronDown className="mr-1 h-3 w-3" /> : <ChevronRight className="mr-1 h-3 w-3" />}
+                            Trace
+                          </Button>
+                        ) : null}
+                      </div>
+                      <div className="space-y-1">
+                        <IdentifierDisplay
+                          identifiers={row.item_identifiers ?? undefined}
+                          externalId={row.resolved_item_id || undefined}
+                          displayMode="full"
+                          textSize="xs"
+                        />
+                      </div>
+                    </div>
+                    <div className="mt-2 rounded-md bg-background p-2">
+                      <div className="prose prose-sm max-w-none text-muted-foreground prose-p:mb-0 prose-p:text-muted-foreground">
+                        <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+                          {row.explanation || row.error || "No explanation provided."}
+                        </ReactMarkdown>
+                      </div>
+                    </div>
+                    {traceExpanded ? (
+                      <div className="mt-2 rounded-md bg-background p-2" data-testid={`trace-content-${key}`}>
+                        <ScoreResultTrace trace={row.trace} variant="compact" />
+                      </div>
+                    ) : null}
+                    <div className="mt-2 text-xs text-muted-foreground">
+                      {!cost ? (
+                        "Cost N/A"
+                      ) : !usd && !promptTokens && !completionTokens ? (
+                        "Cost available"
+                      ) : (
+                        <>
+                          Cost {usd ?? "N/A"}
+                          {promptTokens ? ` · In ${promptTokens}` : ""}
+                          {completionTokens ? ` · Out ${completionTokens}` : ""}
+                        </>
+                      )}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </ReportBlock>
+  );
+};
+
+(ScoreResultsReport as BlockComponent).blockClass = "ScoreResultsReport";
+
+export default ScoreResultsReport;

--- a/dashboard/components/blocks/__tests__/ScoreResultsReport.test.tsx
+++ b/dashboard/components/blocks/__tests__/ScoreResultsReport.test.tsx
@@ -1,0 +1,215 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ScoreResultsReport from "@/components/blocks/ScoreResultsReport";
+
+const mockDownloadData = jest.fn();
+
+jest.mock("aws-amplify/storage", () => ({
+  downloadData: (...args: any[]) => mockDownloadData(...args),
+}));
+
+jest.mock("@/components/blocks/ReportBlock", () => {
+  const MockReportBlock = ({ title, subtitle, children }: any) => (
+    <div>
+      <div>{title}</div>
+      {subtitle ? <div data-testid="report-subtitle">{subtitle}</div> : null}
+      {children}
+    </div>
+  );
+  return {
+    __esModule: true,
+    default: MockReportBlock,
+  };
+});
+
+jest.mock("@/components/ui/score-result-trace", () => ({
+  __esModule: true,
+  ScoreResultTrace: ({ trace }: any) => (
+    <div data-testid="structured-trace">{JSON.stringify(trace)}</div>
+  ),
+}));
+
+describe("ScoreResultsReport", () => {
+  beforeEach(() => {
+    mockDownloadData.mockReset();
+  });
+
+  const output = {
+    report_type: "score_results_report",
+    block_title: "Score Results Report",
+    scorecard_name: "Test Scorecard",
+    summary: {
+      input_identifier_count: 2,
+      resolved_item_count: 2,
+      total_predictions: 2,
+      failed_predictions: 1,
+    },
+    unresolved_identifiers: [
+      { input_identifier: "bad-id", error: "No item found" },
+    ],
+    failed_predictions: [
+      { input_identifier: "311430190", score_name: "Score 1", error: "Prediction failed" },
+    ],
+    scores: [
+      {
+        score_id: "score-1",
+        score_name: "Score 1",
+        results: [
+          {
+            input_identifier: "311430191",
+            resolved_item_id: "item-1",
+            item_identifiers: [
+              { name: "Customer ID", value: "CUST-311430191", url: "https://example.com/customer/CUST-311430191" },
+              { name: "Conversation ID", value: "311430191" },
+            ],
+            status: "success",
+            score_result_id: "sr-1",
+            value: "yes",
+            explanation: "Aligned behavior",
+            cost: { total_cost: 0.2, prompt_tokens: 120, completion_tokens: 80 },
+            trace: { node_results: [] },
+          },
+          {
+            input_identifier: "311430190",
+            resolved_item_id: "item-2",
+            status: "failed",
+            score_result_id: null,
+            value: null,
+            explanation: null,
+            cost: null,
+            trace: null,
+            error: "Prediction failed",
+          },
+        ],
+      },
+    ],
+  };
+
+  const baseProps = {
+    id: "block-1",
+    config: {},
+    output,
+    log: undefined,
+    name: "Score Results Report",
+    position: 1,
+    type: "ScoreResultsReport",
+    attachedFiles: [],
+  };
+
+  it("renders grouped-by-score card rows, identifiers, value/explanation, and diagnostics", () => {
+    render(<ScoreResultsReport {...baseProps} />);
+
+    expect(screen.getByText("Score Results Report")).toBeInTheDocument();
+    expect(screen.getByTestId("report-subtitle")).toHaveTextContent("Test Scorecard");
+    expect(screen.queryByTestId("score-results-header-row")).not.toBeInTheDocument();
+    expect(screen.getByTestId("score-section-score-1")).toBeInTheDocument();
+    expect(screen.getByTestId("score-results-summary")).toHaveTextContent("Score Results: 2");
+    expect(screen.getByTestId("score-results-summary")).toHaveTextContent("Input Tokens: 120");
+    expect(screen.getByTestId("score-results-summary")).toHaveTextContent("Output Tokens: 80");
+    expect(screen.getByTestId("score-results-summary")).toHaveTextContent("Total Cost: $0.20");
+    expect(screen.queryByText("Scores: 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Inputs:")).not.toBeInTheDocument();
+    expect(screen.getByTestId("unresolved-identifiers")).toHaveTextContent("bad-id");
+    expect(screen.queryByTestId("failed-predictions")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Requested Identifier:/)).not.toBeInTheDocument();
+    expect(screen.getByText((_, element) => element?.textContent === "Customer ID:")).toBeInTheDocument();
+    expect(screen.getByText("Aligned behavior")).toBeInTheDocument();
+    expect(screen.queryByText("Status success")).not.toBeInTheDocument();
+    expect(screen.getByText("Status failed")).toBeInTheDocument();
+    expect(screen.queryByText(/Result sr-1/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Cost \$0.20/)).toBeInTheDocument();
+    expect(screen.getByText(/In 120 tok/)).toBeInTheDocument();
+    expect(screen.getByText(/Out 80 tok/)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("keeps traces collapsed by default and renders structured trace when expanded", () => {
+    render(<ScoreResultsReport {...baseProps} />);
+
+    expect(screen.queryByTestId("structured-trace")).not.toBeInTheDocument();
+    const toggle = screen.getByTestId("trace-toggle-score-1-311430191-0");
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("trace-content-score-1-311430191-0")).toBeInTheDocument();
+    expect(screen.getByTestId("structured-trace")).toBeInTheDocument();
+  });
+
+  it("loads compacted output from attachment", async () => {
+    mockDownloadData.mockReturnValue({
+      result: Promise.resolve({
+        body: {
+          text: () => Promise.resolve(JSON.stringify(output)),
+        },
+      }),
+    });
+
+    render(
+      <ScoreResultsReport
+        {...baseProps}
+        output={{
+          output_compacted: true,
+          output_attachment: "reportblocks/block-1/output-block-1.json",
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("score-section-score-1")).toBeInTheDocument();
+    });
+
+    expect(mockDownloadData).toHaveBeenCalledWith({
+      path: "reportblocks/block-1/output-block-1.json",
+      options: { bucket: "reportBlockDetails" },
+    });
+  });
+
+  it("shows loading state for compacted output before attachment resolves", async () => {
+    let resolveBodyText: ((value: string) => void) | null = null;
+    const textPromise = new Promise<string>((resolve) => {
+      resolveBodyText = resolve;
+    });
+
+    mockDownloadData.mockReturnValue({
+      result: Promise.resolve({
+        body: {
+          text: () => textPromise,
+        },
+      }),
+    });
+
+    render(
+      <ScoreResultsReport
+        {...baseProps}
+        output={{
+          output_compacted: true,
+          output_attachment: "reportblocks/block-1/output-block-1.json",
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("score-results-report-loading")).toBeInTheDocument();
+    resolveBodyText?.(JSON.stringify(output));
+    await waitFor(() => {
+      expect(screen.queryByTestId("score-results-report-loading")).not.toBeInTheDocument();
+    });
+  });
+
+  it("dedupes single-score title and keeps score name in the score section header", () => {
+    render(
+      <ScoreResultsReport
+        {...baseProps}
+        output={{
+          ...output,
+          block_title: "PolicyPoint - Non-Sales",
+          scorecard_name: "Policy Point",
+          score_name: "PolicyPoint - Non-Sales",
+          scores: [{ score_id: "score-pp", score_name: "PolicyPoint - Non-Sales", results: [] }],
+        }}
+      />
+    );
+
+    expect(screen.getByText("Score Results Report")).toBeInTheDocument();
+    expect(screen.getByTestId("report-subtitle")).toHaveTextContent("Policy Point");
+    expect(screen.getAllByText("PolicyPoint - Non-Sales")).toHaveLength(1);
+  });
+});

--- a/dashboard/components/blocks/index.ts
+++ b/dashboard/components/blocks/index.ts
@@ -21,6 +21,7 @@ export { default as AcceptanceRateTimeline } from './AcceptanceRateTimeline';
 export { default as RecentFeedback } from './RecentFeedback';
 export { default as ScoreChampionVersionTimeline } from './ScoreChampionVersionTimeline';
 export { default as ScorecardHistory } from './ScorecardHistory';
+export { default as ScoreResultsReport } from './ScoreResultsReport';
 export { BlockRenderer } from './BlockRegistry';
 export type { BlockRendererProps } from './BlockRegistry';
 export { getBlock, hasBlock, getRegisteredBlockTypes } from './BlockRegistry';

--- a/dashboard/components/blocks/registrySetup.ts
+++ b/dashboard/components/blocks/registrySetup.ts
@@ -26,6 +26,7 @@ import AcceptanceRateTimeline from './AcceptanceRateTimeline';
 import RecentFeedback from './RecentFeedback';
 import ScoreChampionVersionTimeline from './ScoreChampionVersionTimeline';
 import ScorecardHistory from './ScorecardHistory';
+import ScoreResultsReport from './ScoreResultsReport';
 
 // Register all block components
 // Register the default block handler first
@@ -51,3 +52,4 @@ registerBlock('AcceptanceRateTimeline', AcceptanceRateTimeline as BlockComponent
 registerBlock('RecentFeedback', RecentFeedback as BlockComponent);
 registerBlock('ScoreChampionVersionTimeline', ScoreChampionVersionTimeline as BlockComponent);
 registerBlock('ScorecardHistory', ScorecardHistory as BlockComponent);
+registerBlock('ScoreResultsReport', ScoreResultsReport as BlockComponent);

--- a/plexus/cli/evaluation/evaluations.py
+++ b/plexus/cli/evaluation/evaluations.py
@@ -1608,8 +1608,8 @@ def load_scorecard_from_api(scorecard_identifier: str, score_names=None, use_cac
         scorecard_identifier: A string that can identify the scorecard (id, key, name, etc.)
         score_names: Optional list of specific score names to load
         use_cache: Whether to prefer local cache files over API (default: False)
-                   When False, will always fetch from API but still write cache files
-                   When True, will check local cache first and only fetch missing configs
+                   When False, fetch from API and keep configurations in memory only
+                   When True, check local cache first and only fetch missing configs
         specific_version: Optional specific score version ID to use instead of champion version
         
     Returns:

--- a/plexus/cli/feedback/feedback_report.py
+++ b/plexus/cli/feedback/feedback_report.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 from contextlib import nullcontext
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import click
 import yaml
@@ -139,6 +139,31 @@ def _score_has_nonempty_champion_guidelines(
         return True, None
     except Exception as exc:
         return False, f"Skipped Feedback Contradictions: failed to resolve champion guidelines ({exc})."
+
+
+def _normalize_identifier_inputs(ids: Optional[str], id_values: Tuple[str, ...]) -> List[str]:
+    normalized: List[str] = []
+    seen: set[str] = set()
+
+    def _add(value: Optional[str]) -> None:
+        if value is None:
+            return
+        text = str(value).strip()
+        if not text:
+            return
+        if "," in text:
+            for piece in text.split(","):
+                _add(piece)
+            return
+        if text in seen:
+            return
+        seen.add(text)
+        normalized.append(text)
+
+    _add(ids)
+    for value in id_values:
+        _add(value)
+    return normalized
 
 
 @click.group(name="report")
@@ -754,6 +779,55 @@ def scorecard_history(
     )
     _print_result(
         title="ScorecardHistory",
+        result=result,
+        output_format=output_format,
+        include_log=include_log,
+    )
+
+
+@report.command(name="score-results-report")
+@click.option("--scorecard", required=True, help="Scorecard identifier (id, external id, key, or name).")
+@click.option("--score", required=False, help="Optional score identifier (id, external id, key, or name).")
+@click.option("--ids", required=False, help="Comma-separated list of item identifiers.")
+@click.option("--id", "id_values", multiple=True, help="Item identifier (repeatable).")
+@click.option("--cache-key", required=False, help="Deterministic cache key for repeated runs.")
+@click.option("--ttl-hours", type=float, default=24.0, show_default=True, help="Cache TTL in hours.")
+@click.option("--fresh", is_flag=True, help="Ignore cached results and rerun.")
+@click.option("--background", is_flag=True, help="Queue as a durable task for dispatcher execution and return immediately.")
+@click.option("--account", "account_identifier", default=None, help="Optional account key or id.")
+@click.option("--format", "output_format", type=click.Choice(["json", "yaml"]), default="json", show_default=True)
+@click.option("--include-log", is_flag=True, help="Include report block log output.")
+def score_results_report(
+    scorecard: str,
+    score: Optional[str],
+    ids: Optional[str],
+    id_values: Tuple[str, ...],
+    cache_key: Optional[str],
+    ttl_hours: float,
+    fresh: bool,
+    background: bool,
+    account_identifier: Optional[str],
+    output_format: str,
+    include_log: bool,
+) -> None:
+    """Run the ScoreResultsReport block."""
+    normalized_ids = _normalize_identifier_inputs(ids, id_values)
+    if not normalized_ids:
+        raise click.ClickException("At least one item identifier is required via --ids or --id.")
+
+    result = run_feedback_report_block(
+        block_class="ScoreResultsReport",
+        scorecard=scorecard,
+        score=score,
+        account_identifier=account_identifier,
+        cache_key=cache_key,
+        ttl_hours=ttl_hours,
+        fresh=fresh,
+        background=background,
+        extra_config={"ids": normalized_ids},
+    )
+    _print_result(
+        title="ScoreResultsReport",
         result=result,
         output_format=output_format,
         include_log=include_log,

--- a/plexus/cli/feedback/feedback_report_test.py
+++ b/plexus/cli/feedback/feedback_report_test.py
@@ -337,6 +337,51 @@ def test_scorecard_history_supports_single_score_explicit_window_and_summary_mod
     assert kwargs["fresh"] is True
 
 
+@patch("plexus.cli.feedback.feedback_report.run_feedback_report_block")
+def test_score_results_report_supports_ids_and_repeated_id_flags(mock_run_feedback_report_block):
+    runner = CliRunner()
+    mock_run_feedback_report_block.return_value = {"status": "success", "output": {"scores": []}}
+
+    result = runner.invoke(
+        report,
+        [
+            "score-results-report",
+            "--scorecard",
+            "1562",
+            "--score",
+            "48059",
+            "--ids",
+            "311434634,311432364",
+            "--id",
+            "311432363",
+            "--id",
+            "311432364",
+        ],
+    )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_run_feedback_report_block.call_args
+    assert kwargs["block_class"] == "ScoreResultsReport"
+    assert kwargs["scorecard"] == "1562"
+    assert kwargs["score"] == "48059"
+    assert kwargs["extra_config"] == {"ids": ["311434634", "311432364", "311432363"]}
+
+
+def test_score_results_report_requires_at_least_one_identifier():
+    runner = CliRunner()
+    result = runner.invoke(
+        report,
+        [
+            "score-results-report",
+            "--scorecard",
+            "1562",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "At least one item identifier is required" in result.output
+
+
 @patch("plexus.cli.feedback.feedback_report.resolve_account_id_for_command")
 @patch("plexus.cli.feedback.feedback_report.enrich_parameters_with_names")
 @patch("plexus.cli.feedback.feedback_report.memoized_resolve_score_identifier")

--- a/plexus/cli/shared/fetch_score_configurations.py
+++ b/plexus/cli/shared/fetch_score_configurations.py
@@ -25,9 +25,9 @@ def fetch_score_configurations(
         target_scores: List of score objects to process
         cache_status: Either a dictionary mapping score IDs to their cache status (bool)
                      or a tuple of (cached_ids, uncached_ids) lists
-        use_cache: Whether to return configurations from cache (True) or use in-memory data (False)
+        use_cache: Whether to use local cache files.
                   When True: after fetching, load everything from cache files
-                  When False: return API results directly without loading from cache
+                  When False: return API results directly without reading or writing cache files
         
     Returns:
         Dictionary mapping score IDs to their parsed configurations
@@ -190,21 +190,22 @@ def fetch_score_configurations(
                 yaml.dump(ordered_config, rendered_config)
                 normalized_config_yaml = rendered_config.getvalue()
 
-                # Get the YAML file path
-                yaml_path = get_score_yaml_path(scorecard_name, score_name)
-                
-                # Write to file with proper formatting
-                with open(yaml_path, 'w') as f:
-                    f.write(normalized_config_yaml)
-                
-                # Keep the in-memory configuration identical to the cached YAML on disk.
+                if use_cache:
+                    # Get the YAML file path
+                    yaml_path = get_score_yaml_path(scorecard_name, score_name)
+
+                    # Write to file with proper formatting
+                    with open(yaml_path, 'w') as f:
+                        f.write(normalized_config_yaml)
+
+                    logging.info(f"==== CONFIGURATION SAVED ====")
+                    logging.info(f"Score: {score_name}")
+                    logging.info(f"Version: {champion_version_id}")
+                    logging.info(f"Saved to: {yaml_path}")
+                    logging.info(f"===============================")
+
+                # Keep the in-memory configuration identical to what cache mode writes.
                 configurations[score_id] = normalized_config_yaml
-                
-                logging.info(f"==== CONFIGURATION SAVED ====")
-                logging.info(f"Score: {score_name}")
-                logging.info(f"Version: {champion_version_id}")
-                logging.info(f"Saved to: {yaml_path}")
-                logging.info(f"===============================")
                 
             except Exception as e:
                 message = f"Error parsing YAML for score {score_name}: {str(e)}"

--- a/plexus/cli/shared/fetch_score_configurations_test.py
+++ b/plexus/cli/shared/fetch_score_configurations_test.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from ruamel.yaml import YAML
 
 from plexus.cli.shared import get_score_yaml_path
@@ -32,8 +30,14 @@ class _FakeClient:
         }
 
 
-def test_fetch_score_configurations_normalizes_in_memory_version(tmp_path, monkeypatch):
+def test_fetch_score_configurations_without_cache_is_api_only(tmp_path, monkeypatch):
     monkeypatch.setenv("SCORECARD_CACHE_DIR", str(tmp_path / "scorecards"))
+    monkeypatch.setattr(
+        "plexus.cli.shared.fetch_score_configurations.get_score_yaml_path",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("use_cache=False must not resolve or write score YAML paths")
+        ),
+    )
 
     configurations = fetch_score_configurations(
         client=_FakeClient(),
@@ -51,12 +55,34 @@ def test_fetch_score_configurations_normalizes_in_memory_version(tmp_path, monke
 
     parser = YAML(typ="safe")
     in_memory = parser.load(configurations["69e2adba-553e-49a3-9ede-7f9a679a08f3"])
+
+    assert in_memory["version"] == "score-version-db-123"
+    assert not (tmp_path / "scorecards").exists()
+
+
+def test_fetch_score_configurations_with_cache_writes_normalized_yaml(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCORECARD_CACHE_DIR", str(tmp_path / "scorecards"))
+
+    configurations = fetch_score_configurations(
+        client=_FakeClient(),
+        scorecard_data={"name": "SelectQuote HCS Medium-Risk"},
+        target_scores=[
+            {
+                "id": "69e2adba-553e-49a3-9ede-7f9a679a08f3",
+                "name": "Agent Misrepresentation",
+                "championVersionId": "score-version-db-123",
+            }
+        ],
+        cache_status={"69e2adba-553e-49a3-9ede-7f9a679a08f3": False},
+        use_cache=True,
+    )
+
+    parser = YAML(typ="safe")
+    in_memory = parser.load(configurations["69e2adba-553e-49a3-9ede-7f9a679a08f3"])
     on_disk = parser.load(
-        Path(
-            get_score_yaml_path(
-                "SelectQuote HCS Medium-Risk",
-                "Agent Misrepresentation",
-            )
+        get_score_yaml_path(
+            "SelectQuote HCS Medium-Risk",
+            "Agent Misrepresentation",
         ).read_text()
     )
 

--- a/plexus/cli/shared/iterative_config_fetching.py
+++ b/plexus/cli/shared/iterative_config_fetching.py
@@ -36,8 +36,8 @@ def iteratively_fetch_configurations(
         scorecard_data: The scorecard data containing name and other properties
         target_scores: List of score objects to process initially
         use_cache: Whether to use local cache files instead of always fetching from API
-                  When False, will always fetch from API but still write cache files
-                  When True, will check local cache first and only fetch missing configs
+                  When False, fetch from API and keep configurations in memory only
+                  When True, check local cache first and only fetch missing configs
         specific_version: Optional specific version ID to use instead of champion version
         
     Returns:
@@ -354,4 +354,4 @@ def iteratively_fetch_configurations(
                 logging.warning(f"Could not update version in configuration: {str(e)}")
     
     # Return all configurations
-    return configurations 
+    return configurations

--- a/plexus/reports/blocks/__init__.py
+++ b/plexus/reports/blocks/__init__.py
@@ -18,6 +18,7 @@ from .acceptance_rate_timeline import AcceptanceRateTimeline
 from .recent_feedback import RecentFeedback
 from .score_champion_version_timeline import ScoreChampionVersionTimeline
 from .scorecard_history import ScorecardHistory
+from .score_results_report import ScoreResultsReport
 
 __all__ = [
     "BaseReportBlock",
@@ -38,4 +39,5 @@ __all__ = [
     "RecentFeedback",
     "ScoreChampionVersionTimeline",
     "ScorecardHistory",
+    "ScoreResultsReport",
 ]

--- a/plexus/reports/blocks/score_results_report.py
+++ b/plexus/reports/blocks/score_results_report.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import date, datetime
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+
+from plexus.cli.shared.identifier_resolution import resolve_item_reference
+from .reinforcement_helpers import fetch_item_identifiers
+
+from .base import BaseReportBlock
+from .feedback_scope_resolver import (
+    list_scores_for_scorecard,
+    resolve_score_for_scorecard,
+    resolve_scorecard,
+)
+
+
+@dataclass(frozen=True)
+class _ResolvedScoreScope:
+    score_id: str
+    score_name: str
+
+
+@dataclass(frozen=True)
+class _ResolvedItem:
+    input_identifier: str
+    item_id: str
+    resolution_source: Optional[str]
+    order_index: int
+    item_identifiers: Optional[List[Dict[str, str]]] = None
+
+
+class ScoreResultsReport(BaseReportBlock):
+    DEFAULT_NAME = "Score Results Report"
+    DEFAULT_DESCRIPTION = "Prediction results for requested item identifiers"
+    MAX_PREDICTION_CONCURRENCY = 4
+
+    async def generate(self) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        self.log_messages = []
+        try:
+            scorecard_identifier_raw = self._get_param("scorecard")
+            if not scorecard_identifier_raw:
+                raise ValueError("'scorecard' is required.")
+            scorecard_identifier = str(scorecard_identifier_raw).strip()
+            if not scorecard_identifier:
+                raise ValueError("'scorecard' is required.")
+
+            score_identifier_raw = self._get_param("score") or self._get_param("score_id")
+            score_identifier = (
+                str(score_identifier_raw).strip()
+                if score_identifier_raw is not None and str(score_identifier_raw).strip()
+                else None
+            )
+
+            input_ids = self._parse_ids()
+            scorecard = await self._resolve_scorecard(scorecard_identifier)
+            scores_to_analyze = await self._resolve_scores_for_mode(
+                scorecard_id=scorecard.id,
+                score_identifier=score_identifier,
+            )
+            if not scores_to_analyze:
+                raise ValueError("No scores found for the requested scope.")
+
+            account_id = await self._resolve_account_id(scorecard.id)
+            resolved_items, unresolved_identifiers = await self._resolve_items(
+                input_ids=input_ids,
+                account_id=account_id,
+            )
+
+            self._log(
+                f"Running ScoreResultsReport for scorecard '{scorecard.name}' with "
+                f"{len(scores_to_analyze)} score(s), {len(input_ids)} input identifiers, "
+                f"{len(resolved_items)} resolved item(s), {len(unresolved_identifiers)} unresolved."
+            )
+
+            per_score_results: Dict[str, List[Dict[str, Any]]] = {
+                scope.score_id: [] for scope in scores_to_analyze
+            }
+            failed_predictions: List[Dict[str, Any]] = []
+
+            if resolved_items:
+                semaphore = asyncio.Semaphore(self.MAX_PREDICTION_CONCURRENCY)
+                tasks = [
+                    self._run_prediction_for_item_score_guarded(
+                        semaphore=semaphore,
+                        scorecard_identifier=scorecard_identifier,
+                        score_scope=score_scope,
+                        item=item,
+                    )
+                    for item in resolved_items
+                    for score_scope in scores_to_analyze
+                ]
+                prediction_results = await asyncio.gather(*tasks)
+            else:
+                prediction_results = []
+
+            for score_id, result_entry, failed_entry in prediction_results:
+                per_score_results.setdefault(score_id, []).append(result_entry)
+                if failed_entry:
+                    failed_predictions.append(failed_entry)
+
+            for score_id, rows in per_score_results.items():
+                rows.sort(
+                    key=lambda row: (
+                        int(row.get("_order_index", 0)),
+                        str(row.get("input_identifier") or ""),
+                    )
+                )
+                for row in rows:
+                    row.pop("_order_index", None)
+
+            score_outputs: List[Dict[str, Any]] = []
+            for scope in scores_to_analyze:
+                score_outputs.append(
+                    {
+                        "score_id": scope.score_id,
+                        "score_name": scope.score_name,
+                        "results": per_score_results.get(scope.score_id, []),
+                    }
+                )
+
+            total_predictions = sum(len(score.get("results") or []) for score in score_outputs)
+            failed_prediction_count = len(failed_predictions)
+            success_prediction_count = max(total_predictions - failed_prediction_count, 0)
+            mode = "single_score" if score_identifier else "scorecard_all_scores"
+
+            output: Dict[str, Any] = {
+                "report_type": "score_results_report",
+                "block_title": self.DEFAULT_NAME,
+                "block_description": self.DEFAULT_DESCRIPTION,
+                "scope": mode,
+                "scorecard_id": scorecard.id,
+                "scorecard_name": scorecard.name,
+                "score_id": scores_to_analyze[0].score_id if mode == "single_score" else None,
+                "score_name": scores_to_analyze[0].score_name if mode == "single_score" else None,
+                "ids": input_ids,
+                "summary": {
+                    "input_identifier_count": len(input_ids),
+                    "resolved_item_count": len(resolved_items),
+                    "unresolved_identifier_count": len(unresolved_identifiers),
+                    "scores_analyzed": len(scores_to_analyze),
+                    "total_predictions": total_predictions,
+                    "successful_predictions": success_prediction_count,
+                    "failed_predictions": failed_prediction_count,
+                },
+                "scores": score_outputs,
+                "unresolved_identifiers": unresolved_identifiers,
+                "failed_predictions": failed_predictions,
+            }
+            output = self._to_json_safe(output)
+            return output, self._get_log_string()
+        except Exception as exc:
+            self._log(f"ERROR generating ScoreResultsReport: {exc}", level="ERROR")
+            return {
+                "report_type": "score_results_report",
+                "block_title": self.DEFAULT_NAME,
+                "block_description": self.DEFAULT_DESCRIPTION,
+                "error": str(exc),
+                "scores": [],
+            }, self._get_log_string()
+
+    def _to_json_safe(self, value: Any) -> Any:
+        if isinstance(value, Decimal):
+            return float(value)
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+        if isinstance(value, dict):
+            return {str(k): self._to_json_safe(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [self._to_json_safe(v) for v in value]
+        try:
+            json.dumps(value)
+            return value
+        except Exception:
+            return str(value)
+
+    def _get_param(self, name: str) -> Any:
+        if name in self.config and self.config.get(name) is not None:
+            return self.config.get(name)
+        if name in self.params and self.params.get(name) is not None:
+            return self.params.get(name)
+        param_name = f"param_{name}"
+        if param_name in self.params and self.params.get(param_name) is not None:
+            return self.params.get(param_name)
+        return None
+
+    def _parse_ids(self) -> List[str]:
+        raw_ids = self._get_param("ids")
+        raw_id_flags = self._get_param("id")
+        parts: List[str] = []
+
+        def _add(value: Any) -> None:
+            if value is None:
+                return
+            if isinstance(value, (list, tuple, set)):
+                for entry in value:
+                    _add(entry)
+                return
+            text = str(value).strip()
+            if not text:
+                return
+            if "," in text:
+                for piece in text.split(","):
+                    normalized = piece.strip()
+                    if normalized:
+                        parts.append(normalized)
+                return
+            parts.append(text)
+
+        _add(raw_ids)
+        _add(raw_id_flags)
+
+        deduped: List[str] = []
+        seen: set[str] = set()
+        for identifier in parts:
+            if identifier in seen:
+                continue
+            seen.add(identifier)
+            deduped.append(identifier)
+
+        if not deduped:
+            raise ValueError("At least one item identifier is required via 'ids' or 'id'.")
+        return deduped
+
+    async def _resolve_scorecard(self, scorecard_identifier: str) -> Any:
+        return await resolve_scorecard(self.api_client, scorecard_identifier)
+
+    async def _resolve_scores_for_mode(
+        self,
+        *,
+        scorecard_id: str,
+        score_identifier: Optional[str],
+    ) -> List[_ResolvedScoreScope]:
+        if score_identifier:
+            score = await resolve_score_for_scorecard(
+                self.api_client,
+                scorecard_id,
+                score_identifier,
+            )
+            return [_ResolvedScoreScope(score_id=score.id, score_name=score.name)]
+
+        scores = await list_scores_for_scorecard(self.api_client, scorecard_id)
+        return [
+            _ResolvedScoreScope(score_id=score.id, score_name=score.name)
+            for score in scores
+        ]
+
+    async def _resolve_account_id(self, scorecard_id: str) -> str:
+        account_id = (
+            self._get_param("account_id")
+            or self._get_param("param_account_id")
+            or getattr(self.api_client, "account_id", None)
+        )
+        if account_id:
+            return str(account_id)
+
+        query = """
+        query GetScorecardAccountForScoreResultsReport($id: ID!) {
+            getScorecard(id: $id) {
+                id
+                accountId
+            }
+        }
+        """
+        result = await asyncio.to_thread(self.api_client.execute, query, {"id": scorecard_id})
+        account_id = ((result or {}).get("getScorecard") or {}).get("accountId")
+        if not account_id:
+            raise ValueError("Could not resolve account_id required for item identifier resolution.")
+        return str(account_id)
+
+    async def _resolve_items(
+        self,
+        *,
+        input_ids: List[str],
+        account_id: str,
+    ) -> Tuple[List[_ResolvedItem], List[Dict[str, Any]]]:
+        resolved: List[_ResolvedItem] = []
+        unresolved: List[Dict[str, Any]] = []
+        for order_index, identifier in enumerate(input_ids):
+            try:
+                resolved_ref = await asyncio.to_thread(
+                    resolve_item_reference,
+                    self.api_client,
+                    identifier,
+                    account_id,
+                )
+                if not resolved_ref:
+                    unresolved.append(
+                        {
+                            "input_identifier": identifier,
+                            "status": "unresolved",
+                            "error": "No item found for identifier.",
+                        }
+                    )
+                    continue
+
+                item_id, source = resolved_ref
+                item_identifiers = await fetch_item_identifiers(self.api_client, str(item_id))
+                resolved.append(
+                    _ResolvedItem(
+                        input_identifier=identifier,
+                        item_id=str(item_id),
+                        resolution_source=str(source) if source is not None else None,
+                        order_index=order_index,
+                        item_identifiers=item_identifiers,
+                    )
+                )
+            except Exception as exc:
+                unresolved.append(
+                    {
+                        "input_identifier": identifier,
+                        "status": "unresolved",
+                        "error": str(exc),
+                    }
+                )
+        return resolved, unresolved
+
+    async def _run_prediction_for_item_score_guarded(
+        self,
+        *,
+        semaphore: asyncio.Semaphore,
+        scorecard_identifier: str,
+        score_scope: _ResolvedScoreScope,
+        item: _ResolvedItem,
+    ) -> Tuple[str, Dict[str, Any], Optional[Dict[str, Any]]]:
+        async with semaphore:
+            return await self._run_prediction_for_item_score(
+                scorecard_identifier=scorecard_identifier,
+                score_scope=score_scope,
+                item=item,
+            )
+
+    async def _run_prediction_for_item_score(
+        self,
+        *,
+        scorecard_identifier: str,
+        score_scope: _ResolvedScoreScope,
+        item: _ResolvedItem,
+    ) -> Tuple[str, Dict[str, Any], Optional[Dict[str, Any]]]:
+        from plexus.cli.prediction.predictions import (
+            persist_prediction_score_result,
+            predict_score_with_individual_loading,
+            select_sample,
+        )
+
+        base_result = {
+            "input_identifier": item.input_identifier,
+            "resolved_item_id": item.item_id,
+            "item_identifiers": item.item_identifiers,
+            "resolution_source": item.resolution_source,
+            "score_id": score_scope.score_id,
+            "score_name": score_scope.score_name,
+            "_order_index": item.order_index,
+        }
+        try:
+            sample_row, used_item_id = await asyncio.to_thread(
+                select_sample,
+                scorecard_identifier,
+                score_scope.score_name,
+                item.item_id,
+                False,
+            )
+            scorecard_instance, prediction_result, costs = await predict_score_with_individual_loading(
+                scorecard_identifier=scorecard_identifier,
+                score_name=score_scope.score_name,
+                sample_row=sample_row,
+                used_item_id=used_item_id,
+                no_cache=False,
+                yaml_only=False,
+                specific_version=None,
+            )
+
+            if not prediction_result or getattr(prediction_result, "value", None) is None:
+                raise ValueError("Prediction returned no value.")
+
+            trace = getattr(prediction_result, "trace", None)
+            metadata = getattr(prediction_result, "metadata", None)
+            if trace is None and isinstance(metadata, dict):
+                trace = metadata.get("trace")
+            explanation = (
+                getattr(prediction_result, "explanation", None)
+                or (metadata.get("explanation") if isinstance(metadata, dict) else "")
+                or ""
+            )
+
+            score_result = await asyncio.to_thread(
+                persist_prediction_score_result,
+                scorecard_instance=scorecard_instance,
+                scorecard_identifier=scorecard_identifier,
+                score_name=score_scope.score_name,
+                item_id=used_item_id,
+                prediction=prediction_result,
+                costs=costs,
+                trace=trace,
+            )
+            result = {
+                **base_result,
+                "status": "success",
+                "score_result_id": getattr(score_result, "id", None),
+                "value": getattr(prediction_result, "value", None),
+                "explanation": explanation,
+                "cost": costs,
+                "trace": trace,
+                "error": None,
+            }
+            return score_scope.score_id, result, None
+        except Exception as exc:
+            result = {
+                **base_result,
+                "status": "failed",
+                "score_result_id": None,
+                "value": None,
+                "explanation": None,
+                "cost": None,
+                "trace": None,
+                "error": str(exc),
+            }
+            failed_entry = {
+                "input_identifier": item.input_identifier,
+                "resolved_item_id": item.item_id,
+                "score_id": score_scope.score_id,
+                "score_name": score_scope.score_name,
+                "error": str(exc),
+            }
+            self._log(
+                f"Prediction failed for item '{item.input_identifier}' ({item.item_id}) "
+                f"score '{score_scope.score_name}': {exc}",
+                level="WARNING",
+            )
+            return score_scope.score_id, result, failed_entry

--- a/plexus/reports/blocks/score_results_report_test.py
+++ b/plexus/reports/blocks/score_results_report_test.py
@@ -1,0 +1,229 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from decimal import Decimal
+import json
+
+import pytest
+
+from plexus.reports.blocks.score_results_report import (
+    ScoreResultsReport,
+    _ResolvedItem,
+    _ResolvedScoreScope,
+)
+
+
+@pytest.fixture
+def mock_api_client():
+    client = MagicMock()
+    client.account_id = "acct-1"
+    return client
+
+
+def _block(config, api_client):
+    return ScoreResultsReport(config=config, params={"account_id": "acct-1"}, api_client=api_client)
+
+
+@pytest.mark.asyncio
+async def test_scorecard_scope_runs_all_scores_and_groups_results_by_score(mock_api_client):
+    block = _block({"scorecard": "1562", "ids": ["a", "b"]}, mock_api_client)
+    scorecard = SimpleNamespace(id="sc-1", name="Test Scorecard")
+    scopes = [
+        _ResolvedScoreScope(score_id="score-1", score_name="Score 1"),
+        _ResolvedScoreScope(score_id="score-2", score_name="Score 2"),
+    ]
+    resolved_items = [
+        _ResolvedItem(input_identifier="a", item_id="item-a", resolution_source="id", order_index=0),
+        _ResolvedItem(input_identifier="b", item_id="item-b", resolution_source="identifier", order_index=1),
+    ]
+    unresolved = [{"input_identifier": "x", "status": "unresolved", "error": "Not found"}]
+
+    async def _prediction_side_effect(scorecard_identifier, score_scope, item):
+        return (
+            score_scope.score_id,
+            {
+                "input_identifier": item.input_identifier,
+                "resolved_item_id": item.item_id,
+                "status": "success",
+                "score_result_id": f"sr-{score_scope.score_id}-{item.item_id}",
+                "value": "yes",
+                "explanation": "ok",
+                "cost": {"total_cost": 0.1},
+                "trace": {"node_results": []},
+                "error": None,
+                "_order_index": item.order_index,
+            },
+            None,
+        )
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=scopes)),
+        patch.object(block, "_resolve_account_id", new=AsyncMock(return_value="acct-1")),
+        patch.object(block, "_resolve_items", new=AsyncMock(return_value=(resolved_items, unresolved))),
+        patch.object(block, "_run_prediction_for_item_score", new=AsyncMock(side_effect=_prediction_side_effect)),
+    ):
+        output, _ = await block.generate()
+
+    assert output["report_type"] == "score_results_report"
+    assert output["scope"] == "scorecard_all_scores"
+    assert output["score_id"] is None
+    assert [score["score_id"] for score in output["scores"]] == ["score-1", "score-2"]
+    assert [row["input_identifier"] for row in output["scores"][0]["results"]] == ["a", "b"]
+    assert [row["input_identifier"] for row in output["scores"][1]["results"]] == ["a", "b"]
+    assert output["unresolved_identifiers"] == unresolved
+    assert output["summary"]["total_predictions"] == 4
+    assert output["summary"]["failed_predictions"] == 0
+    assert output["summary"]["successful_predictions"] == 4
+
+
+@pytest.mark.asyncio
+async def test_single_score_scope_sets_score_fields(mock_api_client):
+    block = _block({"scorecard": "1562", "score": "my-score", "ids": ["a"]}, mock_api_client)
+    scorecard = SimpleNamespace(id="sc-1", name="Test Scorecard")
+    scope = _ResolvedScoreScope(score_id="score-1", score_name="Score 1")
+    resolved_items = [_ResolvedItem(input_identifier="a", item_id="item-a", resolution_source="id", order_index=0)]
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])) as resolve_scores,
+        patch.object(block, "_resolve_account_id", new=AsyncMock(return_value="acct-1")),
+        patch.object(block, "_resolve_items", new=AsyncMock(return_value=(resolved_items, []))),
+        patch.object(
+            block,
+            "_run_prediction_for_item_score",
+            new=AsyncMock(
+                return_value=(
+                    "score-1",
+                    {
+                        "input_identifier": "a",
+                        "resolved_item_id": "item-a",
+                        "status": "success",
+                        "score_result_id": "sr-1",
+                        "value": "yes",
+                        "explanation": "ok",
+                        "cost": {"total_cost": 0.2},
+                        "trace": {"node_results": []},
+                        "error": None,
+                        "_order_index": 0,
+                    },
+                    None,
+                )
+            ),
+        ),
+    ):
+        output, _ = await block.generate()
+
+    resolve_scores.assert_awaited_once_with(scorecard_id="sc-1", score_identifier="my-score")
+    assert output["scope"] == "single_score"
+    assert output["score_id"] == "score-1"
+    assert output["score_name"] == "Score 1"
+
+
+@pytest.mark.asyncio
+async def test_prediction_failures_are_reported_without_failing_report(mock_api_client):
+    block = _block({"scorecard": "1562", "ids": ["a"]}, mock_api_client)
+    scorecard = SimpleNamespace(id="sc-1", name="Test Scorecard")
+    scope = _ResolvedScoreScope(score_id="score-1", score_name="Score 1")
+    resolved_items = [_ResolvedItem(input_identifier="a", item_id="item-a", resolution_source="id", order_index=0)]
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_resolve_account_id", new=AsyncMock(return_value="acct-1")),
+        patch.object(block, "_resolve_items", new=AsyncMock(return_value=(resolved_items, []))),
+        patch.object(
+            block,
+            "_run_prediction_for_item_score",
+            new=AsyncMock(
+                return_value=(
+                    "score-1",
+                    {
+                        "input_identifier": "a",
+                        "resolved_item_id": "item-a",
+                        "status": "failed",
+                        "score_result_id": None,
+                        "value": None,
+                        "explanation": None,
+                        "cost": None,
+                        "trace": None,
+                        "error": "Prediction failed",
+                        "_order_index": 0,
+                    },
+                    {
+                        "input_identifier": "a",
+                        "resolved_item_id": "item-a",
+                        "score_id": "score-1",
+                        "score_name": "Score 1",
+                        "error": "Prediction failed",
+                    },
+                )
+            ),
+        ),
+    ):
+        output, _ = await block.generate()
+
+    assert output["scores"][0]["results"][0]["status"] == "failed"
+    assert output["failed_predictions"] == [
+        {
+            "input_identifier": "a",
+            "resolved_item_id": "item-a",
+            "score_id": "score-1",
+            "score_name": "Score 1",
+            "error": "Prediction failed",
+        }
+    ]
+    assert output["summary"]["total_predictions"] == 1
+    assert output["summary"]["failed_predictions"] == 1
+
+
+def test_parse_ids_accepts_comma_and_list_and_dedupes(mock_api_client):
+    block = _block({"scorecard": "1562", "ids": "one,two, one", "id": ["three", "two"]}, mock_api_client)
+    assert block._parse_ids() == ["one", "two", "three"]
+
+
+@pytest.mark.asyncio
+async def test_generate_errors_when_no_identifiers(mock_api_client):
+    block = _block({"scorecard": "1562"}, mock_api_client)
+    output, _ = await block.generate()
+    assert "At least one item identifier is required" in output["error"]
+
+
+@pytest.mark.asyncio
+async def test_generate_output_is_json_serializable_when_cost_contains_decimal(mock_api_client):
+    block = _block({"scorecard": "1562", "ids": ["a"]}, mock_api_client)
+    scorecard = SimpleNamespace(id="sc-1", name="Test Scorecard")
+    scope = _ResolvedScoreScope(score_id="score-1", score_name="Score 1")
+    resolved_items = [_ResolvedItem(input_identifier="a", item_id="item-a", resolution_source="id", order_index=0)]
+
+    with (
+        patch.object(block, "_resolve_scorecard", new=AsyncMock(return_value=scorecard)),
+        patch.object(block, "_resolve_scores_for_mode", new=AsyncMock(return_value=[scope])),
+        patch.object(block, "_resolve_account_id", new=AsyncMock(return_value="acct-1")),
+        patch.object(block, "_resolve_items", new=AsyncMock(return_value=(resolved_items, []))),
+        patch.object(
+            block,
+            "_run_prediction_for_item_score",
+            new=AsyncMock(
+                return_value=(
+                    "score-1",
+                    {
+                        "input_identifier": "a",
+                        "resolved_item_id": "item-a",
+                        "status": "success",
+                        "score_result_id": "sr-1",
+                        "value": "yes",
+                        "explanation": "ok",
+                        "cost": {"total_cost": Decimal("0.25"), "parts": [Decimal("0.10"), Decimal("0.15")]},
+                        "trace": {"created_at": "2026-05-07T00:00:00Z"},
+                        "error": None,
+                        "_order_index": 0,
+                    },
+                    None,
+                )
+            ),
+        ),
+    ):
+        output, _ = await block.generate()
+
+    assert output["scores"][0]["results"][0]["cost"]["total_cost"] == 0.25
+    json.dumps(output)

--- a/plexus/tests/test_iterative_config_fetching.py
+++ b/plexus/tests/test_iterative_config_fetching.py
@@ -151,6 +151,35 @@ model: test-model
         # Verify fetch_score_configurations was called twice (once per iteration)
         assert mock_fetch_configurations.call_count == 2
 
+    def test_api_only_mode_propagates_to_configuration_fetches(self, mock_client, mock_check_cache):
+        """use_cache=False must keep the whole dependency fetch path API-only."""
+
+        with patch(
+            'plexus.cli.shared.iterative_config_fetching.fetch_score_configurations'
+        ) as mock_fetch:
+            def side_effect(client, scorecard_data, scores, cache_status, use_cache=False):
+                configs = {}
+                for score in scores:
+                    score_id = score.get('id')
+                    if score_id == 'score-with-deps-id':
+                        configs[score_id] = self.mock_score_config_with_deps
+                    elif score_id == 'dependency-score-id':
+                        configs[score_id] = self.mock_dependency_config
+                return configs
+
+            mock_fetch.side_effect = side_effect
+
+            result = iteratively_fetch_configurations(
+                mock_client,
+                self.mock_scorecard_data,
+                self.mock_target_scores,
+                use_cache=False
+            )
+
+        assert len(result) == 2
+        assert mock_fetch.call_count == 2
+        assert all(call.kwargs["use_cache"] is False for call in mock_fetch.call_args_list)
+
     def test_complete_structure_fetching(self, mock_client, mock_fetch_configurations, mock_check_cache):
         """Test that complete scorecard structure is fetched for dependency resolution."""
         

--- a/project/events/2026-05-06T14:31:37.603Z__180e4309-14bd-4444-937a-dcdecd8fe118.json
+++ b/project/events/2026-05-06T14:31:37.603Z__180e4309-14bd-4444-937a-dcdecd8fe118.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "180e4309-14bd-4444-937a-dcdecd8fe118",
+  "issue_id": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T14:31:37.603Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Set up PolicyPoint Sales Skills QA scorecard",
+    "description": "Create the new PolicyPoint Sales Skills QA scorecard from the SalesFloor SOW workbook.\n\nScope:\n- Extract scorecard metadata and populated score rubrics from `/Users/ryan/Downloads/SalesFloor_Sales Skills SOW_v2.xlsx`.\n- Create the scorecard and score records in Plexus.\n- Transform each rubric into Plexus classifier guidelines.\n- Validate every generated guidelines document before publishing it to score versions.\n\nDefinition of Done:\n- Scorecard record exists and is verified.\n- All populated workbook items have score records.\n- Each score has valid guidelines created from the workbook rubric.\n- Final setup is verified with Plexus read APIs.",
+    "issue_type": "epic",
+    "status": "open",
+    "priority": 2,
+    "assignee": null,
+    "parent": null,
+    "labels": []
+  }
+}

--- a/project/events/2026-05-06T14:31:43.889Z__c934069f-ddfb-459c-848a-f3485ee019a7.json
+++ b/project/events/2026-05-06T14:31:43.889Z__c934069f-ddfb-459c-848a-f3485ee019a7.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "c934069f-ddfb-459c-848a-f3485ee019a7",
+  "issue_id": "plx-37b7f7ac-fdd5-463a-809a-65842883b990",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T14:31:43.889Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Create records and validated guidelines for PolicyPoint sales skills",
+    "description": "Implement the setup for the PolicyPoint Sales Skills QA Scorecard.\n\nSteps:\n1. Parse workbook metadata and populated item rubrics.\n2. Create or verify the scorecard and score records.\n3. Generate classifier guidelines for each populated score.\n4. Validate guidelines with `skills/guidelines/validate_guidelines.py`.\n5. Publish validated guidelines to score versions and verify via Plexus read APIs.\n\nNotes:\n- Workbook contains populated Items 1-6 and 11-14; item numbers 7-10 are not populated in the provided workbook.\n- MCP exposes score version update but not scorecard/score create methods, so record creation may need the local GraphQL client path.",
+    "issue_type": "task",
+    "status": "open",
+    "priority": 2,
+    "assignee": null,
+    "parent": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-06T14:31:48.494Z__aa60bc0b-9c2b-43e0-bf2b-2a7bc0cd490a.json
+++ b/project/events/2026-05-06T14:31:48.494Z__aa60bc0b-9c2b-43e0-bf2b-2a7bc0cd490a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "aa60bc0b-9c2b-43e0-bf2b-2a7bc0cd490a",
+  "issue_id": "plx-37b7f7ac-fdd5-463a-809a-65842883b990",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:31:48.494Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "08d5e8ec-9e05-408f-9ea5-fb951b6abe89",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:31:48.513Z__be9ea3f5-296e-4638-a26c-39528cdda595.json
+++ b/project/events/2026-05-06T14:31:48.513Z__be9ea3f5-296e-4638-a26c-39528cdda595.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "be9ea3f5-296e-4638-a26c-39528cdda595",
+  "issue_id": "plx-37b7f7ac-fdd5-463a-809a-65842883b990",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:31:48.513Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T14:36:59.373Z__2167d2f0-1585-45b3-a42b-47415d1c5527.json
+++ b/project/events/2026-05-06T14:36:59.373Z__2167d2f0-1585-45b3-a42b-47415d1c5527.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2167d2f0-1585-45b3-a42b-47415d1c5527",
+  "issue_id": "plx-37b7f7ac-fdd5-463a-809a-65842883b990",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:36:59.373Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "cd8bdcbc-18cd-42df-a462-e01be1c66a18",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:39:25.703Z__c51750c5-27ed-4ff7-8b60-b651c6c2a81b.json
+++ b/project/events/2026-05-06T14:39:25.703Z__c51750c5-27ed-4ff7-8b60-b651c6c2a81b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c51750c5-27ed-4ff7-8b60-b651c6c2a81b",
+  "issue_id": "plx-37b7f7ac-fdd5-463a-809a-65842883b990",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:39:25.703Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "96f6752e-ac30-46cc-a87b-a2bc8f29d7d2",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:39:40.463Z__3ca19e08-dfa4-48fd-b604-fba12f3678b9.json
+++ b/project/events/2026-05-06T14:39:40.463Z__3ca19e08-dfa4-48fd-b604-fba12f3678b9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3ca19e08-dfa4-48fd-b604-fba12f3678b9",
+  "issue_id": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:39:40.463Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "7f1a3723-f979-494e-bd83-5fe2641da673",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:39:40.463Z__f2e24475-6db4-4d9f-8bad-11fbd55c7954.json
+++ b/project/events/2026-05-06T14:39:40.463Z__f2e24475-6db4-4d9f-8bad-11fbd55c7954.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f2e24475-6db4-4d9f-8bad-11fbd55c7954",
+  "issue_id": "plx-37b7f7ac-fdd5-463a-809a-65842883b990",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:39:40.463Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "53fd0314-f714-4d1f-9bfa-bdadbd1e51cb",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:39:44.788Z__1241bd0d-1bdf-4319-9fa5-70248df54e7a.json
+++ b/project/events/2026-05-06T14:39:44.788Z__1241bd0d-1bdf-4319-9fa5-70248df54e7a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1241bd0d-1bdf-4319-9fa5-70248df54e7a",
+  "issue_id": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:39:44.788Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-06T14:39:44.788Z__2aa7813b-4cad-46f0-bfd1-e7d6f9927e3e.json
+++ b/project/events/2026-05-06T14:39:44.788Z__2aa7813b-4cad-46f0-bfd1-e7d6f9927e3e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2aa7813b-4cad-46f0-bfd1-e7d6f9927e3e",
+  "issue_id": "plx-37b7f7ac-fdd5-463a-809a-65842883b990",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:39:44.788Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-06T14:41:26.276Z__4eb45eb9-1d03-4fc4-9db1-a7120cd94084.json
+++ b/project/events/2026-05-06T14:41:26.276Z__4eb45eb9-1d03-4fc4-9db1-a7120cd94084.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "4eb45eb9-1d03-4fc4-9db1-a7120cd94084",
+  "issue_id": "plx-040f4094-af67-4bb0-ae24-23b6345dd8b8",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T14:41:26.276Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Rename PolicyPoint four-class labels to Yes and No",
+    "description": "Update the PolicyPoint Sales Skills QA score versions that currently use Met / Partially Met / Missed / NA.\n\nRequired behavior:\n- Rename Met to Yes.\n- Rename Missed/not met to No.\n- Retain Partially Met and NA.\n- Regenerate matching guidelines and score configs.\n- Validate guidelines with `skills/guidelines/validate_guidelines.py`.\n- Publish and promote updated score versions for the affected scores only.",
+    "issue_type": "task",
+    "status": "open",
+    "priority": 2,
+    "assignee": null,
+    "parent": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-06T14:41:45.525Z__d712bdc7-244c-4587-bf87-f3a003cef79a.json
+++ b/project/events/2026-05-06T14:41:45.525Z__d712bdc7-244c-4587-bf87-f3a003cef79a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d712bdc7-244c-4587-bf87-f3a003cef79a",
+  "issue_id": "plx-040f4094-af67-4bb0-ae24-23b6345dd8b8",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:41:45.525Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "d849ebe6-b357-47c5-b287-1d4938fab9ba",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:41:45.541Z__50d9e831-cbd4-4995-bb24-e888146e5187.json
+++ b/project/events/2026-05-06T14:41:45.541Z__50d9e831-cbd4-4995-bb24-e888146e5187.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "50d9e831-cbd4-4995-bb24-e888146e5187",
+  "issue_id": "plx-040f4094-af67-4bb0-ae24-23b6345dd8b8",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:41:45.541Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T14:43:12.514Z__bde9a91d-035c-4120-9df0-59fb3cf3b7de.json
+++ b/project/events/2026-05-06T14:43:12.514Z__bde9a91d-035c-4120-9df0-59fb3cf3b7de.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bde9a91d-035c-4120-9df0-59fb3cf3b7de",
+  "issue_id": "plx-040f4094-af67-4bb0-ae24-23b6345dd8b8",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:43:12.514Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "66f98194-2323-474f-84a9-b1ea3213ca59",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:44:01.653Z__e4a23213-75ed-45a8-9841-7942aa338bb3.json
+++ b/project/events/2026-05-06T14:44:01.653Z__e4a23213-75ed-45a8-9841-7942aa338bb3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e4a23213-75ed-45a8-9841-7942aa338bb3",
+  "issue_id": "plx-040f4094-af67-4bb0-ae24-23b6345dd8b8",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:44:01.653Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "e513f3e1-0fa3-4448-a0c2-b16d275b47e2",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:44:05.007Z__2dd189bd-9a7a-42b5-9243-302562ecece0.json
+++ b/project/events/2026-05-06T14:44:05.007Z__2dd189bd-9a7a-42b5-9243-302562ecece0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2dd189bd-9a7a-42b5-9243-302562ecece0",
+  "issue_id": "plx-040f4094-af67-4bb0-ae24-23b6345dd8b8",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:44:05.007Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-06T14:47:19.891Z__a5d49f0c-a0ae-4ef7-9068-74d24bfce175.json
+++ b/project/events/2026-05-06T14:47:19.891Z__a5d49f0c-a0ae-4ef7-9068-74d24bfce175.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "a5d49f0c-a0ae-4ef7-9068-74d24bfce175",
+  "issue_id": "plx-a579d9c5-3dd3-4490-9612-8ceefb3604dd",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T14:47:19.891Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Apply PolicyPoint external IDs and pending questions",
+    "description": "Update the existing PolicyPoint scorecard setup with the source system external IDs supplied by the user.\n\nScope:\n- Set scorecard external ID to `1562` for `PolicyPoint - Non-Sales`.\n- Set score external IDs 48846-48859 for the named questions.\n- Create any missing question records where needed.\n- Use workbook Items Template rubrics when available for guidelines/configuration.\n- Validate any generated or changed guidelines with `skills/guidelines/validate_guidelines.py`.\n- Verify final Plexus state by read-back.",
+    "issue_type": "task",
+    "status": "open",
+    "priority": 2,
+    "assignee": null,
+    "parent": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-06T14:48:01.784Z__43503ce6-33ce-4d31-a274-ba96d8d304c0.json
+++ b/project/events/2026-05-06T14:48:01.784Z__43503ce6-33ce-4d31-a274-ba96d8d304c0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "43503ce6-33ce-4d31-a274-ba96d8d304c0",
+  "issue_id": "plx-a579d9c5-3dd3-4490-9612-8ceefb3604dd",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:48:01.784Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T14:48:01.801Z__b317b442-d3e5-4274-98ba-b24da4f6fe89.json
+++ b/project/events/2026-05-06T14:48:01.801Z__b317b442-d3e5-4274-98ba-b24da4f6fe89.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b317b442-d3e5-4274-98ba-b24da4f6fe89",
+  "issue_id": "plx-a579d9c5-3dd3-4490-9612-8ceefb3604dd",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:48:01.801Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "6db3d90b-94c1-464c-9652-28b163e0cc4b",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:50:18.555Z__d2a3b2d5-7173-4c8f-8d79-4b2f1c0e3b4c.json
+++ b/project/events/2026-05-06T14:50:18.555Z__d2a3b2d5-7173-4c8f-8d79-4b2f1c0e3b4c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d2a3b2d5-7173-4c8f-8d79-4b2f1c0e3b4c",
+  "issue_id": "plx-a579d9c5-3dd3-4490-9612-8ceefb3604dd",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:50:18.555Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "f468503b-d5ce-4669-969f-560cb8698c14",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:50:18.574Z__017832f9-1e65-4456-b2a6-fd532e048f6b.json
+++ b/project/events/2026-05-06T14:50:18.574Z__017832f9-1e65-4456-b2a6-fd532e048f6b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "017832f9-1e65-4456-b2a6-fd532e048f6b",
+  "issue_id": "plx-a579d9c5-3dd3-4490-9612-8ceefb3604dd",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:50:18.574Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-06T14:53:06.934Z__fb4956b7-333c-4fdd-84aa-7a793cb260fb.json
+++ b/project/events/2026-05-06T14:53:06.934Z__fb4956b7-333c-4fdd-84aa-7a793cb260fb.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "fb4956b7-333c-4fdd-84aa-7a793cb260fb",
+  "issue_id": "plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T14:53:06.934Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Sync PolicyPoint classifier code classes with guidelines",
+    "description": "Compare PolicyPoint classifier champion guidelines against score code classes and update code where the class labels diverge.\n\nScope:\n- Inspect champion versions for PolicyPoint - Non-Sales.\n- Identify scores whose guidelines define classes that differ from `valid_classes` or `ClassifyProcedure` classes in code.\n- Publish corrected score versions preserving existing guidelines.\n- Promote corrected versions and verify by read-back.",
+    "issue_type": "task",
+    "status": "open",
+    "priority": 2,
+    "assignee": null,
+    "parent": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-06T14:53:19.298Z__77ee430b-11b6-4b08-87d8-78e2aaaa588b.json
+++ b/project/events/2026-05-06T14:53:19.298Z__77ee430b-11b6-4b08-87d8-78e2aaaa588b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "77ee430b-11b6-4b08-87d8-78e2aaaa588b",
+  "issue_id": "plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:53:19.298Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "9ee5843d-e19e-41bd-95c5-984aea9534d3",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:53:19.315Z__719857e1-2a24-456d-9337-54ef7294cd26.json
+++ b/project/events/2026-05-06T14:53:19.315Z__719857e1-2a24-456d-9337-54ef7294cd26.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "719857e1-2a24-456d-9337-54ef7294cd26",
+  "issue_id": "plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:53:19.315Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T14:55:03.285Z__0e7cbbbf-bbf5-4962-afcf-c9074e9e6b29.json
+++ b/project/events/2026-05-06T14:55:03.285Z__0e7cbbbf-bbf5-4962-afcf-c9074e9e6b29.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0e7cbbbf-bbf5-4962-afcf-c9074e9e6b29",
+  "issue_id": "plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:55:03.285Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "7ba23682-d17b-4f82-be31-2ff2bfdd4760",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:55:12.767Z__6093f8b4-0af0-47dc-857a-891421b8f1ff.json
+++ b/project/events/2026-05-06T14:55:12.767Z__6093f8b4-0af0-47dc-857a-891421b8f1ff.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6093f8b4-0af0-47dc-857a-891421b8f1ff",
+  "issue_id": "plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T14:55:12.767Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "4cc02a66-b30c-4913-8e24-f022469e4157",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-06T14:55:12.780Z__715f3985-6aff-4a8b-92b6-9723dbfc2e70.json
+++ b/project/events/2026-05-06T14:55:12.780Z__715f3985-6aff-4a8b-92b6-9723dbfc2e70.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "715f3985-6aff-4a8b-92b6-9723dbfc2e70",
+  "issue_id": "plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T14:55:12.780Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-07T16:10:10.484Z__882e0c0e-4149-4728-9c08-e170a55ba57a.json
+++ b/project/events/2026-05-07T16:10:10.484Z__882e0c0e-4149-4728-9c08-e170a55ba57a.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "882e0c0e-4149-4728-9c08-e170a55ba57a",
+  "issue_id": "plx-d54ab8bc-1e75-4fd5-b8f6-c2047cee7f56",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T16:10:10.484Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Score Results Report runs predictions for specified item identifiers",
+    "description": "As a lab operator, I want a report that runs predictions for a provided list of item identifiers on one score or an entire scorecard, so that I can review current prediction outcomes quickly.\n\nFeature: Score Results Report\n\nScenario: Scorecard scope predicts all scores for all resolved identifiers\nGiven a required scorecard identifier and a list of item identifiers\nAnd the score parameter is not provided\nWhen the report runs\nThen it resolves each identifier to an item id when possible\nAnd it runs predictions for each resolved item across all scores on the scorecard\nAnd it persists prediction score results\nAnd it returns output grouped by score\n\nScenario: Single-score scope predicts one score for all resolved identifiers\nGiven a required scorecard identifier, an optional score identifier, and a list of item identifiers\nWhen the report runs\nThen it resolves the score within the scorecard\nAnd it runs predictions only for that score across resolved items\nAnd it persists prediction score results\nAnd it returns output grouped by score\n\nScenario: Unresolved identifiers are reported without failing the report\nGiven at least one provided identifier cannot be resolved to an item\nWhen the report runs\nThen it continues predicting for resolvable identifiers\nAnd it includes unresolved identifiers in diagnostics\nAnd report execution succeeds if at least one prediction succeeds\n\nScenario: CLI accepts both list styles for identifiers\nGiven a scorecard identifier\nWhen the user runs score-results-report with --ids comma-separated values\nOr the user repeats --id multiple times\nThen the report receives one normalized ids list\nAnd at least one identifier is required\n\nScenario: Detailed prediction payload is returned per item-score run\nGiven a prediction run completes for an item and score\nWhen output is generated\nThen each result includes status, score_result_id, value, explanation, cost, and trace when available\nAnd failed predictions include error details",
+    "issue_type": "story",
+    "status": "open",
+    "priority": 1,
+    "assignee": null,
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-07T16:10:19.897Z__08e10e5a-ad48-4e17-92b2-8a0d8d9e97cd.json
+++ b/project/events/2026-05-07T16:10:19.897Z__08e10e5a-ad48-4e17-92b2-8a0d8d9e97cd.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "08e10e5a-ad48-4e17-92b2-8a0d8d9e97cd",
+  "issue_id": "plx-78b08ea4-dd6a-44d3-a04f-1e290da6e6fd",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T16:10:19.897Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Add score-results-report direct CLI command",
+    "description": "Add feedback report score-results-report command with --scorecard, optional --score, and identifier inputs via --ids and repeatable --id; normalize/validate IDs and map to report block config.",
+    "issue_type": "task",
+    "status": "open",
+    "priority": 1,
+    "assignee": null,
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-07T16:10:19.897Z__4c4e8e95-6807-4e47-b906-d1f7d6504ecd.json
+++ b/project/events/2026-05-07T16:10:19.897Z__4c4e8e95-6807-4e47-b906-d1f7d6504ecd.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "4c4e8e95-6807-4e47-b906-d1f7d6504ecd",
+  "issue_id": "plx-b5749b6a-a7d7-45e4-8514-9adf69bdad9d",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T16:10:19.897Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Add BDD/spec coverage and tests for ScoreResultsReport",
+    "description": "Add backend, CLI, and dashboard tests for scope behavior, identifier input parsing, unresolved/failed handling, payload shape, and rendering behavior per story scenarios.",
+    "issue_type": "task",
+    "status": "open",
+    "priority": 1,
+    "assignee": null,
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-07T16:10:19.897Z__7e003877-c293-4817-9302-de09eabec83e.json
+++ b/project/events/2026-05-07T16:10:19.897Z__7e003877-c293-4817-9302-de09eabec83e.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "7e003877-c293-4817-9302-de09eabec83e",
+  "issue_id": "plx-cf118293-51d1-437c-96f3-3b4f98beab29",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T16:10:19.897Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Implement ScoreResultsReport backend block",
+    "description": "Implement new ScoreResultsReport report block: parameter parsing, scope resolution, identifier resolution, prediction execution + ScoreResult persistence, grouped-by-score output, diagnostics, bounded concurrency, and deterministic ordering.",
+    "issue_type": "task",
+    "status": "open",
+    "priority": 1,
+    "assignee": null,
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-07T16:10:19.897Z__9d57aeb3-8226-4dc2-b996-1d5da8d60204.json
+++ b/project/events/2026-05-07T16:10:19.897Z__9d57aeb3-8226-4dc2-b996-1d5da8d60204.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "9d57aeb3-8226-4dc2-b996-1d5da8d60204",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T16:10:19.897Z",
+  "actor_id": "ryan",
+  "payload": {
+    "title": "Build dashboard renderer for ScoreResultsReport",
+    "description": "Add dedicated dashboard block renderer grouped by score, including prediction details, expandable trace display, and diagnostics panels for unresolved identifiers and failed predictions.",
+    "issue_type": "task",
+    "status": "open",
+    "priority": 1,
+    "assignee": null,
+    "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+    "labels": []
+  }
+}

--- a/project/events/2026-05-07T16:10:24.766Z__f78adc53-7993-4ad9-b66e-bfcac2a1ffe5.json
+++ b/project/events/2026-05-07T16:10:24.766Z__f78adc53-7993-4ad9-b66e-bfcac2a1ffe5.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f78adc53-7993-4ad9-b66e-bfcac2a1ffe5",
+  "issue_id": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T16:10:24.766Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "ee46e617-6c5d-4911-8a1b-6e3a5bf5dd43",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-07T16:10:24.782Z__5a8648c1-5480-4649-90e0-146ca703cac2.json
+++ b/project/events/2026-05-07T16:10:24.782Z__5a8648c1-5480-4649-90e0-146ca703cac2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5a8648c1-5480-4649-90e0-146ca703cac2",
+  "issue_id": "plx-cf118293-51d1-437c-96f3-3b4f98beab29",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T16:10:24.782Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T16:10:24.782Z__da7ef2d7-5adb-414d-bdfc-3f603a19118b.json
+++ b/project/events/2026-05-07T16:10:24.782Z__da7ef2d7-5adb-414d-bdfc-3f603a19118b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "da7ef2d7-5adb-414d-bdfc-3f603a19118b",
+  "issue_id": "plx-d54ab8bc-1e75-4fd5-b8f6-c2047cee7f56",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T16:10:24.782Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T16:17:43.479Z__b6250131-13ee-4efa-afd4-fc52c334931a.json
+++ b/project/events/2026-05-07T16:17:43.479Z__b6250131-13ee-4efa-afd4-fc52c334931a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b6250131-13ee-4efa-afd4-fc52c334931a",
+  "issue_id": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T16:17:43.479Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "efe5e193-5f4b-4412-a512-d6e9ce612652",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-07T16:17:43.502Z__ac07c116-8029-43d7-98b8-78dac00f1637.json
+++ b/project/events/2026-05-07T16:17:43.502Z__ac07c116-8029-43d7-98b8-78dac00f1637.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ac07c116-8029-43d7-98b8-78dac00f1637",
+  "issue_id": "plx-b5749b6a-a7d7-45e4-8514-9adf69bdad9d",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T16:17:43.502Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T16:17:43.503Z__db6ae74c-afcb-48a5-8664-24ce0233a01a.json
+++ b/project/events/2026-05-07T16:17:43.503Z__db6ae74c-afcb-48a5-8664-24ce0233a01a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "db6ae74c-afcb-48a5-8664-24ce0233a01a",
+  "issue_id": "plx-78b08ea4-dd6a-44d3-a04f-1e290da6e6fd",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T16:17:43.503Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T16:17:43.504Z__69471c31-6d79-4188-b2fa-92ff4f6fb5a2.json
+++ b/project/events/2026-05-07T16:17:43.504Z__69471c31-6d79-4188-b2fa-92ff4f6fb5a2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "69471c31-6d79-4188-b2fa-92ff4f6fb5a2",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T16:17:43.504Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T16:19:26.105Z__6765582b-6cc7-45b1-9cf4-c30c0614cc25.json
+++ b/project/events/2026-05-07T16:19:26.105Z__6765582b-6cc7-45b1-9cf4-c30c0614cc25.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6765582b-6cc7-45b1-9cf4-c30c0614cc25",
+  "issue_id": "plx-cf118293-51d1-437c-96f3-3b4f98beab29",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T16:19:26.105Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_id": "7a5a4404-2617-490a-bde6-6b5f52e1ddef",
+    "comment_author": "ryan"
+  }
+}

--- a/project/events/2026-05-07T18:39:43.968Z__6d6cec8f-b369-4d7a-b10b-af0716b56160.json
+++ b/project/events/2026-05-07T18:39:43.968Z__6d6cec8f-b369-4d7a-b10b-af0716b56160.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "6d6cec8f-b369-4d7a-b10b-af0716b56160",
+  "issue_id": "plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-07T18:39:43.968Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Console execute_tactus predictions fail in Lambda because API-loaded score configs are still written to the local scorecards cache when use_cache=false. Make non-cache GraphQL loading in-memory only and prove with read-only smoke.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Fix Console prediction API-only config loading"
+  }
+}

--- a/project/events/2026-05-07T18:39:46.028Z__85420999-b43e-4efc-bd12-8f092601d908.json
+++ b/project/events/2026-05-07T18:39:46.028Z__85420999-b43e-4efc-bd12-8f092601d908.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "85420999-b43e-4efc-bd12-8f092601d908",
+  "issue_id": "plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T18:39:46.028Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-07T18:41:28.169Z__7651d2c1-d47f-4a71-bbc0-50ee4601a78a.json
+++ b/project/events/2026-05-07T18:41:28.169Z__7651d2c1-d47f-4a71-bbc0-50ee4601a78a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7651d2c1-d47f-4a71-bbc0-50ee4601a78a",
+  "issue_id": "plx-d54ab8bc-1e75-4fd5-b8f6-c2047cee7f56",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T18:41:28.169Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "cd22d4f8-06f3-4c05-a339-c7e15a7a0640"
+  }
+}

--- a/project/events/2026-05-07T18:41:28.169Z__f93857a6-ed73-4159-a661-4739e03f45bd.json
+++ b/project/events/2026-05-07T18:41:28.169Z__f93857a6-ed73-4159-a661-4739e03f45bd.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f93857a6-ed73-4159-a661-4739e03f45bd",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T18:41:28.169Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "bb03f4c5-53d6-4577-b128-8a6669dbe3b4"
+  }
+}

--- a/project/events/2026-05-07T18:44:14.054Z__b47ef7df-5e0f-4591-bb26-617d72661f64.json
+++ b/project/events/2026-05-07T18:44:14.054Z__b47ef7df-5e0f-4591-bb26-617d72661f64.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b47ef7df-5e0f-4591-bb26-617d72661f64",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T18:44:14.054Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "a5d9a9e6-2334-4547-ad76-77b77a7c33e1"
+  }
+}

--- a/project/events/2026-05-07T18:44:48.991Z__b2d2577a-a6fb-4fd4-b8ec-b7c41066b411.json
+++ b/project/events/2026-05-07T18:44:48.991Z__b2d2577a-a6fb-4fd4-b8ec-b7c41066b411.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b2d2577a-a6fb-4fd4-b8ec-b7c41066b411",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T18:44:48.991Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "f34a54ec-7ed1-4644-bbe9-e1268c96b44d"
+  }
+}

--- a/project/events/2026-05-07T18:45:08.553Z__4050c509-d067-4271-bb83-56b93c2973f4.json
+++ b/project/events/2026-05-07T18:45:08.553Z__4050c509-d067-4271-bb83-56b93c2973f4.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "4050c509-d067-4271-bb83-56b93c2973f4",
+  "issue_id": "plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-07T18:45:08.553Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-07T18:45:19.382Z__82af4102-96af-4d5b-9a01-99e60f168e49.json
+++ b/project/events/2026-05-07T18:45:19.382Z__82af4102-96af-4d5b-9a01-99e60f168e49.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "82af4102-96af-4d5b-9a01-99e60f168e49",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T18:45:19.382Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "edfee4ff-4978-4eb8-ae54-523f7036f75d"
+  }
+}

--- a/project/events/2026-05-07T18:47:48.943Z__07f029ba-5856-498b-b053-d66d4ed24bb6.json
+++ b/project/events/2026-05-07T18:47:48.943Z__07f029ba-5856-498b-b053-d66d4ed24bb6.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "07f029ba-5856-498b-b053-d66d4ed24bb6",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T18:47:48.943Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "01784911-cdc5-4762-a464-ef8349a7df77"
+  }
+}

--- a/project/events/2026-05-07T18:54:22.666Z__2626b677-3e34-4050-b6f5-66bd4d8b593e.json
+++ b/project/events/2026-05-07T18:54:22.666Z__2626b677-3e34-4050-b6f5-66bd4d8b593e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2626b677-3e34-4050-b6f5-66bd4d8b593e",
+  "issue_id": "plx-cf118293-51d1-437c-96f3-3b4f98beab29",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T18:54:22.666Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "aa01d204-29b1-41f9-a7b5-2c6a3416651f"
+  }
+}

--- a/project/events/2026-05-07T18:59:17.272Z__a459e363-4fc1-41d4-a0b1-ba14a0971217.json
+++ b/project/events/2026-05-07T18:59:17.272Z__a459e363-4fc1-41d4-a0b1-ba14a0971217.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a459e363-4fc1-41d4-a0b1-ba14a0971217",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T18:59:17.272Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "77bb16b6-9135-425f-ad07-c9a9696b51c7"
+  }
+}

--- a/project/events/2026-05-07T19:02:30.675Z__73f569da-3a9e-47df-aaf3-f120338b5d18.json
+++ b/project/events/2026-05-07T19:02:30.675Z__73f569da-3a9e-47df-aaf3-f120338b5d18.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "73f569da-3a9e-47df-aaf3-f120338b5d18",
+  "issue_id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T19:02:30.675Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "83cce1ce-8c1d-44b6-b06a-04ac238000dd"
+  }
+}

--- a/project/events/2026-05-07T19:04:23.374Z__b75e467b-e9cd-4f25-aec9-dc9d5a7e13ee.json
+++ b/project/events/2026-05-07T19:04:23.374Z__b75e467b-e9cd-4f25-aec9-dc9d5a7e13ee.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b75e467b-e9cd-4f25-aec9-dc9d5a7e13ee",
+  "issue_id": "plx-cf118293-51d1-437c-96f3-3b4f98beab29",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T19:04:23.374Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "167a5799-210c-492b-9ab4-fae190173712"
+  }
+}

--- a/project/events/2026-05-07T19:05:42.225Z__078faf87-b704-4bb9-b885-ea879b92c9e9.json
+++ b/project/events/2026-05-07T19:05:42.225Z__078faf87-b704-4bb9-b885-ea879b92c9e9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "078faf87-b704-4bb9-b885-ea879b92c9e9",
+  "issue_id": "plx-cf118293-51d1-437c-96f3-3b4f98beab29",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-07T19:05:42.225Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "44b3ea96-7bce-4176-9b25-e7cd0b7fc0a1"
+  }
+}

--- a/project/issues/plx-03d93482-b49d-4d3a-a997-31dc558f9979.json
+++ b/project/issues/plx-03d93482-b49d-4d3a-a997-31dc558f9979.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+  "title": "Set up PolicyPoint Sales Skills QA scorecard",
+  "description": "Create the new PolicyPoint Sales Skills QA scorecard from the SalesFloor SOW workbook.\n\nScope:\n- Extract scorecard metadata and populated score rubrics from `/Users/ryan/Downloads/SalesFloor_Sales Skills SOW_v2.xlsx`.\n- Create the scorecard and score records in Plexus.\n- Transform each rubric into Plexus classifier guidelines.\n- Validate every generated guidelines document before publishing it to score versions.\n\nDefinition of Done:\n- Scorecard record exists and is verified.\n- All populated workbook items have score records.\n- Each score has valid guidelines created from the workbook rubric.\n- Final setup is verified with Plexus read APIs.",
+  "type": "epic",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "7f1a3723-f979-494e-bd83-5fe2641da673",
+      "author": "ryan",
+      "text": "Closed after completion of child task plx-37b7f7. Scorecard and all populated workbook score rubrics are set up and verified in Plexus.",
+      "created_at": "2026-05-06T14:39:40.463078Z"
+    }
+  ],
+  "created_at": "2026-05-06T14:31:37.602876Z",
+  "updated_at": "2026-05-06T14:39:44.788067Z",
+  "closed_at": "2026-05-06T14:39:44.788067Z",
+  "custom": {}
+}

--- a/project/issues/plx-040f4094-af67-4bb0-ae24-23b6345dd8b8.json
+++ b/project/issues/plx-040f4094-af67-4bb0-ae24-23b6345dd8b8.json
@@ -1,0 +1,37 @@
+{
+  "id": "plx-040f4094-af67-4bb0-ae24-23b6345dd8b8",
+  "title": "Rename PolicyPoint four-class labels to Yes and No",
+  "description": "Update the PolicyPoint Sales Skills QA score versions that currently use Met / Partially Met / Missed / NA.\n\nRequired behavior:\n- Rename Met to Yes.\n- Rename Missed/not met to No.\n- Retain Partially Met and NA.\n- Regenerate matching guidelines and score configs.\n- Validate guidelines with `skills/guidelines/validate_guidelines.py`.\n- Publish and promote updated score versions for the affected scores only.",
+  "type": "task",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "d849ebe6-b357-47c5-b287-1d4938fab9ba",
+      "author": "ryan",
+      "text": "Started label correction. Existing setup payload is available. Affected scores are the 8 four-class classifiers; the 2 existing Yes / No / NA qualifying question scores are already aligned and will not be changed.",
+      "created_at": "2026-05-06T14:41:45.525527Z"
+    },
+    {
+      "id": "66f98194-2323-474f-84a9-b1ea3213ca59",
+      "author": "ryan",
+      "text": "Validated 8 regenerated guideline files and 8 regenerated score configs. Created 8 new score versions with the corrected classes: Yes / No / Partially Met / NA. Next step is champion promotion and read-back verification.",
+      "created_at": "2026-05-06T14:43:12.513936Z"
+    },
+    {
+      "id": "e513f3e1-0fa3-4448-a0c2-b16d275b47e2",
+      "author": "ryan",
+      "text": "Completed label correction. Published and promoted updated champion versions for all 8 four-class PolicyPoint Sales Skills scores. Final verification confirmed champion configs and code classes are exactly `Yes`, `No`, `Partially Met`, `NA`; guidelines match the generated payload; all promoted versions are featured; old `Met` / `Missed` headings are absent. The 2 binary Yes / No / NA scores were unchanged.",
+      "created_at": "2026-05-06T14:44:01.653522Z"
+    }
+  ],
+  "created_at": "2026-05-06T14:41:26.276143Z",
+  "updated_at": "2026-05-06T14:44:05.006001Z",
+  "closed_at": "2026-05-06T14:44:05.006001Z",
+  "custom": {}
+}

--- a/project/issues/plx-26c455f0-13dc-411f-afdd-afaeddbb0740.json
+++ b/project/issues/plx-26c455f0-13dc-411f-afdd-afaeddbb0740.json
@@ -1,0 +1,64 @@
+{
+  "id": "plx-26c455f0-13dc-411f-afdd-afaeddbb0740",
+  "title": "Build dashboard renderer for ScoreResultsReport",
+  "description": "Add dedicated dashboard block renderer grouped by score, including prediction details, expandable trace display, and diagnostics panels for unresolved identifiers and failed predictions.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "bb03f4c5-53d6-4577-b128-8a6669dbe3b4",
+      "author": "ryan",
+      "text": "Implementing dashboard renderer refactor per design plan: replace table with score-grouped cards, use IdentifierDisplay, restyle diagnostics panels, and keep traces collapsed by default via structured ScoreResultTrace expansion.",
+      "created_at": "2026-05-07T18:41:28.168488Z"
+    },
+    {
+      "id": "a5d9a9e6-2334-4547-ad76-77b77a7c33e1",
+      "author": "ryan",
+      "text": "Applying follow-up UI refinement: remove score result ID from ScoreResultsReport rows and improve cost presentation from raw JSON to concise human-readable metrics (USD and token counts).",
+      "created_at": "2026-05-07T18:44:14.054532Z"
+    },
+    {
+      "id": "f34a54ec-7ed1-4644-bbe9-e1268c96b44d",
+      "author": "ryan",
+      "text": "Adjusting ScoreResultsReport explanation rendering to full-height content (no truncation/line clamp); explanations should grow naturally with content length.",
+      "created_at": "2026-05-07T18:44:48.991102Z"
+    },
+    {
+      "id": "edfee4ff-4978-4eb8-ae54-523f7036f75d",
+      "author": "ryan",
+      "text": "Refining row metadata display: show status only for non-success results, and move cost rendering to final footer line after explanation/trace content.",
+      "created_at": "2026-05-07T18:45:19.382013Z"
+    },
+    {
+      "id": "01784911-cdc5-4762-a464-ef8349a7df77",
+      "author": "ryan",
+      "text": "Adjusting value badge semantics: remove green/red success/failure color coding from score result value pills; use neutral muted styling since correctness is unknown.",
+      "created_at": "2026-05-07T18:47:48.943591Z"
+    },
+    {
+      "id": "77bb16b6-9135-425f-ad07-c9a9696b51c7",
+      "author": "ryan",
+      "text": "Removing top-level 'Failed Predictions' diagnostics panel from ScoreResultsReport UI; failures remain represented inline per result row only.",
+      "created_at": "2026-05-07T18:59:17.272707Z"
+    },
+    {
+      "id": "83cce1ce-8c1d-44b6-b06a-04ac238000dd",
+      "author": "ryan",
+      "text": "UI tweak: reverse top-row alignment in ScoreResultsReport result cards so value pill is on the left above explanation, identifiers on the right.",
+      "created_at": "2026-05-07T19:02:30.674957Z"
+    }
+  ],
+  "created_at": "2026-05-07T16:10:19.897047Z",
+  "updated_at": "2026-05-07T19:02:30.674957Z",
+  "closed_at": null,
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
+}

--- a/project/issues/plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7.json
+++ b/project/issues/plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7.json
@@ -16,10 +16,22 @@
       "author": "ryan",
       "text": "Starting implementation. First priority is the urgent GraphQL schema slice: add ScoreVersion.metadata as JSON and one featured-version lookup index, with no other table/index changes. Follow-up implementation will add frontend, CLI, MCP, and champion-history promotion wiring on the same feature branch.",
       "created_at": "2026-04-27T18:14:17.839783Z"
+    },
+    {
+      "id": "ee46e617-6c5d-4911-8a1b-6e3a5bf5dd43",
+      "author": "ryan",
+      "text": "Started Score Results Report implementation on feature/score-results-report. Created story plx-d54ab8 and tasks for backend, CLI, dashboard, and tests (plx-cf1182, plx-78b08e, plx-26c455, plx-b5749b). Beginning backend block implementation first, then CLI, renderer, and tests.",
+      "created_at": "2026-05-07T16:10:24.765665Z"
+    },
+    {
+      "id": "efe5e193-5f4b-4412-a512-d6e9ce612652",
+      "author": "ryan",
+      "text": "Implemented Score Results Report on branch feature/score-results-report. Added backend block (ScoreResultsReport), direct CLI command (feedback report score-results-report), dashboard renderer, and tests.\n\nValidation:\n- python3.11 -m pytest plexus/reports/blocks/score_results_report_test.py plexus/cli/feedback/feedback_report_test.py -q -> 23 passed\n- dashboard jest ScoreResultsReport.test.tsx -> passed\n- Manual run (single-score smoke): scorecard 1562 + score 'Asks Beyond the Script' + id 311434634 returned success with persisted score_result_id and grouped-by-score payload.\n- Full 20-id scorecard-wide run was initiated and processed predictions; it is heavy/long-running due item x score fanout.",
+      "created_at": "2026-05-07T16:17:43.478641Z"
     }
   ],
   "created_at": "2026-04-27T18:14:11.621385Z",
-  "updated_at": "2026-04-27T18:14:17.839783Z",
+  "updated_at": "2026-05-07T16:17:43.478641Z",
   "closed_at": null,
   "custom": {}
 }

--- a/project/issues/plx-37b7f7ac-fdd5-463a-809a-65842883b990.json
+++ b/project/issues/plx-37b7f7ac-fdd5-463a-809a-65842883b990.json
@@ -1,0 +1,43 @@
+{
+  "id": "plx-37b7f7ac-fdd5-463a-809a-65842883b990",
+  "title": "Create records and validated guidelines for PolicyPoint sales skills",
+  "description": "Implement the setup for the PolicyPoint Sales Skills QA Scorecard.\n\nSteps:\n1. Parse workbook metadata and populated item rubrics.\n2. Create or verify the scorecard and score records.\n3. Generate classifier guidelines for each populated score.\n4. Validate guidelines with `skills/guidelines/validate_guidelines.py`.\n5. Publish validated guidelines to score versions and verify via Plexus read APIs.\n\nNotes:\n- Workbook contains populated Items 1-6 and 11-14; item numbers 7-10 are not populated in the provided workbook.\n- MCP exposes score version update but not scorecard/score create methods, so record creation may need the local GraphQL client path.",
+  "type": "task",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "08d5e8ec-9e05-408f-9ea5-fb951b6abe89",
+      "author": "ryan",
+      "text": "Started setup. Parsed workbook metadata and found 10 populated score rubrics: Items 1-6 and 11-14. MCP score setup create methods are not exposed by api_list; score.update is available for publishing versions/guidelines.",
+      "created_at": "2026-05-06T14:31:48.493858Z"
+    },
+    {
+      "id": "cd8bdcbc-18cd-42df-a462-e01be1c66a18",
+      "author": "ryan",
+      "text": "Created Plexus records under Call Criteria account. Scorecard `049ac545-c75b-4d36-9c3d-8d58b99db320`, Default section `cdbdeaf3-7a8f-475e-8d7d-57dad9107316`, and 10 score records were created and verified. Next step is publishing the validated score versions/guidelines.",
+      "created_at": "2026-05-06T14:36:59.372585Z"
+    },
+    {
+      "id": "96f6752e-ac30-46cc-a87b-a2bc8f29d7d2",
+      "author": "ryan",
+      "text": "Published and promoted 10 initial score versions. Final verification confirmed all champion versions match the generated YAML configuration and guidelines, and each champion version is featured. Guidelines validator passed for all 10 files; score YAML linter passed for all 10 configs.",
+      "created_at": "2026-05-06T14:39:25.703320Z"
+    },
+    {
+      "id": "53fd0314-f714-4d1f-9bfa-bdadbd1e51cb",
+      "author": "ryan",
+      "text": "Completed setup. Created scorecard `PolicyPoint Sales Skills QA Scorecard` (`049ac545-c75b-4d36-9c3d-8d58b99db320`) under Call Criteria, created Default section and 10 score records from workbook Items 1-6 and 11-14, generated/validated guidelines, published initial score versions, promoted all versions to champion, and verified champion configuration/guidelines match the generated payload.",
+      "created_at": "2026-05-06T14:39:40.463081Z"
+    }
+  ],
+  "created_at": "2026-05-06T14:31:43.889101Z",
+  "updated_at": "2026-05-06T14:39:44.788066Z",
+  "closed_at": "2026-05-06T14:39:44.788066Z",
+  "custom": {}
+}

--- a/project/issues/plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f.json
+++ b/project/issues/plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-6309a5b5-f088-4481-9d7a-17da7d6b3d9f",
+  "title": "Fix Console prediction API-only config loading",
+  "description": "Console execute_tactus predictions fail in Lambda because API-loaded score configs are still written to the local scorecards cache when use_cache=false. Make non-cache GraphQL loading in-memory only and prove with read-only smoke.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-07T18:39:43.966399Z",
+  "updated_at": "2026-05-07T18:45:08.552877Z",
+  "closed_at": "2026-05-07T18:45:08.552877Z",
+  "custom": {}
+}

--- a/project/issues/plx-78b08ea4-dd6a-44d3-a04f-1e290da6e6fd.json
+++ b/project/issues/plx-78b08ea4-dd6a-44d3-a04f-1e290da6e6fd.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-78b08ea4-dd6a-44d3-a04f-1e290da6e6fd",
+  "title": "Add score-results-report direct CLI command",
+  "description": "Add feedback report score-results-report command with --scorecard, optional --score, and identifier inputs via --ids and repeatable --id; normalize/validate IDs and map to report block config.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-07T16:10:19.897220Z",
+  "updated_at": "2026-05-07T16:17:43.502748Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7.json
+++ b/project/issues/plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7.json
@@ -1,0 +1,37 @@
+{
+  "id": "plx-7cc6f8f1-b34f-45b2-9ada-12cc8a1650e7",
+  "title": "Sync PolicyPoint classifier code classes with guidelines",
+  "description": "Compare PolicyPoint classifier champion guidelines against score code classes and update code where the class labels diverge.\n\nScope:\n- Inspect champion versions for PolicyPoint - Non-Sales.\n- Identify scores whose guidelines define classes that differ from `valid_classes` or `ClassifyProcedure` classes in code.\n- Publish corrected score versions preserving existing guidelines.\n- Promote corrected versions and verify by read-back.",
+  "type": "task",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "9ee5843d-e19e-41bd-95c5-984aea9534d3",
+      "author": "ryan",
+      "text": "Started code/class reconciliation for PolicyPoint - Non-Sales. Next step: compare champion guideline class metadata against YAML `valid_classes` and Tactus `ClassifyProcedure.classes`, then publish corrected code versions only where mismatched.",
+      "created_at": "2026-05-06T14:53:19.297978Z"
+    },
+    {
+      "id": "7ba23682-d17b-4f82-be31-2ff2bfdd4760",
+      "author": "ryan",
+      "text": "Verification found no code/class mismatch. Checked champion and draft version history for PolicyPoint - Non-Sales: four-class scores already have matching guideline, YAML `valid_classes`, and Tactus `ClassifyProcedure.classes` values: `Yes`, `No`, `Partially Met`, `NA`. The four pending records 48852-48855 have no versions/guidelines/code yet.",
+      "created_at": "2026-05-06T14:55:03.285341Z"
+    },
+    {
+      "id": "4cc02a66-b30c-4913-8e24-f022469e4157",
+      "author": "ryan",
+      "text": "Final validation passed: all 10 champion-backed PolicyPoint scores lint cleanly, guidelines validate, and guideline classes match both YAML `valid_classes` and Tactus `ClassifyProcedure.classes`. No new score versions were published because there was no code mismatch to correct.",
+      "created_at": "2026-05-06T14:55:12.767124Z"
+    }
+  ],
+  "created_at": "2026-05-06T14:53:06.934346Z",
+  "updated_at": "2026-05-06T14:55:12.780159Z",
+  "closed_at": "2026-05-06T14:55:12.780159Z",
+  "custom": {}
+}

--- a/project/issues/plx-a579d9c5-3dd3-4490-9612-8ceefb3604dd.json
+++ b/project/issues/plx-a579d9c5-3dd3-4490-9612-8ceefb3604dd.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-a579d9c5-3dd3-4490-9612-8ceefb3604dd",
+  "title": "Apply PolicyPoint external IDs and pending questions",
+  "description": "Update the existing PolicyPoint scorecard setup with the source system external IDs supplied by the user.\n\nScope:\n- Set scorecard external ID to `1562` for `PolicyPoint - Non-Sales`.\n- Set score external IDs 48846-48859 for the named questions.\n- Create any missing question records where needed.\n- Use workbook Items Template rubrics when available for guidelines/configuration.\n- Validate any generated or changed guidelines with `skills/guidelines/validate_guidelines.py`.\n- Verify final Plexus state by read-back.",
+  "type": "task",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-03d93482-b49d-4d3a-a997-31dc558f9979",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "6db3d90b-94c1-464c-9652-28b163e0cc4b",
+      "author": "ryan",
+      "text": "Started external ID alignment. Rechecked workbook `/Users/ryan/Downloads/SalesFloor_Sales Skills SOW_v2.xlsx`: Items Template still contains populated rubrics for 10 questions only. Missing/pending rows are 48852 Conversational, Not Robotic; 48853 Shows Empathy and Warmth; 48854 Builds Trust and Confidence; 48855 No-Sale Root Cause Classification. Those will be created as administrative score records without champion guideline/config versions until rubrics are supplied.",
+      "created_at": "2026-05-06T14:48:01.800753Z"
+    },
+    {
+      "id": "f468503b-d5ce-4669-969f-560cb8698c14",
+      "author": "ryan",
+      "text": "Completed external ID alignment and pending question creation. Scorecard `049ac545-c75b-4d36-9c3d-8d58b99db320` now has name `PolicyPoint - Non-Sales`, key `policy-point-non-sales`, external ID `1562`. Verified 14 questions with external IDs 48846-48859 in order. Created pending score records for 48852-48855 without champion versions because their rubric rows are not present in the workbook. Validated the 10 available champion guideline documents from workbook-backed scores.",
+      "created_at": "2026-05-06T14:50:18.555705Z"
+    }
+  ],
+  "created_at": "2026-05-06T14:47:19.890893Z",
+  "updated_at": "2026-05-06T14:50:18.574195Z",
+  "closed_at": "2026-05-06T14:50:18.574195Z",
+  "custom": {}
+}

--- a/project/issues/plx-b5749b6a-a7d7-45e4-8514-9adf69bdad9d.json
+++ b/project/issues/plx-b5749b6a-a7d7-45e4-8514-9adf69bdad9d.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-b5749b6a-a7d7-45e4-8514-9adf69bdad9d",
+  "title": "Add BDD/spec coverage and tests for ScoreResultsReport",
+  "description": "Add backend, CLI, and dashboard tests for scope behavior, identifier input parsing, unresolved/failed handling, payload shape, and rendering behavior per story scenarios.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-07T16:10:19.897108Z",
+  "updated_at": "2026-05-07T16:17:43.502516Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-cf118293-51d1-437c-96f3-3b4f98beab29.json
+++ b/project/issues/plx-cf118293-51d1-437c-96f3-3b4f98beab29.json
@@ -1,0 +1,46 @@
+{
+  "id": "plx-cf118293-51d1-437c-96f3-3b4f98beab29",
+  "title": "Implement ScoreResultsReport backend block",
+  "description": "Implement new ScoreResultsReport report block: parameter parsing, scope resolution, identifier resolution, prediction execution + ScoreResult persistence, grouped-by-score output, diagnostics, bounded concurrency, and deterministic ordering.",
+  "type": "task",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "7a5a4404-2617-490a-bde6-6b5f52e1ddef",
+      "author": "ryan",
+      "text": "Backend block implemented in plexus/reports/blocks/score_results_report.py with required parameters (scorecard, optional score/score_id, ids), identifier normalization/dedup, partial unresolved handling, bounded concurrency, prediction + persistence, grouped-by-score output, and diagnostics arrays. Added backend unit tests in score_results_report_test.py covering scope modes, ordering/grouping, unresolved handling, failure handling, and ids parsing/validation.",
+      "created_at": "2026-05-07T16:19:26.104260Z"
+    },
+    {
+      "id": "aa01d204-29b1-41f9-a7b5-2c6a3416651f",
+      "author": "ryan",
+      "text": "Adding item identifier hydration to ScoreResultsReport backend output so UI can use standard collapsed/expandable IdentifierDisplay with identifier URLs.",
+      "created_at": "2026-05-07T18:54:22.665936Z"
+    },
+    {
+      "id": "167a5799-210c-492b-9ab4-fae190173712",
+      "author": "ryan",
+      "text": "Adjusting ScoreResultsReport single-score header dedupe and standardizing score section spacing/padding to p-3.",
+      "created_at": "2026-05-07T19:04:23.373819Z"
+    },
+    {
+      "id": "44b3ea96-7bce-4176-9b25-e7cd0b7fc0a1",
+      "author": "ryan",
+      "text": "Tightening ScoreResultsReport row spacing by removing extra horizontal padding layer around score result cards; keep row-level padding only.",
+      "created_at": "2026-05-07T19:05:42.225251Z"
+    }
+  ],
+  "created_at": "2026-05-07T16:10:19.897024Z",
+  "updated_at": "2026-05-07T19:05:42.225251Z",
+  "closed_at": null,
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
+}

--- a/project/issues/plx-d54ab8bc-1e75-4fd5-b8f6-c2047cee7f56.json
+++ b/project/issues/plx-d54ab8bc-1e75-4fd5-b8f6-c2047cee7f56.json
@@ -1,0 +1,28 @@
+{
+  "id": "plx-d54ab8bc-1e75-4fd5-b8f6-c2047cee7f56",
+  "title": "Score Results Report runs predictions for specified item identifiers",
+  "description": "As a lab operator, I want a report that runs predictions for a provided list of item identifiers on one score or an entire scorecard, so that I can review current prediction outcomes quickly.\n\nFeature: Score Results Report\n\nScenario: Scorecard scope predicts all scores for all resolved identifiers\nGiven a required scorecard identifier and a list of item identifiers\nAnd the score parameter is not provided\nWhen the report runs\nThen it resolves each identifier to an item id when possible\nAnd it runs predictions for each resolved item across all scores on the scorecard\nAnd it persists prediction score results\nAnd it returns output grouped by score\n\nScenario: Single-score scope predicts one score for all resolved identifiers\nGiven a required scorecard identifier, an optional score identifier, and a list of item identifiers\nWhen the report runs\nThen it resolves the score within the scorecard\nAnd it runs predictions only for that score across resolved items\nAnd it persists prediction score results\nAnd it returns output grouped by score\n\nScenario: Unresolved identifiers are reported without failing the report\nGiven at least one provided identifier cannot be resolved to an item\nWhen the report runs\nThen it continues predicting for resolvable identifiers\nAnd it includes unresolved identifiers in diagnostics\nAnd report execution succeeds if at least one prediction succeeds\n\nScenario: CLI accepts both list styles for identifiers\nGiven a scorecard identifier\nWhen the user runs score-results-report with --ids comma-separated values\nOr the user repeats --id multiple times\nThen the report receives one normalized ids list\nAnd at least one identifier is required\n\nScenario: Detailed prediction payload is returned per item-score run\nGiven a prediction run completes for an item and score\nWhen output is generated\nThen each result includes status, score_result_id, value, explanation, cost, and trace when available\nAnd failed predictions include error details",
+  "type": "story",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-2dc3bc16-4869-4a67-96cb-b4859db28ac7",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "cd22d4f8-06f3-4c05-a339-c7e15a7a0640",
+      "author": "ryan",
+      "text": "Starting UI redesign pass for ScoreResultsReport to align visual language with Feedback Alignment: flat regions, identifier component, value+explanation presentation, and collapsed structured trace.",
+      "created_at": "2026-05-07T18:41:28.168509Z"
+    }
+  ],
+  "created_at": "2026-05-07T16:10:10.484256Z",
+  "updated_at": "2026-05-07T18:41:28.168509Z",
+  "closed_at": null,
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
+}


### PR DESCRIPTION
## Summary
- Promotes the Console prediction fixes currently on develop.
- Standardizes `plexus.score.predict` on canonical `scorecard_identifier` / `score_identifier` arguments.
- Fixes Console/Lambda prediction config loading so `use_cache=false` is GraphQL-only and does not read/write local `scorecards/...` YAML.
- Preserves explicit cache-backed behavior for `use_cache=true` local workflows.

## Verification
- Develop CI green for the prediction contract fix before this PR sync: https://github.com/AnthusAI/Plexus/actions/runs/25515366655
- Focused local tests passed:
  - `/Users/ryan/miniconda3/bin/python -m pytest MCP/tools/tactus_runtime/execute_test.py -q` -> 130 passed
  - `/Users/ryan/miniconda3/bin/python -m pytest plexus/tests/test_fetch_score_configurations.py plexus/tests/test_iterative_config_fetching.py plexus/cli/shared/fetch_score_configurations_test.py -q` -> 12 passed
  - `/Users/ryan/miniconda3/bin/python -m pytest plexus/cli/procedure/test_builtin_procedures.py plexus/cli/procedure/test_mcp_transport.py -q` -> 39 passed
- Real read-only smoke from a chmod 555 temp cwd with `SCORECARD_CACHE_DIR` unset returned `ok=true` for PolicyPoint - Non-Sales / Acknowledges Before Redirecting / item 311432364 and did not create `scorecards/`.

## Notes
- This is an application fix, not a Lambda filesystem/env-var workaround.
- New develop CI for the main sync commit is running at https://github.com/AnthusAI/Plexus/actions/runs/25515970606.

## Added in this merge window
- Merged PR #322 into `develop` for the new **Score Results Report** feature.
- Includes backend block `ScoreResultsReport`, direct CLI command `plexus feedback report score-results-report`, grouped dashboard renderer, and tests.
- This release also includes the latest UI adjustments (identifier component usage, trace collapsed by default, tokenized cost display, de-duplicated single-score header, and tightened row padding).