### PR TITLE
fix: restore score-processor Lambda INFO runtime logging

### DIFF
--- a/project/events/2026-05-11T20:49:55.206Z__546d93a2-60b8-4920-80ab-df70abd5c477.json
+++ b/project/events/2026-05-11T20:49:55.206Z__546d93a2-60b8-4920-80ab-df70abd5c477.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "546d93a2-60b8-4920-80ab-df70abd5c477",
+  "issue_id": "plx-360d2b02-2fe8-4480-ba5e-066730487675",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-11T20:49:55.206Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Purpose: restore actionable CloudWatch/Lambda logs for score-processing runs so LLM execution paths can be debugged in production.\n\nDefinition of Done:\n- Production score-processor Lambda emits INFO-level runtime scoring logs in CloudWatch (including score orchestration and LangGraph execution markers).\n- Per-request  attachment includes the expected runtime scoring breadcrumbs for investigation.\n- Logging behavior is deterministic from Lambda startup (not dependent on incidental import order).",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Restore score-processor Lambda observability logging"
+  }
+}

--- a/project/events/2026-05-11T20:50:01.421Z__d331f8d5-0e12-421a-9c89-eb47e01e9957.json
+++ b/project/events/2026-05-11T20:50:01.421Z__d331f8d5-0e12-421a-9c89-eb47e01e9957.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "d331f8d5-0e12-421a-9c89-eb47e01e9957",
+  "issue_id": "plx-360d2b02-2fe8-4480-ba5e-066730487675",
+  "event_type": "field_updated",
+  "occurred_at": "2026-05-11T20:50:01.421Z",
+  "actor_id": "derek",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "Purpose: restore actionable CloudWatch/Lambda logs for score-processing runs so LLM execution paths can be debugged in production.\n\nDefinition of Done:\n- Production score-processor Lambda emits INFO-level runtime scoring logs in CloudWatch (including score orchestration and LangGraph execution markers).\n- Per-request  attachment includes the expected runtime scoring breadcrumbs for investigation.\n- Logging behavior is deterministic from Lambda startup (not dependent on incidental import order).",
+        "to": "Purpose: restore actionable CloudWatch/Lambda logs for score-processing runs so LLM execution paths can be debugged in production.\n\nDefinition of Done:\n- Production score-processor Lambda emits INFO-level runtime scoring logs in CloudWatch (including score orchestration and LangGraph execution markers).\n- Per-request log.txt attachment includes the expected runtime scoring breadcrumbs for investigation.\n- Logging behavior is deterministic from Lambda startup (not dependent on incidental import order)."
+      }
+    }
+  }
+}

--- a/project/events/2026-05-11T20:50:05.526Z__512d7e8e-2dff-48ab-a34b-86a67bd7cba5.json
+++ b/project/events/2026-05-11T20:50:05.526Z__512d7e8e-2dff-48ab-a34b-86a67bd7cba5.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "512d7e8e-2dff-48ab-a34b-86a67bd7cba5",
+  "issue_id": "plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-11T20:50:05.526Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Observed behavior:\n- Runtime/LangGraph INFO breadcrumbs are absent from `/aws/lambda/plexus-lambda-production-score-processor`.\n- Error/WARNING lines still appear, indicating execution occurs but INFO is filtered.\n\nExpected behavior:\n- INFO-level runtime scoring logs are visible in CloudWatch and request-captured log artifacts.\n\nPlan:\n- Set deterministic startup logging configuration in score-processor Lambda handler so root logger level follows LOG_LEVEL (default INFO).\n- Keep noisy dependency loggers at WARNING.\n- Validate with local runtime simulation and test/lint pass.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-360d2b02-2fe8-4480-ba5e-066730487675",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix score-processor Lambda root logger level so runtime INFO logs are emitted"
+  }
+}

--- a/project/events/2026-05-11T20:50:07.970Z__08c579f6-68f4-4b60-aa2c-5d47f6404106.json
+++ b/project/events/2026-05-11T20:50:07.970Z__08c579f6-68f4-4b60-aa2c-5d47f6404106.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "08c579f6-68f4-4b60-aa2c-5d47f6404106",
+  "issue_id": "plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-11T20:50:07.970Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-11T20:50:13.365Z__8c3cddd5-36e0-4c68-bf80-fa5d7219f6d1.json
+++ b/project/events/2026-05-11T20:50:13.365Z__8c3cddd5-36e0-4c68-bf80-fa5d7219f6d1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8c3cddd5-36e0-4c68-bf80-fa5d7219f6d1",
+  "issue_id": "plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-11T20:50:13.365Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "924c88bf-1bc2-4d68-a1c4-16c15fc87896"
+  }
+}

--- a/project/events/2026-05-11T20:50:52.592Z__67f5413d-2b77-43d0-ab50-c148e14f2db0.json
+++ b/project/events/2026-05-11T20:50:52.592Z__67f5413d-2b77-43d0-ab50-c148e14f2db0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "67f5413d-2b77-43d0-ab50-c148e14f2db0",
+  "issue_id": "plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-11T20:50:52.592Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "561d26ef-f915-42d0-bad7-ec2994eb3b40"
+  }
+}

--- a/project/events/2026-05-11T21:05:21.112Z__fd385643-3681-4eb9-9670-1c3d19c1bc8c.json
+++ b/project/events/2026-05-11T21:05:21.112Z__fd385643-3681-4eb9-9670-1c3d19c1bc8c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "fd385643-3681-4eb9-9670-1c3d19c1bc8c",
+  "issue_id": "plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-11T21:05:21.112Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "a1ac733a-581a-48ab-9511-a0a168f30b07"
+  }
+}

--- a/project/events/2026-05-11T21:05:26.720Z__7108fc3e-9ef7-477d-a61d-dd7a9b3cd25e.json
+++ b/project/events/2026-05-11T21:05:26.720Z__7108fc3e-9ef7-477d-a61d-dd7a9b3cd25e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7108fc3e-9ef7-477d-a61d-dd7a9b3cd25e",
+  "issue_id": "plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-11T21:05:26.720Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "00df1219-c372-4b66-8ca6-5511f3da8437"
+  }
+}

--- a/project/issues/plx-360d2b02-2fe8-4480-ba5e-066730487675.json
+++ b/project/issues/plx-360d2b02-2fe8-4480-ba5e-066730487675.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-360d2b02-2fe8-4480-ba5e-066730487675",
+  "title": "Restore score-processor Lambda observability logging",
+  "description": "Purpose: restore actionable CloudWatch/Lambda logs for score-processing runs so LLM execution paths can be debugged in production.\n\nDefinition of Done:\n- Production score-processor Lambda emits INFO-level runtime scoring logs in CloudWatch (including score orchestration and LangGraph execution markers).\n- Per-request log.txt attachment includes the expected runtime scoring breadcrumbs for investigation.\n- Logging behavior is deterministic from Lambda startup (not dependent on incidental import order).",
+  "type": "epic",
+  "status": "open",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-11T20:49:55.206740308Z",
+  "updated_at": "2026-05-11T20:50:01.421381192Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346.json
+++ b/project/issues/plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346",
+  "title": "Fix score-processor Lambda root logger level so runtime INFO logs are emitted",
+  "description": "Observed behavior:\n- Runtime/LangGraph INFO breadcrumbs are absent from `/aws/lambda/plexus-lambda-production-score-processor`.\n- Error/WARNING lines still appear, indicating execution occurs but INFO is filtered.\n\nExpected behavior:\n- INFO-level runtime scoring logs are visible in CloudWatch and request-captured log artifacts.\n\nPlan:\n- Set deterministic startup logging configuration in score-processor Lambda handler so root logger level follows LOG_LEVEL (default INFO).\n- Keep noisy dependency loggers at WARNING.\n- Validate with local runtime simulation and test/lint pass.",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-360d2b02-2fe8-4480-ba5e-066730487675",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "924c88bf-1bc2-4d68-a1c4-16c15fc87896",
+      "author": "derek",
+      "text": "Starting implementation. Verified previously that runtime INFO logs are suppressed because root logger stays at WARNING in the Lambda image while scoring code emits many module-level logging.info() lines. Next: create feature branch from develop, patch handler startup logging to deterministic LOG_LEVEL-root behavior, and run local validation.",
+      "created_at": "2026-05-11T20:50:13.365326618Z"
+    },
+    {
+      "id": "561d26ef-f915-42d0-bad7-ec2994eb3b40",
+      "author": "derek",
+      "text": "Implemented fix in score-processor-lambda/handler.py: added configure_lambda_logging() and called it at module load to set root logger level from LOG_LEVEL (default INFO), align existing root handlers to that level, and keep noisy libs (urllib3/botocore/boto3/gql.*) at WARNING.\n\nValidation:\n- python3 -m py_compile score-processor-lambda/handler.py passed.\n- Runtime simulation in current production Lambda image (sha256:32f2e25...) with local patched file mounted:\n  - LOG_LEVEL unset => root effective level 20 (INFO).\n  - LOG_LEVEL=DEBUG => root effective level 10 (DEBUG).\n\nThis restores deterministic INFO emission for module-level logging.info() calls used across scoring code paths.",
+      "created_at": "2026-05-11T20:50:52.592754187Z"
+    }
+  ],
+  "created_at": "2026-05-11T20:50:05.526183479Z",
+  "updated_at": "2026-05-11T20:50:52.592754187Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/project/issues/plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346.json
+++ b/project/issues/plx-78b907a7-30e5-4ccd-8c37-5e081a0b9346.json
@@ -22,10 +22,22 @@
       "author": "derek",
       "text": "Implemented fix in score-processor-lambda/handler.py: added configure_lambda_logging() and called it at module load to set root logger level from LOG_LEVEL (default INFO), align existing root handlers to that level, and keep noisy libs (urllib3/botocore/boto3/gql.*) at WARNING.\n\nValidation:\n- python3 -m py_compile score-processor-lambda/handler.py passed.\n- Runtime simulation in current production Lambda image (sha256:32f2e25...) with local patched file mounted:\n  - LOG_LEVEL unset => root effective level 20 (INFO).\n  - LOG_LEVEL=DEBUG => root effective level 10 (DEBUG).\n\nThis restores deterministic INFO emission for module-level logging.info() calls used across scoring code paths.",
       "created_at": "2026-05-11T20:50:52.592754187Z"
+    },
+    {
+      "id": "a1ac733a-581a-48ab-9511-a0a168f30b07",
+      "author": "derek",
+      "text": "Implemented and pushed on branch .\n\nCommits:\n- d80d2e08 fix(score-processor-lambda): restore INFO runtime logs via deterministic root logger config\n- 6065f2f8 chore(kanbus): sync issue/event artifacts for plx-360d2b and plx-78b907\n\nPR opened against develop: https://github.com/AnthusAI/Plexus/pull/341",
+      "created_at": "2026-05-11T21:05:21.112883269Z"
+    },
+    {
+      "id": "00df1219-c372-4b66-8ca6-5511f3da8437",
+      "author": "derek",
+      "text": "Implemented and pushed on branch feature/plx-78b907-score-processor-logging.\n\nCommits:\n- d80d2e08 fix(score-processor-lambda): restore INFO runtime logs via deterministic root logger config\n- 6065f2f8 chore(kanbus): sync issue/event artifacts for plx-360d2b and plx-78b907\n\nPR opened against develop: https://github.com/AnthusAI/Plexus/pull/341",
+      "created_at": "2026-05-11T21:05:26.720882100Z"
     }
   ],
   "created_at": "2026-05-11T20:50:05.526183479Z",
-  "updated_at": "2026-05-11T20:50:52.592754187Z",
+  "updated_at": "2026-05-11T21:05:26.720882100Z",
   "closed_at": null,
   "custom": {}
 }

--- a/score-processor-lambda/handler.py
+++ b/score-processor-lambda/handler.py
@@ -55,6 +55,28 @@ from plexus.dashboard.api.models.item import Item
 from plexus.utils.request_log_capture import capture_request_logs
 
 
+def configure_lambda_logging():
+    """Configure deterministic root logging for Lambda runtime."""
+    log_level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    log_level = getattr(logging, log_level_name, logging.INFO)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+
+    # Lambda may preconfigure handlers. Keep them aligned to our selected level.
+    if root_logger.handlers:
+        for handler in root_logger.handlers:
+            handler.setLevel(log_level)
+    else:
+        logging.basicConfig(level=log_level)
+
+    for noisy_logger in ("urllib3", "botocore", "boto3", "gql.transport", "gql.dsl"):
+        logging.getLogger(noisy_logger).setLevel(logging.WARNING)
+
+
+configure_lambda_logging()
+
+
 class LambdaJobProcessor:
     """Processes a single scoring job for Lambda execution"""
 


### PR DESCRIPTION
## Summary
- add deterministic Lambda startup logging configuration in `score-processor-lambda/handler.py`
- set root logger level from `LOG_LEVEL` (default `INFO`) so module-level `logging.info(...)` calls from scoring code are emitted
- align existing root handlers to the selected level and keep noisy libraries (`urllib3`, `botocore`, `boto3`, `gql.*`) at `WARNING`
- include required Kanbus artifact sync commit for `plx-360d2b` / `plx-78b907`

## Why
Production score-processor runs were executing LLM scoring paths but CloudWatch lacked INFO-level LangGraph/score orchestration breadcrumbs, making investigations difficult. Root logger effective level drifted to `WARNING` in runtime, suppressing those INFO logs.

## Validation
- `python3 -m py_compile score-processor-lambda/handler.py`
- production-image simulation with patched handler mounted:
  - `LOG_LEVEL` unset => root effective level `INFO` (20)
  - `LOG_LEVEL=DEBUG` => root effective level `DEBUG` (10)

## Kanbus
- Epic: `plx-360d2b`
- Bug: `plx-78b907`