### PR TITLE
fix(dashboard): accept useless-conditional suggestion in conversation viewer

### DIFF
--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -3442,7 +3442,7 @@ function ConversationViewer({
                 current_privacy_span_id: isConsolePrivate ? privacySpanId : undefined,
               },
             }
-        if (nextSessionMetadata && targetSessionId) {
+        if (nextSessionMetadata) {
           const updatedAt = nowIso
           try {
             const client = getClient()


### PR DESCRIPTION
Applies github-code-quality suggestion on PR #339: simplify `if (nextSessionMetadata && targetSessionId)` to `if (nextSessionMetadata)` in conversation-viewer.tsx.