### PR TITLE
fix(code-quality): remove unused imports in async scoring follow-up

### DIFF
--- a/plexus/utils/scoring.py
+++ b/plexus/utils/scoring.py
@@ -15,12 +15,10 @@ except ModuleNotFoundError:
 try:
     from plexus.dashboard.api.models.scorecard import Scorecard as ScorecardModel
     from plexus.dashboard.api.models.score import Score as ScoreModel
-    from plexus.dashboard.api.models.account import Account
     from plexus.dashboard.api.models.score_result import ScoreResult
 except Exception:
     ScorecardModel = None
     ScoreModel = None
-    Account = None
     ScoreResult = None
 
 try:

--- a/project/events/2026-05-11T22:37:38.595Z__f9ae1750-46c5-40da-998b-f18b2013bcd6.json
+++ b/project/events/2026-05-11T22:37:38.595Z__f9ae1750-46c5-40da-998b-f18b2013bcd6.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "f9ae1750-46c5-40da-998b-f18b2013bcd6",
+  "issue_id": "plx-4883f860-ceb6-4f77-9c41-adc3996d1661",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-11T22:37:38.595Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "Remove unused imports reported by GitHub code quality in recently touched files: Account import in plexus/utils/scoring.py and pytest import in tests/test_scoring_single_target_helper.py.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-360d2b02-2fe8-4480-ba5e-066730487675",
+    "priority": 2,
+    "status": "open",
+    "title": "Fix CodeQL unused imports after async dependency remediation"
+  }
+}

--- a/project/events/2026-05-11T22:37:41.479Z__d1a028de-299d-4e31-b57b-5adbdf12a720.json
+++ b/project/events/2026-05-11T22:37:41.479Z__d1a028de-299d-4e31-b57b-5adbdf12a720.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d1a028de-299d-4e31-b57b-5adbdf12a720",
+  "issue_id": "plx-4883f860-ceb6-4f77-9c41-adc3996d1661",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-11T22:37:41.479Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-11T22:37:41.493Z__f2638deb-40ca-4892-a109-6275bf4d9646.json
+++ b/project/events/2026-05-11T22:37:41.493Z__f2638deb-40ca-4892-a109-6275bf4d9646.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f2638deb-40ca-4892-a109-6275bf4d9646",
+  "issue_id": "plx-4883f860-ceb6-4f77-9c41-adc3996d1661",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-11T22:37:41.493Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "75a88e3b-b1c6-46ac-840b-ee2d1434e201"
+  }
+}

--- a/project/events/2026-05-11T22:38:00.681Z__eb98f8cc-da9b-43ea-b7a5-5d60f2ef0640.json
+++ b/project/events/2026-05-11T22:38:00.681Z__eb98f8cc-da9b-43ea-b7a5-5d60f2ef0640.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "eb98f8cc-da9b-43ea-b7a5-5d60f2ef0640",
+  "issue_id": "plx-4883f860-ceb6-4f77-9c41-adc3996d1661",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-11T22:38:00.681Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "ef956378-973a-4b31-aaeb-aa61073de3d0"
+  }
+}

--- a/project/events/2026-05-11T22:38:00.696Z__319a376e-5c56-40fe-92a2-775e549aa8de.json
+++ b/project/events/2026-05-11T22:38:00.696Z__319a376e-5c56-40fe-92a2-775e549aa8de.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "319a376e-5c56-40fe-92a2-775e549aa8de",
+  "issue_id": "plx-4883f860-ceb6-4f77-9c41-adc3996d1661",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-11T22:38:00.696Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-4883f860-ceb6-4f77-9c41-adc3996d1661.json
+++ b/project/issues/plx-4883f860-ceb6-4f77-9c41-adc3996d1661.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-4883f860-ceb6-4f77-9c41-adc3996d1661",
+  "title": "Fix CodeQL unused imports after async dependency remediation",
+  "description": "Remove unused imports reported by GitHub code quality in recently touched files: Account import in plexus/utils/scoring.py and pytest import in tests/test_scoring_single_target_helper.py.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-360d2b02-2fe8-4480-ba5e-066730487675",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "75a88e3b-b1c6-46ac-840b-ee2d1434e201",
+      "author": "derek",
+      "text": "Starting fix: remove unused Account import in plexus/utils/scoring.py and unused pytest import in tests/test_scoring_single_target_helper.py; run focused tests; then close issue.",
+      "created_at": "2026-05-11T22:37:41.493719879Z"
+    },
+    {
+      "id": "ef956378-973a-4b31-aaeb-aa61073de3d0",
+      "author": "derek",
+      "text": "Implemented fixes and validated.\n- Removed unused Account import/fallback in plexus/utils/scoring.py\n- Removed unused pytest import in tests/test_scoring_single_target_helper.py\n- Validation: pytest -q tests/test_scoring_single_target_helper.py tests/lambda/test_score_processor_item.py (7 passed)",
+      "created_at": "2026-05-11T22:38:00.681103109Z"
+    }
+  ],
+  "created_at": "2026-05-11T22:37:38.593982211Z",
+  "updated_at": "2026-05-11T22:38:00.696298457Z",
+  "closed_at": "2026-05-11T22:38:00.696298457Z",
+  "custom": {}
+}

--- a/tests/test_scoring_single_target_helper.py
+++ b/tests/test_scoring_single_target_helper.py
@@ -5,8 +5,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from pathlib import Path
 
-import pytest
-
 def _load_scoring_module():
     scoring_path = Path(__file__).resolve().parents[1] / "plexus" / "utils" / "scoring.py"
     spec = importlib.util.spec_from_file_location("plexus_utils_scoring_test", scoring_path)


### PR DESCRIPTION
## Summary
- remove unused `Account` import and fallback assignment from `plexus/utils/scoring.py`
- remove unused `pytest` import from `tests/test_scoring_single_target_helper.py`

## Validation
- `pytest -q tests/test_scoring_single_target_helper.py tests/lambda/test_score_processor_item.py`

## Kanbus
- closed: `plx-4883f8`
