### PR TITLE
fix: polyfill crypto.randomUUID in dashboard jest setup

### DIFF
--- a/dashboard/jest.setup.ts
+++ b/dashboard/jest.setup.ts
@@ -1,4 +1,20 @@
 import '@testing-library/jest-dom'
+import { webcrypto as nodeWebCrypto } from 'node:crypto'
+
+if (typeof globalThis.crypto === 'undefined') {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: nodeWebCrypto,
+    configurable: true,
+  })
+}
+
+if (typeof globalThis.crypto.randomUUID !== 'function') {
+  Object.defineProperty(globalThis.crypto, 'randomUUID', {
+    value: () => nodeWebCrypto.randomUUID(),
+    configurable: true,
+    writable: true,
+  })
+}
 
 // Mock next/navigation
 jest.mock('next/navigation', () => ({


### PR DESCRIPTION
## Summary
- add a Jest setup polyfill for `crypto.randomUUID` using Node WebCrypto
- keep runtime app logic unchanged; this only normalizes the unit-test environment
- unblock the conversation viewer session-routing test after the CodeQL randomness fix

## Validation
- `cd dashboard && npm test -- --runInBand components/ui/__tests__/conversation-viewer-session-routing.test.tsx`
- `cd dashboard && npm run ci:unit`
