### PR TITLE
fix(dashboard): update batch UI typing after Batch schema removal

### DIFF
--- a/dashboard/components/BatchJobTask.tsx
+++ b/dashboard/components/BatchJobTask.tsx
@@ -12,9 +12,8 @@ import { BatchJobProgressBar, BatchJobStatus } from "@/components/ui/batch-job-p
 import { getClient, listFromModel, getFromModel } from '@/utils/data-operations'
 import type { Schema } from "@/amplify/data/resource"
 import { 
-  createBatchJobScoringJobSubscription,
   createScoringJobSubscription,
-  BatchJobScoringJobSubscriptionData,
+  createBatchJobScoringJobSubscription,
   ScoringJobSubscriptionData
 } from '@/utils/subscriptions'
 import { BaseTaskData } from '@/types/base'
@@ -32,6 +31,11 @@ interface ScoringJobData {
   scoreId?: string | null
   batchJobId: string
   createdAt: string | null | undefined
+}
+
+interface BatchJobScoringJobLink {
+  batchJobId: string
+  scoringJobId: string
 }
 
 export interface BatchJobTaskData {
@@ -104,12 +108,12 @@ export default function BatchJobTask({
       try {
         console.log('Loading scoring jobs for batch:', taskData.id);
         
-        // Use listFromModel helper instead of direct dataClient access
-        const linksResult = await listFromModel<Schema['BatchJobScoringJob']['type']>('BatchJobScoringJob', {
+        // This model is removed from the typed schema; query dynamically for legacy records when present.
+        const linksResult = await (listFromModel as any)('BatchJobScoringJob', {
           filter: {
             batchJobId: { eq: taskData.id }
           }
-        });
+        }) as { data?: BatchJobScoringJobLink[] };
         
         console.log('BatchJobScoringJob links loaded:', {
           count: linksResult.data?.length || 0,
@@ -128,7 +132,7 @@ export default function BatchJobTask({
         }
 
         // Get all scoring jobs in one query using IN filter
-        const scoringJobIds = linksResult.data.map(link => link.scoringJobId);
+        const scoringJobIds = linksResult.data.map((link) => link.scoringJobId);
         
         console.log('Fetching scoring jobs:', {
           ids: scoringJobIds
@@ -177,9 +181,10 @@ export default function BatchJobTask({
         
         // Set up subscriptions with proper types
         const client = getClient();
-        if (client.models.BatchJobScoringJob) {
+        const batchJobScoringJobModel = (client.models as Record<string, unknown>).BatchJobScoringJob;
+        if (batchJobScoringJobModel) {
           // Use the subscription helper for BatchJobScoringJob
-          const handleBatchJobData = async (data: BatchJobScoringJobSubscriptionData) => {
+          const handleBatchJobData = async (data: BatchJobScoringJobLink) => {
             if (!data?.batchJobId || !data?.scoringJobId) return;
             
             if (data.batchJobId === taskData.id) {

--- a/dashboard/components/batches-dashboard.tsx
+++ b/dashboard/components/batches-dashboard.tsx
@@ -42,7 +42,6 @@ const ACCOUNT_KEY = 'call-criteria'
 
 type ScorecardType = Schema['Scorecard']['type']
 type ScoreType = Schema['Score']['type']
-type BatchJobType = Schema['BatchJob']['type']
 
 interface SimpleResponse<T> {
   data: T | null
@@ -97,11 +96,11 @@ async function listAccounts(): Promise<SimpleResponse<SimpleAccount[]>> {
 
 async function listBatchJobs(accountId: string): Promise<SimpleResponse<SimpleBatchJob[]>> {
   try {
-    const result = await listFromModel<Schema['BatchJob']['type']>('BatchJob', {
+    const result = await (listFromModel as any)('BatchJob', {
       filter: {
         accountId: { eq: accountId }
       }
-    });
+    }) as { data?: SimpleBatchJob[] | null };
 
     if (!result.data) {
       return { data: null };
@@ -243,7 +242,7 @@ function formatTimeAgo(dateStr?: string | null): string {
   }
 }
 
-const mapBatchJob = async (job: BatchJobType): Promise<BatchJobWithCount> => {
+const mapBatchJob = async (job: SimpleBatchJob): Promise<BatchJobWithCount> => {
   let scorecardData: ScorecardType | null = null;
   let scoreData: ScoreType | null = null;
 
@@ -326,7 +325,7 @@ const BATCH_JOB_SUBSCRIPTION = `
 `;
 
 interface SubscriptionResponse {
-  items: Schema['BatchJob']['type'][];
+  items: SimpleBatchJob[];
 }
 
 interface BatchJobWithRelatedData extends BatchJobWithCount {
@@ -527,8 +526,9 @@ export default function BatchesDashboard({
     if (!accountId) return;
 
     try {
-      if (getClient().models.BatchJob) {
-        const handleBatchUpdate = async (data: Schema['BatchJob']['type']) => {
+      const batchJobModel = (getClient().models as Record<string, any>).BatchJob;
+      if (batchJobModel?.onCreate && batchJobModel?.onUpdate) {
+        const handleBatchUpdate = async (data: { id: string }) => {
           if (!accountId) return;
           
           const { data: updatedBatchJobs } = await listBatchJobs(accountId);
@@ -556,14 +556,12 @@ export default function BatchesDashboard({
           setError(error instanceof Error ? error : new Error(String(error)));
         };
 
-        // @ts-ignore - Amplify Gen2 typing issue
-        const createSub = getClient().models.BatchJob.onCreate().subscribe({
+        const createSub = batchJobModel.onCreate().subscribe({
           next: handleBatchUpdate,
           error: handleError
         });
 
-        // @ts-ignore - Amplify Gen2 typing issue
-        const updateSub = getClient().models.BatchJob.onUpdate().subscribe({
+        const updateSub = batchJobModel.onUpdate().subscribe({
           next: handleBatchUpdate,
           error: handleError
         });

--- a/dashboard/utils/amplify-client.ts
+++ b/dashboard/utils/amplify-client.ts
@@ -386,12 +386,20 @@ export const amplifyClient = {
   },
   BatchJob: {
     list: async (params: any) => {
-      const response = await (getClient().models.BatchJob as any).list(params)
-      return response as AmplifyResponse<Schema['BatchJob']['type'][]>
+      const batchJobModel = (getClient().models as Record<string, any>).BatchJob
+      if (!batchJobModel?.list) {
+        return { data: [] } as AmplifyResponse<any[]>
+      }
+      const response = await batchJobModel.list(params)
+      return response as AmplifyResponse<any[]>
     },
     get: async (params: any) => {
-      const response = await (getClient().models.BatchJob as any).get(params)
-      return { data: response.data as Schema['BatchJob']['type'] | null }
+      const batchJobModel = (getClient().models as Record<string, any>).BatchJob
+      if (!batchJobModel?.get) {
+        return { data: null as any | null }
+      }
+      const response = await batchJobModel.get(params)
+      return { data: response.data as any | null }
     }
   },
   Item: {

--- a/dashboard/utils/subscriptions.ts
+++ b/dashboard/utils/subscriptions.ts
@@ -73,7 +73,11 @@ export function createBatchJobScoringJobSubscription(
   onError: ErrorCallback
 ) {
   const client = getClient();
-  const subscription = (client.models.BatchJobScoringJob as any).onCreate() as AmplifySubscription;
+  const batchJobScoringJobModel = (client.models as Record<string, any>).BatchJobScoringJob;
+  if (!batchJobScoringJobModel?.onCreate) {
+    return { unsubscribe: () => {} };
+  }
+  const subscription = batchJobScoringJobModel.onCreate() as AmplifySubscription;
   return subscription.subscribe({
     next: onData,
     error: onError


### PR DESCRIPTION
## Summary
- removes direct typed references to `Schema['BatchJob']` and `Schema['BatchJobScoringJob']`
- switches batch model lookups/subscriptions to dynamic model access compatible with removed schema models
- fixes Dashboard TypeScript errors blocking PR #339 checks

## Files
- dashboard/components/BatchJobTask.tsx
- dashboard/components/batches-dashboard.tsx
- dashboard/utils/amplify-client.ts
- dashboard/utils/subscriptions.ts
