### PR TITLE
schema: add FeedbackItem metadata for explanation cache

### DIFF
--- a/dashboard/amplify/data/resource.ts
+++ b/dashboard/amplify/data/resource.ts
@@ -649,6 +649,7 @@ const schema = a.schema({
             editorName: a.string(),
             isAgreement: a.boolean(),
             isInvalid: a.boolean(),
+            metadata: a.json(),
             createdAt: a.datetime().required(),
             updatedAt: a.datetime().required(),
             scoreResults: a.hasMany('ScoreResult', 'feedbackItemId'),


### PR DESCRIPTION
## Summary
- stage 2 of the schema train: add FeedbackItem.metadata as a.json()
- commit is isolated to dashboard/amplify/data/resource.ts only
- this follows the completed stage-1 removal/deploy

## Validation
- git diff --name-only origin/develop...HEAD shows only dashboard/amplify/data/resource.ts
