### PR TITLE
chore: accept remaining CodeQL unused-import suggestions

### DIFF
--- a/plexus/utils/scoring.py
+++ b/plexus/utils/scoring.py
@@ -15,12 +15,10 @@ except ModuleNotFoundError:
 try:
     from plexus.dashboard.api.models.scorecard import Scorecard as ScorecardModel
     from plexus.dashboard.api.models.score import Score as ScoreModel
-    from plexus.dashboard.api.models.account import Account
     from plexus.dashboard.api.models.score_result import ScoreResult
 except Exception:
     ScorecardModel = None
     ScoreModel = None
-    Account = None
     ScoreResult = None
 
 try:

--- a/tests/test_scoring_single_target_helper.py
+++ b/tests/test_scoring_single_target_helper.py
@@ -5,8 +5,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from pathlib import Path
 
-import pytest
-
 def _load_scoring_module():
     scoring_path = Path(__file__).resolve().parents[1] / "plexus" / "utils" / "scoring.py"
     spec = importlib.util.spec_from_file_location("plexus_utils_scoring_test", scoring_path)


### PR DESCRIPTION
## Summary
- remove unused Account import and fallback assignment from plexus/utils/scoring.py
- remove unused pytest import from tests/test_scoring_single_target_helper.py

## Validation
- pytest tests/test_scoring_single_target_helper.py
