### PR TITLE
Fix undefined variable in dataset curation stats

### DIFF
--- a/plexus/cli/dataset/curation.py
+++ b/plexus/cli/dataset/curation.py
@@ -755,8 +755,8 @@ def build_associated_dataset_from_vetted_feedback_items(
             dataset_stats={
                 "row_count": int(len(dataframe)),
                 "requested_max_items": max_items,
-                "qualifying_found": len(all_qualifying_items),
-                "source_exhausted": len(all_qualifying_items) < max_items,
+                "qualifying_found": len(all_vetted_items),
+                "source_exhausted": len(all_vetted_items) < max_items,
                 "label_distribution": class_distribution_after,
                 "class_list_used": class_list_used,
                 "class_resolution_source": class_resolution_source,


### PR DESCRIPTION
## Summary

Fixes linting error causing CI failures on develop branch.

## Problem

Lines 758-759 in `plexus/cli/dataset/curation.py` reference `all_qualifying_items` which is undefined in that scope, causing ruff linting to fail:
```
F821 Undefined name 'all_qualifying_items'
```

## Root Cause

The variable was renamed from `all_qualifying_items` to `all_vetted_items` in this function, but two references in the `dataset_stats` dictionary were not updated.

## Fix

Changed lines 758-759:
```python
# Before
"qualifying_found": len(all_qualifying_items),
"source_exhausted": len(all_qualifying_items) < max_items,

# After
"qualifying_found": len(all_vetted_items),
"source_exhausted": len(all_vetted_items) < max_items,
```

## Testing

- ✅ Ruff linting now passes: `python -m ruff check plexus/cli/dataset/curation.py --select F821`
- This fix unblocks CI for all PRs targeting develop