### PR TITLE
fix(metrics-aggregator): serialize feedback metadata as JSON string for Amplify

### DIFF
--- a/infrastructure/lambda_functions/metrics_aggregator/bucket_counter.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/bucket_counter.py
@@ -5,6 +5,7 @@ This module handles counting records into multiple time buckets efficiently
 by iterating through the data once and assigning each record to all relevant buckets.
 """
 
+import json
 from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Tuple, Optional
 from collections import defaultdict
@@ -321,11 +322,11 @@ def count_feedback_records_efficiently(
                 'number_of_minutes': bucket_minutes,
                 'count': bucket['count'],
                 'complete': bucket_end <= now,
-                'metadata': {
+                'metadata': json.dumps({
                     'changedCount': bucket['changed_count'],
                     'unchangedCount': bucket['unchanged_count'],
                     'invalidCount': bucket['invalid_count'],
-                },
+                }),
             })
 
     print(f"  Processed: {processed} feedback items ({skipped} skipped - no effective timestamp)")

--- a/infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py
+++ b/infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -93,9 +94,10 @@ def test_count_feedback_records_efficiently_writes_scoped_buckets_and_metadata()
 
     assert len(account_one_min) == 3
     assert sum(bucket["count"] for bucket in account_one_min) == 3
-    assert sum(bucket["metadata"]["changedCount"] for bucket in account_one_min) == 1
-    assert sum(bucket["metadata"]["unchangedCount"] for bucket in account_one_min) == 1
-    assert sum(bucket["metadata"]["invalidCount"] for bucket in account_one_min) == 1
+    # Metadata is now a JSON string, need to parse it
+    assert sum(json.loads(bucket["metadata"])["changedCount"] for bucket in account_one_min) == 1
+    assert sum(json.loads(bucket["metadata"])["unchangedCount"] for bucket in account_one_min) == 1
+    assert sum(json.loads(bucket["metadata"])["invalidCount"] for bucket in account_one_min) == 1
 
     assert len(scorecard_one_min) == 3
     assert {bucket["scorecard_id"] for bucket in scorecard_one_min} == {"scorecard-1"}
@@ -140,6 +142,12 @@ def test_update_buckets_passes_scope_and_metadata_to_graphql_client():
             self.calls.append(kwargs)
 
     graphql_client = FakeGraphQLClient()
+    # Metadata is now a JSON string (as produced by bucket_counter.py)
+    metadata_json = json.dumps({
+        "changedCount": 1,
+        "unchangedCount": 0,
+        "invalidCount": 0,
+    })
     buckets = [
         {
             "account_id": "account-1",
@@ -151,11 +159,7 @@ def test_update_buckets_passes_scope_and_metadata_to_graphql_client():
             "number_of_minutes": 1,
             "count": 1,
             "complete": True,
-            "metadata": {
-                "changedCount": 1,
-                "unchangedCount": 0,
-                "invalidCount": 0,
-            },
+            "metadata": metadata_json,
         }
     ]
 
@@ -174,11 +178,7 @@ def test_update_buckets_passes_scope_and_metadata_to_graphql_client():
             "complete": True,
             "scorecard_id": "scorecard-1",
             "score_id": "score-1",
-            "metadata": {
-                "changedCount": 1,
-                "unchangedCount": 0,
-                "invalidCount": 0,
-            },
+            "metadata": metadata_json,
         }
     ]
 


### PR DESCRIPTION
## Summary

Fixes the metrics aggregator Lambda which has been failing to write feedback metrics since May 11, causing the feedback dashboard to show stale data (last update: April 29).

## Problem

The Lambda was failing with GraphQL error:
```
Variable 'metadata' has an invalid value
```

The FeedbackItem DynamoDB stream mapping shows:
```json
"LastProcessingResult": "PROBLEM: Function call failed"
```

## Root Cause

Amplify Gen 2's `a.json()` type expects a **JSON string**, not a dict object. The Lambda was passing metadata as a Python dict, which stopped working on May 11 when Amplify validation was tightened (same issue that was fixed for FeedbackItem model in commit 9b4d8f6).

## Solution

- Wrap metadata dict with `json.dumps()` in `bucket_counter.py`
- Update tests to expect and validate JSON string format
- Aligns with FeedbackItem model serialization pattern

## Changes

**Modified files:**
- `infrastructure/lambda_functions/metrics_aggregator/bucket_counter.py` - Add JSON serialization
- `infrastructure/lambda_functions/metrics_aggregator/test_feedback_metrics.py` - Update tests for string format

## Testing

- ✅ All existing tests pass with updated assertions
- ✅ Validated JSON string format matches Amplify AWSJSON type expectations
- ✅ Verified data integrity through JSON round-trip

## Impact

After deployment:
- FeedbackItem stream mapping will recover from failed state
- Feedback metrics will resume updating in dashboard
- Dashboard at https://lab.callcriteria.com/lab/feedback will show current data

## Related

- Fixes same issue as commit 9b4d8f6 (FeedbackItem metadata serialization)
- Related to schema change on May 11 when validation was tightened