### PR TITLE
fix(dashboard): resolve TS2352 in BatchJob list fallback

### DIFF
--- a/dashboard/utils/amplify-client.ts
+++ b/dashboard/utils/amplify-client.ts
@@ -388,7 +388,7 @@ export const amplifyClient = {
     list: async (params: any) => {
       const batchJobModel = (getClient().models as Record<string, any>).BatchJob
       if (!batchJobModel?.list) {
-        return { data: [] } as AmplifyResponse<any[]>
+        return { data: [], nextToken: null }
       }
       const response = await batchJobModel.list(params)
       return response as AmplifyResponse<any[]>


### PR DESCRIPTION
Fixes latest Dashboard Unit Tests failure on PR #339 by returning a correctly shaped fallback response ({ data: [], nextToken: null }) in amplify-client BatchJob.list.