### PR TITLE
fix: preserve feedback explanation metadata in compacted RCA exemplars

### DIFF
--- a/plexus/Evaluation.py
+++ b/plexus/Evaluation.py
@@ -3361,11 +3361,20 @@ class FeedbackEvaluation(Evaluation):
         if not isinstance(exemplar, dict):
             return {}
         keep_keys = (
+            "feedback_item_id",
             "item_id",
             "identifiers",
             "initial_answer_value",
             "final_answer_value",
             "score_explanation",
+            "text",
+            "edit_comment",
+            "initial_comment",
+            "final_comment",
+            "label_provenance_source",
+            "feedback_item_explanation_provider",
+            "feedback_item_explanation_model",
+            "feedback_item_explanation_cache_hit",
             "timestamp",
             "above_fold",
             "detailed_cause",

--- a/plexus/Evaluation.py
+++ b/plexus/Evaluation.py
@@ -37,6 +37,7 @@ from plexus.cli.shared.optimizer_shadow_invalidation import (
     resolve_score_version_shadow_invalidation_metadata,
 )
 from plexus.bedrock_models import CLAUDE_HAIKU_45_MODEL_ID
+from plexus.feedback_item_explanations import get_or_generate_feedback_item_explanation
 
 from plexus.scores.LangGraphScore import LangGraphScore
 import inspect
@@ -3747,6 +3748,7 @@ class FeedbackEvaluation(Evaluation):
                     editCommentValue
                     isAgreement
                     isInvalid
+                    metadata
                     editedAt
                     createdAt
                     updatedAt
@@ -4235,45 +4237,60 @@ class FeedbackEvaluation(Evaluation):
                     if fi.itemId:
                         metadata["item_id"] = fi.itemId
 
-                    # Build the text that will be clustered and analysed.
-                    # Goal: text explaining WHY the ground-truth label is correct —
-                    # not what our model said (which describes the wrong reasoning).
-                    #
-                    # Source depends on whether the reviewer agreed or disagreed:
-                    #   Agreed   → original production explanation describes the correct answer
-                    #   Disagreed → edit comment explains why the reviewer changed the label
-                    if score_result_map is not None:
-                        sr = score_result_map.get(fi.id, {})
-                        new_pred = (sr.get('value') or '')
-                        correct_label = (sr.get('human_label') or fi.finalAnswerValue or '')
-                        our_explanation = sr.get('explanation', '')
-                        orig_explanation = (original_explanations or {}).get(fi.id, '')
-                        reviewer_agreed = (fi.initialAnswerValue or '') == (fi.finalAnswerValue or '')
+                    sr = score_result_map.get(fi.id, {}) if score_result_map is not None else {}
+                    predicted_value = (
+                        (sr.get("value") or "")
+                        or (fi.initialAnswerValue or "")
+                    )
+                    correct_value = (
+                        (sr.get("human_label") or "")
+                        or (fi.finalAnswerValue or "")
+                    )
+                    score_explanation = sr.get("explanation", "")
+                    original_explanation = (original_explanations or {}).get(fi.id, "")
 
-                        if reviewer_agreed:
-                            text = orig_explanation or fi.editCommentValue or our_explanation
-                        else:
-                            text = fi.editCommentValue or orig_explanation or our_explanation
-
-                        if not text:
-                            text = f"Predicted '{new_pred}' but correct answer is '{correct_label}'."
-
-                        metadata["initial_answer_value"] = new_pred
-                        metadata["final_answer_value"] = correct_label
-                        if our_explanation:
-                            metadata["score_explanation"] = our_explanation
-                    else:
-                        if fi.initialAnswerValue:
-                            metadata["initial_answer_value"] = fi.initialAnswerValue
-                        if fi.finalAnswerValue:
-                            metadata["final_answer_value"] = fi.finalAnswerValue
-                        text = fi.editCommentValue
+                    if predicted_value:
+                        metadata["initial_answer_value"] = predicted_value
+                    if correct_value:
+                        metadata["final_answer_value"] = correct_value
+                    if score_explanation:
+                        metadata["score_explanation"] = score_explanation
 
                     item_context_record = item_context_cache.get(fi.itemId or "", {})
                     primary_input_text = item_context_record.get("primary_input", "")
                     metadata_snapshot = item_context_record.get("metadata_snapshot", "")
                     primary_input_modality = item_context_record.get("primary_input_modality", "unknown")
                     primary_input_fetch_error = bool(item_context_record.get("primary_input_fetch_error"))
+
+                    feedback_explanation_payload = await get_or_generate_feedback_item_explanation(
+                        feedback_item=fi,
+                        api_client=getattr(self, "api_client", None),
+                        predicted_value=predicted_value,
+                        correct_value=correct_value,
+                        score_explanation=score_explanation,
+                        original_explanation=original_explanation,
+                        score_guidelines_text=score_guidelines,
+                        scorecard_guidance_text=scorecard_guidance_text,
+                        transcript_text=primary_input_text,
+                        item_metadata_snapshot=metadata_snapshot,
+                        initial_comment=metadata.get("initial_comment", ""),
+                        final_comment=metadata.get("final_comment", ""),
+                        provider="auto",
+                        model=None,
+                    )
+                    text = feedback_explanation_payload.get("explanation", "") or ""
+                    if feedback_explanation_payload.get("ground_truth_value"):
+                        metadata["final_answer_value"] = feedback_explanation_payload["ground_truth_value"]
+                    metadata["ground_truth_explanation"] = text
+                    metadata["feedback_item_explanation_provider"] = feedback_explanation_payload.get(
+                        "provider", ""
+                    )
+                    metadata["feedback_item_explanation_model"] = feedback_explanation_payload.get(
+                        "model", ""
+                    )
+                    metadata["feedback_item_explanation_cache_hit"] = bool(
+                        feedback_explanation_payload.get("cache_hit", False)
+                    )
 
                     # Run the preprocessor pipeline on the raw text so the RCA sub-agent
                     # can compare what the LLM actually saw vs. the original input.
@@ -5051,20 +5068,6 @@ class FeedbackEvaluation(Evaluation):
             if tracker and hasattr(tracker, "current_stage") and tracker.current_stage:
                 tracker.current_stage.status_message = msg
 
-        def _build_item_text(fi, sr: dict) -> str:
-            new_pred = (sr.get("value") or "")
-            correct_label = (sr.get("human_label") or fi.finalAnswerValue or "")
-            our_explanation = sr.get("explanation", "")
-            orig_explanation = (original_explanations or {}).get(fi.id, "")
-            reviewer_agreed = (fi.initialAnswerValue or "") == (fi.finalAnswerValue or "")
-            if reviewer_agreed:
-                text = orig_explanation or fi.editCommentValue or our_explanation
-            else:
-                text = fi.editCommentValue or orig_explanation or our_explanation
-            if not text:
-                text = f"Predicted '{new_pred}' but correct answer is '{correct_label}'."
-            return text
-
         now_iso = datetime.now(_tz.utc).isoformat()
         score_guidelines = ""
         score_yaml_code = ""
@@ -5126,13 +5129,32 @@ class FeedbackEvaluation(Evaluation):
             predicted = (sr.get("value") or fi.initialAnswerValue or "")
             correct = (sr.get("human_label") or fi.finalAnswerValue or "")
             score_explanation = sr.get("explanation", "")
+            feedback_explanation_payload = await get_or_generate_feedback_item_explanation(
+                feedback_item=fi,
+                api_client=getattr(self, "api_client", None),
+                predicted_value=predicted,
+                correct_value=correct,
+                score_explanation=score_explanation,
+                original_explanation=(original_explanations or {}).get(fi.id, ""),
+                score_guidelines_text=score_guidelines,
+                scorecard_guidance_text=scorecard_guidance_text,
+                transcript_text="",
+                item_metadata_snapshot="",
+                initial_comment=getattr(fi, "initialCommentValue", "") or "",
+                final_comment=getattr(fi, "finalCommentValue", "") or "",
+                provider="auto",
+                model=None,
+            )
+            explanation_text = feedback_explanation_payload.get("explanation", "") or ""
+            if feedback_explanation_payload.get("ground_truth_value"):
+                correct = feedback_explanation_payload["ground_truth_value"]
             ts = fi.editedAt or getattr(fi, "updatedAt", None) or getattr(fi, "createdAt", None)
             ts_str = (
                 (ts if ts.tzinfo else ts.replace(tzinfo=_tz.utc)).isoformat()
                 if ts else now_iso
             )
             exemplars.append({
-                "text": _build_item_text(fi, sr),
+                "text": explanation_text,
                 "feedback_item_id": fi.id,
                 "item_id": fi.itemId,
                 "initial_answer_value": predicted,
@@ -5143,6 +5165,11 @@ class FeedbackEvaluation(Evaluation):
                 "initial_comment": getattr(fi, "initialCommentValue", "") or "",
                 "final_comment": getattr(fi, "finalCommentValue", "") or "",
                 "label_provenance_source": "feedback_final_answer_value",
+                "feedback_item_explanation_provider": feedback_explanation_payload.get("provider", ""),
+                "feedback_item_explanation_model": feedback_explanation_payload.get("model", ""),
+                "feedback_item_explanation_cache_hit": bool(
+                    feedback_explanation_payload.get("cache_hit", False)
+                ),
                 **({"score_explanation": score_explanation} if score_explanation else {}),
             })
 

--- a/plexus/Evaluation_feedback_test.py
+++ b/plexus/Evaluation_feedback_test.py
@@ -1268,6 +1268,34 @@ class TestCompactRootCauseForParameters:
         assert result["overall_explanation"] == "explanation text"
         assert result["overall_improvement_suggestion"] == "suggestion text"
 
+    def test_topic_exemplar_feedback_explanation_metadata_preserved(self):
+        payload = self._make_full_payload(
+            topics=[
+                {
+                    "topic_id": "t1",
+                    "label": "Topic A",
+                    "member_count": 1,
+                    "exemplars": [
+                        {
+                            "feedback_item_id": "feedback-1",
+                            "item_id": "item-1",
+                            "initial_answer_value": "No",
+                            "final_answer_value": "Yes",
+                            "feedback_item_explanation_provider": "openai",
+                            "feedback_item_explanation_model": "gpt-5.4-mini",
+                            "feedback_item_explanation_cache_hit": True,
+                        }
+                    ],
+                }
+            ]
+        )
+        result = FeedbackEvaluation._compact_root_cause_for_parameters(payload, self.ATTACHMENT)
+        exemplar = result["topics"][0]["exemplars"][0]
+        assert exemplar["feedback_item_id"] == "feedback-1"
+        assert exemplar["feedback_item_explanation_provider"] == "openai"
+        assert exemplar["feedback_item_explanation_model"] == "gpt-5.4-mini"
+        assert exemplar["feedback_item_explanation_cache_hit"] is True
+
     def test_misclassification_analysis_included(self):
         result = FeedbackEvaluation._compact_root_cause_for_parameters(
             self._make_full_payload(), self.ATTACHMENT

--- a/plexus/dashboard/api/models/feedback_item.py
+++ b/plexus/dashboard/api/models/feedback_item.py
@@ -36,6 +36,7 @@ class FeedbackItem(BaseModel):
     editorName: Optional[str] = None
     isAgreement: Optional[bool] = None
     isInvalid: Optional[bool] = None
+    metadata: Optional[Dict[str, Any]] = None
     createdAt: Optional[datetime] = None
     updatedAt: Optional[datetime] = None
 
@@ -52,7 +53,8 @@ class FeedbackItem(BaseModel):
     GRAPHQL_BASE_FIELDS = [
         'id', 'accountId', 'scorecardId', 'cacheKey', 'scoreId', 'itemId',
         'initialAnswerValue', 'finalAnswerValue', 'initialCommentValue',
-        'finalCommentValue', 'editCommentValue', 'editedAt', 'editorName', 'isAgreement', 'isInvalid', 'createdAt', 'updatedAt'
+        'finalCommentValue', 'editCommentValue', 'editedAt', 'editorName',
+        'isAgreement', 'isInvalid', 'metadata', 'createdAt', 'updatedAt'
     ]
     GRAPHQL_ITEM_FIELDS = [
         'id', 'identifiers', 'externalId', 'description', 'text', 'metadata'
@@ -98,6 +100,7 @@ class FeedbackItem(BaseModel):
             editorName=data.get('editorName'),
             isAgreement=data.get('isAgreement'),
             isInvalid=data.get('isInvalid'),
+            metadata=data.get('metadata'),
             createdAt=data.get('createdAt'),
             updatedAt=data.get('updatedAt')
         )
@@ -621,6 +624,7 @@ class FeedbackItem(BaseModel):
                     finalCommentValue
                     editCommentValue
                     isAgreement
+                    metadata
                     createdAt
                     updatedAt
                 }
@@ -865,6 +869,7 @@ class FeedbackItem(BaseModel):
                         editedAt
                         editorName
                         itemId
+                        metadata
                         createdAt
                         updatedAt
                     }
@@ -1006,6 +1011,7 @@ class FeedbackItem(BaseModel):
                     editedAt
                     editorName
                     itemId
+                    metadata
                     createdAt
                     updatedAt
                 }

--- a/plexus/dashboard/api/models/feedback_item.py
+++ b/plexus/dashboard/api/models/feedback_item.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any, TYPE_CHECKING, Tuple
 from dataclasses import dataclass, field
@@ -82,6 +83,13 @@ class FeedbackItem(BaseModel):
             data['updatedAt'] = datetime.fromisoformat(data['updatedAt'].replace('Z', '+00:00'))
         if 'editedAt' in data and data['editedAt'] and isinstance(data['editedAt'], str):
             data['editedAt'] = datetime.fromisoformat(data['editedAt'].replace('Z', '+00:00'))
+        if 'metadata' in data and isinstance(data['metadata'], str):
+            try:
+                parsed_metadata = json.loads(data['metadata'])
+                data['metadata'] = parsed_metadata if isinstance(parsed_metadata, dict) else None
+            except Exception:
+                logger.warning("Failed to parse FeedbackItem.metadata JSON for item %s", data.get("id"))
+                data['metadata'] = None
             
         # Create instance with data
         instance = cls(
@@ -338,7 +346,9 @@ class FeedbackItem(BaseModel):
         mutation_name = "createFeedbackItem"
         input_variable_name = "input"
         input_type = "CreateFeedbackItemInput!" # Assuming standard Amplify input type
-        input_data = data # Assume data is already formatted correctly
+        input_data = data.copy()
+        if 'metadata' in input_data and isinstance(input_data['metadata'], dict):
+            input_data['metadata'] = json.dumps(input_data['metadata'])
         
         return_fields = cls.GRAPHQL_BASE_FIELDS 
         mutation_body = cls._build_query(return_fields) # Just get base fields back for now
@@ -965,6 +975,8 @@ class FeedbackItem(BaseModel):
             # Add the ID to the data for update
             update_data = feedback_data.copy()
             update_data["id"] = feedback_item_id
+            if isinstance(update_data.get("metadata"), dict):
+                update_data["metadata"] = json.dumps(update_data["metadata"])
 
             # AppSync requires the full composite key when an update touches a model that
             # participates in the byAccountScorecardScoreUpdatedAt index. Hydrate those

--- a/plexus/feedback_item_explanations.py
+++ b/plexus/feedback_item_explanations.py
@@ -1,0 +1,418 @@
+"""Shared feedback-item explanation generation and cache persistence."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from plexus.bedrock_models import CLAUDE_HAIKU_45_MODEL_ID
+
+logger = logging.getLogger(__name__)
+
+EXPLANATION_CACHE_METADATA_KEY = "feedback_item_explanations"
+EXPLANATION_PROMPT_VERSION = "v1"
+DEFAULT_OPENAI_MODEL = "gpt-5.4-mini"
+DEFAULT_BEDROCK_MODEL = CLAUDE_HAIKU_45_MODEL_ID
+DEFAULT_HEURISTIC_MODEL = "feedback-item-explainer-v1"
+
+
+def _coerce_metadata_dict(raw_metadata: Any) -> Dict[str, Any]:
+    if isinstance(raw_metadata, dict):
+        return dict(raw_metadata)
+    if isinstance(raw_metadata, str) and raw_metadata.strip():
+        try:
+            parsed = json.loads(raw_metadata)
+        except Exception:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _cache_entry_key(provider: str, model: str) -> str:
+    return f"{(provider or '').strip().lower()}::{(model or '').strip()}"
+
+
+def _parse_json_object(text: str) -> Dict[str, Any]:
+    payload = (text or "").strip()
+    if "```" in payload:
+        fenced = re.search(r"```(?:json)?\s*([\s\S]*?)```", payload)
+        if fenced:
+            payload = fenced.group(1).strip()
+    object_match = re.search(r"\{[\s\S]*\}", payload)
+    if object_match:
+        payload = object_match.group(0)
+    parsed = json.loads(payload)
+    if not isinstance(parsed, dict):
+        raise ValueError("Explanation model response must be a JSON object")
+    return parsed
+
+
+def _build_feedback_item_explanation_prompt(context: Dict[str, Any]) -> str:
+    return (
+        "You are analyzing one feedback correction to explain what the feedback means.\\n"
+        "Use all context fields below, then produce one concise ground-truth explanation.\\n\\n"
+        "Context:\\n"
+        f"- Initial AI value: {context.get('initial_answer_value', '')!r}\\n"
+        f"- Final reviewer value: {context.get('final_answer_value', '')!r}\\n"
+        f"- Predicted value for this evaluation: {context.get('predicted_value', '')!r}\\n"
+        f"- Correct value for this evaluation: {context.get('correct_value', '')!r}\\n"
+        f"- Reviewer edit comment: {context.get('edit_comment', '')!r}\\n"
+        f"- Initial reviewer comment: {context.get('initial_comment', '')!r}\\n"
+        f"- Final reviewer comment: {context.get('final_comment', '')!r}\\n"
+        f"- Original production explanation: {context.get('original_explanation', '')!r}\\n"
+        f"- Current score explanation: {context.get('score_explanation', '')!r}\\n"
+        f"- Score guidelines: {context.get('score_guidelines_text', '')[:8000]!r}\\n"
+        f"- Scorecard guidance: {context.get('scorecard_guidance_text', '')[:4000]!r}\\n"
+        f"- Transcript / item text: {context.get('transcript_text', '')[:12000]!r}\\n"
+        f"- Item metadata snapshot: {context.get('item_metadata_snapshot', '')[:4000]!r}\\n\\n"
+        "Return ONLY valid JSON with exactly these keys:\\n"
+        "{\\n"
+        '  "ground_truth_value": "string",\\n'
+        '  "explanation": "1-3 sentence explanation of what this feedback item establishes as ground truth and why",\\n'
+        '  "key_evidence": ["short evidence point 1", "short evidence point 2"]\\n'
+        "}\\n"
+        "No markdown, no prose outside JSON."
+    )
+
+
+def _build_heuristic_explanation(context: Dict[str, Any]) -> Dict[str, Any]:
+    predicted = str(context.get("predicted_value") or context.get("initial_answer_value") or "").strip()
+    correct_value = str(context.get("correct_value") or context.get("final_answer_value") or "").strip()
+    initial_value = str(context.get("initial_answer_value") or "").strip()
+    final_value = str(context.get("final_answer_value") or "").strip()
+    reviewer_agreed = bool(initial_value and final_value and initial_value == final_value)
+
+    ordered_sources: List[str]
+    if reviewer_agreed:
+        ordered_sources = [
+            str(context.get("original_explanation") or "").strip(),
+            str(context.get("edit_comment") or "").strip(),
+            str(context.get("score_explanation") or "").strip(),
+            str(context.get("final_comment") or "").strip(),
+            str(context.get("initial_comment") or "").strip(),
+        ]
+    else:
+        ordered_sources = [
+            str(context.get("edit_comment") or "").strip(),
+            str(context.get("final_comment") or "").strip(),
+            str(context.get("original_explanation") or "").strip(),
+            str(context.get("score_explanation") or "").strip(),
+            str(context.get("initial_comment") or "").strip(),
+        ]
+
+    explanation = next((candidate for candidate in ordered_sources if candidate), "")
+    if not explanation:
+        explanation = f"Predicted '{predicted}' but the corrected ground-truth label is '{correct_value}'."
+
+    key_evidence = [candidate for candidate in ordered_sources if candidate][:2]
+    return {
+        "ground_truth_value": correct_value,
+        "explanation": " ".join(explanation.split()),
+        "key_evidence": key_evidence,
+    }
+
+
+def _resolve_provider_and_model(provider: Optional[str], model: Optional[str]) -> Tuple[str, str, bool]:
+    requested = (provider or "auto").strip().lower()
+    if requested not in {"auto", "openai", "bedrock", "heuristic", "local"}:
+        raise ValueError(
+            "feedback explanation provider must be one of: auto, openai, bedrock, heuristic"
+        )
+
+    if requested == "auto":
+        if os.getenv("OPENAI_API_KEY"):
+            return "openai", model or DEFAULT_OPENAI_MODEL, True
+        if os.getenv("AWS_ACCESS_KEY_ID") or os.getenv("AWS_PROFILE") or os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"):
+            return "bedrock", model or DEFAULT_BEDROCK_MODEL, True
+        return "heuristic", model or DEFAULT_HEURISTIC_MODEL, True
+
+    if requested in {"heuristic", "local"}:
+        return "heuristic", model or DEFAULT_HEURISTIC_MODEL, False
+    if requested == "openai":
+        return "openai", model or DEFAULT_OPENAI_MODEL, False
+    return "bedrock", model or DEFAULT_BEDROCK_MODEL, False
+
+
+def _invoke_openai_explanation_model(prompt: str, model: str) -> Dict[str, Any]:
+    from openai import OpenAI
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is required for feedback explanation provider=openai")
+
+    client = OpenAI(api_key=api_key)
+    response = client.responses.create(
+        model=model,
+        reasoning={"effort": "low"},
+        input=[{"role": "user", "content": prompt}],
+        max_output_tokens=900,
+    )
+    return _parse_json_object(response.output_text)
+
+
+def _invoke_bedrock_explanation_model(prompt: str, model: str) -> Dict[str, Any]:
+    import boto3
+
+    bedrock = boto3.client("bedrock-runtime", region_name=os.getenv("AWS_REGION") or "us-east-1")
+    payload = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 900,
+        "temperature": 0,
+    }
+    response = bedrock.invoke_model(
+        modelId=model,
+        body=json.dumps(payload),
+        contentType="application/json",
+        accept="application/json",
+    )
+    raw = json.loads(response["body"].read())
+    text_chunks = [
+        (block.get("text") or "").strip()
+        for block in raw.get("content", [])
+        if block.get("type") == "text"
+    ]
+    text = "\n".join(chunk for chunk in text_chunks if chunk)
+    return _parse_json_object(text)
+
+
+def _read_cached_entry(metadata: Dict[str, Any], provider: str, model: str) -> Optional[Dict[str, Any]]:
+    envelope = metadata.get(EXPLANATION_CACHE_METADATA_KEY)
+    if not isinstance(envelope, dict):
+        return None
+    entries = envelope.get("entries")
+    if not isinstance(entries, dict):
+        return None
+    candidate = entries.get(_cache_entry_key(provider, model))
+    if isinstance(candidate, dict):
+        return candidate
+    return None
+
+
+def _store_cache_entry(metadata: Dict[str, Any], entry: Dict[str, Any]) -> Dict[str, Any]:
+    merged = dict(metadata)
+    envelope = merged.get(EXPLANATION_CACHE_METADATA_KEY)
+    if not isinstance(envelope, dict):
+        envelope = {}
+    entries = envelope.get("entries")
+    if not isinstance(entries, dict):
+        entries = {}
+
+    entries[_cache_entry_key(entry.get("provider", ""), entry.get("model", ""))] = entry
+    envelope["entries"] = entries
+    envelope["updated_at"] = entry.get("generated_at")
+    merged[EXPLANATION_CACHE_METADATA_KEY] = envelope
+    return merged
+
+
+async def get_or_generate_feedback_item_explanation(
+    *,
+    feedback_item: Any,
+    api_client: Optional[Any],
+    predicted_value: str,
+    correct_value: str,
+    score_explanation: str,
+    original_explanation: str,
+    score_guidelines_text: str,
+    scorecard_guidance_text: str,
+    transcript_text: str,
+    item_metadata_snapshot: str,
+    initial_comment: str,
+    final_comment: str,
+    provider: Optional[str] = "auto",
+    model: Optional[str] = None,
+    force_refresh: bool = False,
+) -> Dict[str, Any]:
+    """Get cached feedback-item explanation or generate and persist it."""
+    resolved_provider, resolved_model, provider_was_auto = _resolve_provider_and_model(provider, model)
+
+    metadata = _coerce_metadata_dict(getattr(feedback_item, "metadata", None))
+    if not force_refresh:
+        cached_entry = _read_cached_entry(metadata, resolved_provider, resolved_model)
+        if cached_entry and cached_entry.get("explanation"):
+            return {
+                "provider": cached_entry.get("provider", resolved_provider),
+                "model": cached_entry.get("model", resolved_model),
+                "ground_truth_value": cached_entry.get("ground_truth_value", correct_value),
+                "explanation": cached_entry.get("explanation", ""),
+                "key_evidence": cached_entry.get("key_evidence", []),
+                "cache_hit": True,
+                "generated_at": cached_entry.get("generated_at"),
+            }
+
+    context = {
+        "feedback_item_id": getattr(feedback_item, "id", None),
+        "item_id": getattr(feedback_item, "itemId", None),
+        "initial_answer_value": getattr(feedback_item, "initialAnswerValue", "") or "",
+        "final_answer_value": getattr(feedback_item, "finalAnswerValue", "") or "",
+        "predicted_value": predicted_value or "",
+        "correct_value": correct_value or "",
+        "edit_comment": getattr(feedback_item, "editCommentValue", "") or "",
+        "initial_comment": initial_comment or "",
+        "final_comment": final_comment or "",
+        "original_explanation": original_explanation or "",
+        "score_explanation": score_explanation or "",
+        "score_guidelines_text": score_guidelines_text or "",
+        "scorecard_guidance_text": scorecard_guidance_text or "",
+        "transcript_text": transcript_text or "",
+        "item_metadata_snapshot": item_metadata_snapshot or "",
+    }
+
+    generation_mode = "model"
+    provider_used = resolved_provider
+    model_used = resolved_model
+
+    if resolved_provider == "heuristic":
+        generated_payload = _build_heuristic_explanation(context)
+        generation_mode = "heuristic"
+    else:
+        prompt = _build_feedback_item_explanation_prompt(context)
+        try:
+            if resolved_provider == "openai":
+                generated_payload = await asyncio.to_thread(
+                    _invoke_openai_explanation_model,
+                    prompt,
+                    resolved_model,
+                )
+            else:
+                generated_payload = await asyncio.to_thread(
+                    _invoke_bedrock_explanation_model,
+                    prompt,
+                    resolved_model,
+                )
+        except Exception as exc:
+            if not provider_was_auto:
+                raise
+            logger.warning(
+                "Feedback explanation model call failed for feedback_item_id=%s (%s:%s): %s. "
+                "Using heuristic generation for this item.",
+                getattr(feedback_item, "id", "unknown"),
+                resolved_provider,
+                resolved_model,
+                exc,
+            )
+            generated_payload = _build_heuristic_explanation(context)
+            provider_used = "heuristic"
+            model_used = DEFAULT_HEURISTIC_MODEL
+            generation_mode = "heuristic"
+
+    explanation = str(generated_payload.get("explanation") or "").strip()
+    if not explanation:
+        generated_payload = _build_heuristic_explanation(context)
+        explanation = generated_payload["explanation"]
+        if provider_used != "heuristic":
+            generation_mode = "heuristic"
+            provider_used = "heuristic"
+            model_used = DEFAULT_HEURISTIC_MODEL
+
+    ground_truth_value = (
+        str(generated_payload.get("ground_truth_value") or "").strip()
+        or str(context.get("correct_value") or "").strip()
+        or str(getattr(feedback_item, "finalAnswerValue", "") or "").strip()
+    )
+
+    key_evidence = generated_payload.get("key_evidence")
+    if not isinstance(key_evidence, list):
+        key_evidence = []
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+    entry = {
+        "provider": provider_used,
+        "model": model_used,
+        "prompt_version": EXPLANATION_PROMPT_VERSION,
+        "ground_truth_value": ground_truth_value,
+        "explanation": explanation,
+        "key_evidence": key_evidence[:3],
+        "generated_at": generated_at,
+        "generation_mode": generation_mode,
+    }
+
+    updated_metadata = _store_cache_entry(metadata, entry)
+    setattr(feedback_item, "metadata", updated_metadata)
+
+    if api_client and getattr(feedback_item, "id", None):
+        from plexus.dashboard.api.models.feedback_item import FeedbackItem
+
+        updated_item = await asyncio.to_thread(
+            FeedbackItem._update_feedback_item,
+            api_client,
+            feedback_item.id,
+            {"metadata": updated_metadata},
+        )
+        if updated_item is not None and getattr(updated_item, "metadata", None) is not None:
+            setattr(feedback_item, "metadata", updated_item.metadata)
+
+    return {
+        "provider": provider_used,
+        "model": model_used,
+        "ground_truth_value": ground_truth_value,
+        "explanation": explanation,
+        "key_evidence": entry["key_evidence"],
+        "cache_hit": False,
+        "generated_at": generated_at,
+    }
+
+
+async def hydrate_feedback_item_explanations(
+    *,
+    feedback_items: List[Any],
+    api_client: Optional[Any],
+    score_results_by_item_id: Optional[Dict[str, Dict[str, Any]]] = None,
+    score_results_by_feedback_id: Optional[Dict[str, Dict[str, Any]]] = None,
+    original_explanations_by_feedback_id: Optional[Dict[str, str]] = None,
+    transcript_by_item_id: Optional[Dict[str, str]] = None,
+    item_metadata_snapshot_by_item_id: Optional[Dict[str, str]] = None,
+    score_guidelines_text: str = "",
+    scorecard_guidance_text: str = "",
+    provider: Optional[str] = "auto",
+    model: Optional[str] = None,
+    max_concurrent: int = 8,
+) -> Dict[str, Dict[str, Any]]:
+    """Hydrate explanation cache for each feedback item and return explanation payloads."""
+    sem = asyncio.Semaphore(max(1, max_concurrent))
+    results: Dict[str, Dict[str, Any]] = {}
+
+    async def hydrate_one(item: Any) -> None:
+        async with sem:
+            score_payload = {}
+            if score_results_by_feedback_id:
+                score_payload = score_results_by_feedback_id.get(getattr(item, "id", ""), {}) or {}
+            if not score_payload and score_results_by_item_id:
+                score_payload = score_results_by_item_id.get(getattr(item, "itemId", ""), {}) or {}
+
+            predicted_value = (
+                str(score_payload.get("value") or "").strip()
+                or str(getattr(item, "initialAnswerValue", "") or "").strip()
+            )
+            correct_value = (
+                str(score_payload.get("human_label") or "").strip()
+                or str(getattr(item, "finalAnswerValue", "") or "").strip()
+            )
+
+            explanation_payload = await get_or_generate_feedback_item_explanation(
+                feedback_item=item,
+                api_client=api_client,
+                predicted_value=predicted_value,
+                correct_value=correct_value,
+                score_explanation=str(score_payload.get("explanation") or "").strip(),
+                original_explanation=(original_explanations_by_feedback_id or {}).get(getattr(item, "id", ""), ""),
+                score_guidelines_text=score_guidelines_text,
+                scorecard_guidance_text=scorecard_guidance_text,
+                transcript_text=(transcript_by_item_id or {}).get(getattr(item, "itemId", ""), ""),
+                item_metadata_snapshot=(item_metadata_snapshot_by_item_id or {}).get(getattr(item, "itemId", ""), ""),
+                initial_comment=str(getattr(item, "initialCommentValue", "") or "").strip(),
+                final_comment=str(getattr(item, "finalCommentValue", "") or "").strip(),
+                provider=provider,
+                model=model,
+            )
+            if getattr(item, "id", None):
+                results[item.id] = explanation_payload
+
+    await asyncio.gather(*[hydrate_one(item) for item in feedback_items])
+    return results

--- a/plexus/feedback_item_explanations_test.py
+++ b/plexus/feedback_item_explanations_test.py
@@ -1,0 +1,159 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from plexus.feedback_item_explanations import (
+    EXPLANATION_CACHE_METADATA_KEY,
+    get_or_generate_feedback_item_explanation,
+    hydrate_feedback_item_explanations,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_or_generate_feedback_item_explanation_uses_cache_hit():
+    cached_entry = {
+        "provider": "heuristic",
+        "model": "feedback-item-explainer-v1",
+        "ground_truth_value": "Yes",
+        "explanation": "Cached explanation text.",
+        "generated_at": "2026-05-01T00:00:00+00:00",
+    }
+    item = SimpleNamespace(
+        id="fi-1",
+        itemId="item-1",
+        initialAnswerValue="No",
+        finalAnswerValue="Yes",
+        editCommentValue="",
+        initialCommentValue="",
+        finalCommentValue="",
+        metadata={
+            EXPLANATION_CACHE_METADATA_KEY: {
+                "entries": {
+                    "heuristic::feedback-item-explainer-v1": cached_entry,
+                }
+            }
+        },
+    )
+
+    result = await get_or_generate_feedback_item_explanation(
+        feedback_item=item,
+        api_client=None,
+        predicted_value="No",
+        correct_value="Yes",
+        score_explanation="",
+        original_explanation="",
+        score_guidelines_text="",
+        scorecard_guidance_text="",
+        transcript_text="",
+        item_metadata_snapshot="",
+        initial_comment="",
+        final_comment="",
+        provider="heuristic",
+        model="feedback-item-explainer-v1",
+    )
+
+    assert result["cache_hit"] is True
+    assert result["explanation"] == "Cached explanation text."
+    assert result["ground_truth_value"] == "Yes"
+
+
+@pytest.mark.asyncio
+async def test_get_or_generate_feedback_item_explanation_persists_generated_entry():
+    item = SimpleNamespace(
+        id="fi-2",
+        itemId="item-2",
+        initialAnswerValue="No",
+        finalAnswerValue="Yes",
+        editCommentValue="Reviewer says this should be yes.",
+        initialCommentValue="",
+        finalCommentValue="",
+        metadata={},
+    )
+    mock_client = Mock()
+
+    with patch(
+        "plexus.dashboard.api.models.feedback_item.FeedbackItem._update_feedback_item",
+        return_value=SimpleNamespace(id="fi-2", metadata=item.metadata),
+    ) as mock_update:
+        result = await get_or_generate_feedback_item_explanation(
+            feedback_item=item,
+            api_client=mock_client,
+            predicted_value="No",
+            correct_value="Yes",
+            score_explanation="",
+            original_explanation="",
+            score_guidelines_text="Guidelines",
+            scorecard_guidance_text="",
+            transcript_text="",
+            item_metadata_snapshot="",
+            initial_comment="",
+            final_comment="",
+            provider="heuristic",
+            model="feedback-item-explainer-v1",
+        )
+
+    assert result["cache_hit"] is False
+    assert result["explanation"]
+    persisted_metadata = mock_update.call_args.args[2]["metadata"]
+    assert persisted_metadata[EXPLANATION_CACHE_METADATA_KEY]["entries"][
+        "heuristic::feedback-item-explainer-v1"
+    ]["explanation"] == result["explanation"]
+    assert mock_update.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_hydrate_feedback_item_explanations_only_generates_missing():
+    cached_item = SimpleNamespace(
+        id="fi-cached",
+        itemId="item-cached",
+        initialAnswerValue="No",
+        finalAnswerValue="Yes",
+        editCommentValue="",
+        initialCommentValue="",
+        finalCommentValue="",
+        metadata={
+            EXPLANATION_CACHE_METADATA_KEY: {
+                "entries": {
+                    "heuristic::feedback-item-explainer-v1": {
+                        "provider": "heuristic",
+                        "model": "feedback-item-explainer-v1",
+                        "ground_truth_value": "Yes",
+                        "explanation": "Already cached",
+                        "generated_at": "2026-05-01T00:00:00+00:00",
+                    }
+                }
+            }
+        },
+    )
+    uncached_item = SimpleNamespace(
+        id="fi-new",
+        itemId="item-new",
+        initialAnswerValue="No",
+        finalAnswerValue="Yes",
+        editCommentValue="Needs correction",
+        initialCommentValue="",
+        finalCommentValue="",
+        metadata={},
+    )
+
+    with patch(
+        "plexus.dashboard.api.models.feedback_item.FeedbackItem._update_feedback_item",
+        side_effect=lambda _client, _id, feedback_data: SimpleNamespace(id=_id, metadata=feedback_data["metadata"]),
+    ) as mock_update:
+        result = await hydrate_feedback_item_explanations(
+            feedback_items=[cached_item, uncached_item],
+            api_client=Mock(),
+            score_results_by_item_id={
+                "item-cached": {"value": "No", "human_label": "Yes", "explanation": ""},
+                "item-new": {"value": "No", "human_label": "Yes", "explanation": ""},
+            },
+            provider="heuristic",
+            model="feedback-item-explainer-v1",
+            max_concurrent=2,
+        )
+
+    assert set(result.keys()) == {"fi-cached", "fi-new"}
+    assert result["fi-cached"]["cache_hit"] is True
+    assert result["fi-new"]["cache_hit"] is False
+    assert mock_update.call_count == 1

--- a/plexus/reports/blocks/feedback_contradictions.py
+++ b/plexus/reports/blocks/feedback_contradictions.py
@@ -21,6 +21,7 @@ from .guideline_vetting import GuidelineVettingService
 from .feedback_scope_resolver import resolve_scorecard
 from .score_resolution import resolve_score_for_scorecard
 from plexus.bedrock_models import CLAUDE_HAIKU_45_MODEL_ID
+from plexus.feedback_item_explanations import hydrate_feedback_item_explanations
 from plexus.rubric_memory import RubricMemoryContextProvider
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,10 @@ class FeedbackContradictions(BaseReportBlock):
         max_feedback_items = int(self.config.get("max_feedback_items", 400))
         num_topics = int(self.config.get("num_topics", 8))
         include_rubric_memory = bool(self.config.get("include_rubric_memory", False))
+        feedback_explanation_provider = str(
+            self.config.get("feedback_explanation_provider", "auto")
+        ).strip().lower()
+        feedback_explanation_model = self.config.get("feedback_explanation_model")
         score_version_param = (
             self.config.get("score_version_id")
             or self.config.get("score_version")
@@ -215,6 +220,8 @@ class FeedbackContradictions(BaseReportBlock):
                     "max_concurrent": max_concurrent,
                     "num_topics": num_topics,
                     "include_rubric_memory": include_rubric_memory,
+                    "feedback_explanation_provider": feedback_explanation_provider,
+                    "feedback_explanation_model": feedback_explanation_model,
                     "score_version_id": score_version_id,
                 },
                 "topics": [],
@@ -252,6 +259,38 @@ class FeedbackContradictions(BaseReportBlock):
                 f"Loaded rubric-memory citation context for {len(rubric_memory_contexts_by_item)} feedback items."
             )
 
+        self._log(
+            "Hydrating feedback-item explanation cache "
+            f"(provider={feedback_explanation_provider}, model={feedback_explanation_model or 'default'})..."
+        )
+        transcript_by_item_id = {
+            getattr(item, "itemId", ""): (getattr(getattr(item, "item", None), "text", "") or "")
+            for item in valid_items
+            if getattr(item, "itemId", None)
+        }
+        feedback_item_explanations_by_id = await hydrate_feedback_item_explanations(
+            feedback_items=valid_items,
+            api_client=self.api_client,
+            score_results_by_item_id=score_results_by_item,
+            transcript_by_item_id=transcript_by_item_id,
+            score_guidelines_text=guidelines or "",
+            scorecard_guidance_text=getattr(scorecard_obj, "guidelines", "") or "",
+            provider=feedback_explanation_provider,
+            model=feedback_explanation_model,
+            max_concurrent=max_concurrent,
+        )
+        explanation_cache_hits = sum(
+            1
+            for payload in feedback_item_explanations_by_id.values()
+            if payload.get("cache_hit") is True
+        )
+        self._log(
+            "Feedback explanations ready for "
+            f"{len(feedback_item_explanations_by_id)} items "
+            f"({explanation_cache_hits} cache hits, "
+            f"{len(feedback_item_explanations_by_id) - explanation_cache_hits} generated)."
+        )
+
         self._log(f"Running guideline-vetting analysis (max_concurrent={max_concurrent})...")
         vetting_service = GuidelineVettingService()
         analyzed_items = await vetting_service.analyze_items(
@@ -260,6 +299,7 @@ class FeedbackContradictions(BaseReportBlock):
             max_concurrent,
             score_results_by_item,
             rubric_memory_contexts_by_item=rubric_memory_contexts_by_item,
+            feedback_item_explanations_by_id=feedback_item_explanations_by_id,
         )
 
         contradictions = [item for item in analyzed_items if item.get("verdict") == "contradiction"]
@@ -321,6 +361,8 @@ class FeedbackContradictions(BaseReportBlock):
                 "max_concurrent": max_concurrent,
                 "num_topics": num_topics,
                 "include_rubric_memory": include_rubric_memory,
+                "feedback_explanation_provider": feedback_explanation_provider,
+                "feedback_explanation_model": feedback_explanation_model,
                 "score_version_id": score_version_id,
             },
             "rubric_memory": {

--- a/plexus/reports/blocks/feedback_utils.py
+++ b/plexus/reports/blocks/feedback_utils.py
@@ -253,12 +253,15 @@ async def fetch_feedback_items_for_score(
                     editorName
                     isAgreement
                     isInvalid
+                    metadata
                     createdAt
                     updatedAt
                     item {
                         id
                         identifiers
                         externalId
+                        text
+                        metadata
                         itemIdentifiers {
                             items {
                                 name

--- a/plexus/reports/blocks/guideline_vetting.py
+++ b/plexus/reports/blocks/guideline_vetting.py
@@ -49,6 +49,7 @@ class GuidelineVettingService:
         item: Any,
         guidelines: Optional[str],
         score_explanation: str,
+        feedback_item_explanation: str = "",
         rubric_memory_context: Optional[Dict[str, Any]] = None,
     ) -> Optional[str]:
         """Build classifier prompt for a feedback item; return None when item should be skipped."""
@@ -65,6 +66,8 @@ class GuidelineVettingService:
         ]
         if score_explanation:
             situation_lines.append(f"- AI reasoning: {score_explanation}")
+        if feedback_item_explanation:
+            situation_lines.append(f"- Cached feedback ground-truth explanation: {feedback_item_explanation}")
         if initial != final:
             situation_lines.append(f"- A human reviewer then changed the score to '{final}'.")
         else:
@@ -225,6 +228,9 @@ class GuidelineVettingService:
         best_result: Dict[str, Any],
         votes_meta: List[Dict[str, Any]],
         score_explanation: str,
+        feedback_item_explanation: str,
+        feedback_item_explanation_provider: str,
+        feedback_item_explanation_model: str,
         confidence: str,
         verdict: str,
         associated_dataset_eligible: bool,
@@ -268,6 +274,9 @@ class GuidelineVettingService:
             "initial_value": getattr(item, "initialAnswerValue", "") or "",
             "final_value": getattr(item, "finalAnswerValue", "") or "",
             "score_result_explanation": score_explanation,
+            "feedback_item_explanation": feedback_item_explanation,
+            "feedback_item_explanation_provider": feedback_item_explanation_provider,
+            "feedback_item_explanation_model": feedback_item_explanation_model,
             "edit_comment": getattr(item, "editCommentValue", "") or "",
             "editor_name": getattr(item, "editorName", None),
             "edited_at": edited_at,
@@ -293,6 +302,7 @@ class GuidelineVettingService:
         max_concurrent: int,
         score_results_by_item: Dict[str, Any],
         rubric_memory_contexts_by_item: Optional[Dict[str, Dict[str, Any]]] = None,
+        feedback_item_explanations_by_id: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Analyze items via shared voting and return both contradiction and aligned results.
@@ -307,6 +317,16 @@ class GuidelineVettingService:
                 item_id = getattr(item, "itemId", None)
                 score_result = score_results_by_item.get(item_id) if item_id else None
                 score_explanation = (score_result.get("explanation") or "") if score_result else ""
+                explanation_payload = (feedback_item_explanations_by_id or {}).get(
+                    getattr(item, "id", "")
+                ) or {}
+                feedback_item_explanation = explanation_payload.get("explanation", "") or ""
+                feedback_item_explanation_provider = (
+                    explanation_payload.get("provider", "") or ""
+                )
+                feedback_item_explanation_model = (
+                    explanation_payload.get("model", "") or ""
+                )
                 rubric_memory_context = (
                     (rubric_memory_contexts_by_item or {}).get(item_id)
                     or (rubric_memory_contexts_by_item or {}).get(getattr(item, "id", ""))
@@ -316,6 +336,7 @@ class GuidelineVettingService:
                     item,
                     guidelines,
                     score_explanation,
+                    feedback_item_explanation=feedback_item_explanation,
                     rubric_memory_context=rubric_memory_context,
                 )
                 if prompt is None:
@@ -416,6 +437,9 @@ class GuidelineVettingService:
                     best_result=best_result,
                     votes_meta=votes_meta,
                     score_explanation=score_explanation,
+                    feedback_item_explanation=feedback_item_explanation,
+                    feedback_item_explanation_provider=feedback_item_explanation_provider,
+                    feedback_item_explanation_model=feedback_item_explanation_model,
                     confidence=confidence,
                     verdict=verdict,
                     associated_dataset_eligible=associated_dataset_eligible,


### PR DESCRIPTION
## Summary
- preserve feedback-item explanation metadata fields when compacting RCA topic exemplars for evaluation parameters
- keep `feedback_item_explanation_provider`, `feedback_item_explanation_model`, and `feedback_item_explanation_cache_hit` in compacted payloads
- add regression coverage in `Evaluation_feedback_test.py`

## Validation
- `pytest plexus/Evaluation_feedback_test.py -k "TestCompactRootCauseForParameters" -q`
- production validation runs on SelectQuote HCS Medium-Risk / Medication Review question scores + feedback evaluations (details in thread)
