### PR TITLE
fix(dashboard): resolve CodeQL insecure randomness in conversation viewer

### DIFF
--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -465,7 +465,7 @@ const canViewSessionForCurrentUser = (
 }
 
 const generatePrivacySpanId = (sessionId: string): string => (
-  `private-${sessionId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  `private-${sessionId}-${Date.now()}-${crypto.randomUUID()}`
 )
 
 const createPrivateConsoleMetadata = ({


### PR DESCRIPTION
## Summary
- replaces insecure `Math.random()` usage in `generatePrivacySpanId` with `crypto.randomUUID()`
- keeps scope to one line in `dashboard/components/ui/conversation-viewer.tsx`

## Why
PR #339 is blocked by CodeQL check run 75448298060 for insecure randomness.
