### PR TITLE
Load PLEXUS_ACCOUNT_KEY from Secrets Manager in console Lambda

### DIFF
--- a/dashboard/amplify/functions/consoleRunWorker/app.py
+++ b/dashboard/amplify/functions/consoleRunWorker/app.py
@@ -46,6 +46,10 @@ def _load_provider_credentials() -> None:
     if anthropic_api_key:
         os.environ["ANTHROPIC_API_KEY"] = anthropic_api_key
 
+    account_key = str(config.get("account-key") or "").strip()
+    if account_key:
+        os.environ["PLEXUS_ACCOUNT_KEY"] = account_key
+
 
 def _deserialize_dynamo_item(raw: Dict[str, Any]) -> Dict[str, Any]:
     return {key: deserializer.deserialize(value) for key, value in raw.items()}


### PR DESCRIPTION
## Summary

Ensures `PLEXUS_ACCOUNT_KEY` persists across Lambda redeployments by loading it from Secrets Manager instead of requiring manual configuration.

## Problem

Currently, `PLEXUS_ACCOUNT_KEY` needs to be manually added to the Lambda environment variables after each deployment. This is error-prone and gets wiped out on redeployment.

## Solution

Modified `_load_provider_credentials()` in `app.py` to read `account-key` from the existing Secrets Manager config (`plexus/{environment}/config`) and set it as the `PLEXUS_ACCOUNT_KEY` environment variable.

## Changes

In `dashboard/amplify/functions/consoleRunWorker/app.py`:
```python
account_key = str(config.get("account-key") or "").strip()
if account_key:
    os.environ["PLEXUS_ACCOUNT_KEY"] = account_key
```

## Prerequisites

Ensure `account-key` is present in the Secrets Manager secret:
- Production: `plexus/production/config`
- Staging: `plexus/staging/config`

## Testing

After deployment:
1. Lambda will automatically load `PLEXUS_ACCOUNT_KEY` from Secrets Manager
2. No manual environment variable configuration needed
3. Value persists across redeployments

## Related

- Follows the same pattern as `openai-api-key` and `anthropic-api-key` loading
- Complements the console chat optimizer fixes from PR #330