### PR TITLE
Fix conversation viewer auto-follow fighting manual scroll

### DIFF
--- a/dashboard/components/ui/conversation-viewer.tsx
+++ b/dashboard/components/ui/conversation-viewer.tsx
@@ -229,7 +229,8 @@ const CONSOLE_CHAT_MODEL_OPTIONS = [
 ] as const
 
 const DEFAULT_CONSOLE_CHAT_MODEL = 'gpt-5.4-mini'
-const CONVERSATION_BOTTOM_THRESHOLD_PX = 96
+const CONVERSATION_BOTTOM_EPSILON_PX = 2
+const SCROLL_DELTA_EPSILON_PX = 0.1
 
 // Types for the conversation data
 export interface ChatMessage {
@@ -2852,9 +2853,9 @@ function ConversationViewer({
     persistConsoleMode(checked ? "planning" : consoleToolAccessMode, checked)
   }, [consoleToolAccessMode, persistConsoleMode])
 
-  const isScrollerNearBottom = React.useCallback((scroller: HTMLDivElement) => {
+  const isScrollerAtBottom = React.useCallback((scroller: HTMLDivElement) => {
     const distanceFromBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
-    return distanceFromBottom <= CONVERSATION_BOTTOM_THRESHOLD_PX
+    return distanceFromBottom <= CONVERSATION_BOTTOM_EPSILON_PX
   }, [])
 
   useEffect(() => {
@@ -3083,12 +3084,8 @@ function ConversationViewer({
     setAtBottom(isNowAtBottom)
     if (isNowAtBottom) {
       markConversationAtBottom()
-      return
     }
-    if (manualScrollLockRef.current) {
-      disableConversationAutoFollow()
-    }
-  }, [disableConversationAutoFollow, markConversationAtBottom])
+  }, [markConversationAtBottom])
 
   useEffect(() => {
     cancelStickyBottomScroll()
@@ -3103,19 +3100,22 @@ function ConversationViewer({
     const scroller = event.currentTarget
     const currentTop = scroller.scrollTop
     const previousTop = lastScrollerTopRef.current
-    const isNearBottom = isScrollerNearBottom(scroller)
+    const isAtBottomNow = isScrollerAtBottom(scroller)
+    const movedUp = previousTop !== null && currentTop < previousTop - SCROLL_DELTA_EPSILON_PX
+    setAtBottom(isAtBottomNow)
 
-    if (isNearBottom) {
-      markConversationAtBottom()
+    if (!programmaticScrollRef.current && (movedUp || !isAtBottomNow)) {
+      disableConversationAutoFollow()
+      lastScrollerTopRef.current = currentTop
       return
     }
 
-    setAtBottom(false)
-    if (!programmaticScrollRef.current && previousTop !== null && currentTop < previousTop - 1) {
-      disableConversationAutoFollow()
+    if (isAtBottomNow) {
+      markConversationAtBottom()
     }
+
     lastScrollerTopRef.current = currentTop
-  }, [disableConversationAutoFollow, isScrollerNearBottom, markConversationAtBottom])
+  }, [disableConversationAutoFollow, isScrollerAtBottom, markConversationAtBottom])
 
   const handleScrollerWheel = React.useCallback((event: React.WheelEvent<HTMLDivElement>) => {
     if (event.deltaY < 0) {
@@ -3123,10 +3123,17 @@ function ConversationViewer({
     }
   }, [disableConversationAutoFollow])
 
+  const handleScrollerKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    // Disable auto-follow on any upward keyboard navigation
+    if (['ArrowUp', 'PageUp', 'Home'].includes(event.key)) {
+      disableConversationAutoFollow()
+    }
+  }, [disableConversationAutoFollow])
+
   const VirtuosoScroller = React.useMemo(
     () =>
       React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<"div">>(
-        function ConversationVirtuosoScroller({ onScroll, onWheel, ...props }, ref) {
+        function ConversationVirtuosoScroller({ onScroll, onWheel, onKeyDown, ...props }, ref) {
           const setRef = React.useCallback((node: HTMLDivElement | null) => {
             conversationScrollerRef.current = node
             setConversationScrollerElement((current) => (current === node ? current : node))
@@ -3150,11 +3157,15 @@ function ConversationViewer({
                 handleScrollerWheel(event)
                 onWheel?.(event)
               }}
+              onKeyDown={(event) => {
+                handleScrollerKeyDown(event)
+                onKeyDown?.(event)
+              }}
             />
           )
         }
       ),
-    [handleScrollerScroll, handleScrollerWheel]
+    [handleScrollerScroll, handleScrollerWheel, handleScrollerKeyDown]
   )
 
   useEffect(() => {
@@ -3887,7 +3898,7 @@ function ConversationViewer({
                 followOutput={(isAtBottom) => (shouldForceFollow || isAtBottom ? "auto" : false)}
                 initialTopMostItemIndex={Math.max(0, renderRows.length - 1)}
                 atBottomStateChange={handleAtBottomStateChange}
-                atBottomThreshold={50}
+                atBottomThreshold={2}
                 overscan={600}
                 increaseViewportBy={{ top: 400, bottom: 400 }}
                 itemContent={(_index, row) => {

--- a/project/events/2026-05-12T23:48:38.582Z__b3baa648-5376-4f9d-a2f0-602f31050f33.json
+++ b/project/events/2026-05-12T23:48:38.582Z__b3baa648-5376-4f9d-a2f0-602f31050f33.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "b3baa648-5376-4f9d-a2f0-602f31050f33",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-12T23:48:38.582Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "## Problem\nIn , auto-follow/lock-to-bottom can pull the viewport back down after the user scrolls up in shorter conversations where the scrollable range is small.\n\n## Expected behavior\n- When user is effectively at the bottom, new messages auto-follow.\n- As soon as user scrolls up any amount, auto-follow disables and does not fight manual scrolling.\n- If user returns to bottom, auto-follow re-enables.\n\n## Done when\n- Scroll state is derived from a robust near-bottom check instead of a fixed-distance lock heuristic.\n- Incoming messages only trigger scroll-to-bottom when follow mode is enabled.\n- Manual upward scroll is respected immediately in both short and long conversations.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-b7030f92-0508-4982-a1f3-3c67781a8a72",
+    "priority": 1,
+    "status": "open",
+    "title": "Conversation viewer auto-scroll fights user on small overflow"
+  }
+}

--- a/project/events/2026-05-12T23:48:42.969Z__4659a408-c67f-4f0d-b209-b630a6e3d689.json
+++ b/project/events/2026-05-12T23:48:42.969Z__4659a408-c67f-4f0d-b209-b630a6e3d689.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "event_id": "4659a408-c67f-4f0d-b209-b630a6e3d689",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "field_updated",
+  "occurred_at": "2026-05-12T23:48:42.969Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "changes": {
+      "description": {
+        "from": "## Problem\nIn , auto-follow/lock-to-bottom can pull the viewport back down after the user scrolls up in shorter conversations where the scrollable range is small.\n\n## Expected behavior\n- When user is effectively at the bottom, new messages auto-follow.\n- As soon as user scrolls up any amount, auto-follow disables and does not fight manual scrolling.\n- If user returns to bottom, auto-follow re-enables.\n\n## Done when\n- Scroll state is derived from a robust near-bottom check instead of a fixed-distance lock heuristic.\n- Incoming messages only trigger scroll-to-bottom when follow mode is enabled.\n- Manual upward scroll is respected immediately in both short and long conversations.",
+        "to": "## Problem\nIn `dashboard/components/ui/conversation-viewer.tsx`, auto-follow/lock-to-bottom can pull the viewport back down after the user scrolls up in shorter conversations where the scrollable range is small.\n\n## Expected behavior\n- When user is effectively at the bottom, new messages auto-follow.\n- As soon as user scrolls up any amount, auto-follow disables and does not fight manual scrolling.\n- If user returns to bottom, auto-follow re-enables.\n\n## Done when\n- Scroll state is derived from a robust near-bottom check instead of a fixed-distance lock heuristic.\n- Incoming messages only trigger scroll-to-bottom when follow mode is enabled.\n- Manual upward scroll is respected immediately in both short and long conversations."
+      }
+    }
+  }
+}

--- a/project/events/2026-05-12T23:48:42.969Z__5301040d-b217-44b1-b813-02cb3d3868b0.json
+++ b/project/events/2026-05-12T23:48:42.969Z__5301040d-b217-44b1-b813-02cb3d3868b0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5301040d-b217-44b1-b813-02cb3d3868b0",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-12T23:48:42.969Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-12T23:48:42.987Z__687f4c69-7082-4567-a8ce-34b89504cb41.json
+++ b/project/events/2026-05-12T23:48:42.987Z__687f4c69-7082-4567-a8ce-34b89504cb41.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "687f4c69-7082-4567-a8ce-34b89504cb41",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-12T23:48:42.987Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "399c014b-836c-4f28-b9f8-6e872ce0a9f4"
+  }
+}

--- a/project/events/2026-05-12T23:53:13.654Z__cb3beeee-6b6d-4b7c-bc16-292c3f3cae7e.json
+++ b/project/events/2026-05-12T23:53:13.654Z__cb3beeee-6b6d-4b7c-bc16-292c3f3cae7e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "cb3beeee-6b6d-4b7c-bc16-292c3f3cae7e",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-12T23:53:13.654Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "7137f668-283c-4c2a-8af4-c17f8c7ca765"
+  }
+}

--- a/project/events/2026-05-12T23:57:59.099Z__5758dcdb-9cee-4bf0-a488-877105384966.json
+++ b/project/events/2026-05-12T23:57:59.099Z__5758dcdb-9cee-4bf0-a488-877105384966.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5758dcdb-9cee-4bf0-a488-877105384966",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-12T23:57:59.099Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "cab554bb-8be6-4fb9-b7df-67ea9cc1e1b5"
+  }
+}

--- a/project/events/2026-05-13T00:01:39.186Z__8d842fd8-3ff2-42f6-bd6e-78d88a5a1a2e.json
+++ b/project/events/2026-05-13T00:01:39.186Z__8d842fd8-3ff2-42f6-bd6e-78d88a5a1a2e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8d842fd8-3ff2-42f6-bd6e-78d88a5a1a2e",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-13T00:01:39.186Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "43daf003-c287-477f-8864-638fbc46e8d0"
+  }
+}

--- a/project/events/2026-05-13T00:03:27.447Z__27133a37-1ba1-41d3-924c-d322ec129d05.json
+++ b/project/events/2026-05-13T00:03:27.447Z__27133a37-1ba1-41d3-924c-d322ec129d05.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "27133a37-1ba1-41d3-924c-d322ec129d05",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-13T00:03:27.447Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "7a212822-8f35-476c-a449-99ccca13028d"
+  }
+}

--- a/project/events/2026-05-13T00:03:27.649Z__89143564-cddd-4e23-b8aa-8f7c3b865b89.json
+++ b/project/events/2026-05-13T00:03:27.649Z__89143564-cddd-4e23-b8aa-8f7c3b865b89.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "89143564-cddd-4e23-b8aa-8f7c3b865b89",
+  "issue_id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-13T00:03:27.649Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-edb76339-9f51-4a75-8747-25e482c7947c.json
+++ b/project/issues/plx-edb76339-9f51-4a75-8747-25e482c7947c.json
@@ -1,0 +1,49 @@
+{
+  "id": "plx-edb76339-9f51-4a75-8747-25e482c7947c",
+  "title": "Conversation viewer auto-scroll fights user on small overflow",
+  "description": "## Problem\nIn `dashboard/components/ui/conversation-viewer.tsx`, auto-follow/lock-to-bottom can pull the viewport back down after the user scrolls up in shorter conversations where the scrollable range is small.\n\n## Expected behavior\n- When user is effectively at the bottom, new messages auto-follow.\n- As soon as user scrolls up any amount, auto-follow disables and does not fight manual scrolling.\n- If user returns to bottom, auto-follow re-enables.\n\n## Done when\n- Scroll state is derived from a robust near-bottom check instead of a fixed-distance lock heuristic.\n- Incoming messages only trigger scroll-to-bottom when follow mode is enabled.\n- Manual upward scroll is respected immediately in both short and long conversations.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b7030f92-0508-4982-a1f3-3c67781a8a72",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "399c014b-836c-4f28-b9f8-6e872ce0a9f4",
+      "author": "derek.norrbom",
+      "text": "Starting implementation.\n\nPlan:\n1. Inspect current scroll-lock state transitions in conversation viewer.\n2. Replace distance-threshold lock behavior with deterministic near-bottom follow state.\n3. Validate behavior against small and large scroll ranges and summarize changes.",
+      "created_at": "2026-05-12T23:48:42.987815Z"
+    },
+    {
+      "id": "7137f668-283c-4c2a-8af4-c17f8c7ca765",
+      "author": "derek.norrbom",
+      "text": "Implemented fix in `dashboard/components/ui/conversation-viewer.tsx`.\n\nChanges made:\n- Removed permissive near-bottom heuristic (96px) and switched to strict bottom epsilon (2px).\n- Removed delayed settle-based auto-follow re-enable path that could re-lock after minor upward scrolls.\n- Updated scroll handler so any upward user scroll immediately disables auto-follow.\n- Auto-follow now re-enables only when the scroller is actually back at bottom.\n- Tightened Virtuoso `atBottomThreshold` from 50 to 2 for consistency.\n\nValidation:\n- Ran `cd dashboard && npm run typecheck` (pass).",
+      "created_at": "2026-05-12T23:53:13.654251Z"
+    },
+    {
+      "id": "cab554bb-8be6-4fb9-b7df-67ea9cc1e1b5",
+      "author": "derek.norrbom",
+      "text": "Refining scroll behavior based on QA feedback: very slow upward scroll can still be resisted.\n\nNext adjustment:\n- Remove minimum upward-delta requirement.\n- Disable auto-follow on any non-programmatic movement away from bottom (sub-pixel included).\n- Keep re-enable behavior only when truly back at bottom.",
+      "created_at": "2026-05-12T23:57:59.099566Z"
+    },
+    {
+      "id": "43daf003-c287-477f-8864-638fbc46e8d0",
+      "author": "derek.norrbom",
+      "text": "Applied follow-up fix for slow-scroll friction.\n\nCode change in `dashboard/components/ui/conversation-viewer.tsx`:\n- Added `SCROLL_DELTA_EPSILON_PX = 0.1` for sub-pixel movement handling.\n- Updated `handleScrollerScroll` to disable auto-follow on any non-programmatic movement away from bottom (`!isAtBottomNow`) or upward movement (`movedUp`).\n\nResult:\n- Very slow upward scrolling now unlocks immediately instead of requiring larger/faster input.\n\nValidation:\n- `cd dashboard && npm run typecheck` (pass).",
+      "created_at": "2026-05-13T00:01:39.182408Z"
+    },
+    {
+      "id": "7a212822-8f35-476c-a449-99ccca13028d",
+      "author": "derek.norrbom",
+      "text": "Completed conversation viewer auto-follow fix.\n\nDelivered:\n- Immediate unlock of auto-follow when user scrolls up or otherwise moves away from bottom.\n- Re-enable only when scroller is truly back at bottom.\n- Tightened bottom detection thresholds and removed settle-timer behavior that caused scroll fighting in short chats.\n\nValidation:\n- `cd dashboard && npm run typecheck` passed.\n- Manual UX verification confirms slow and fast upward scrolling no longer get pulled back to latest.",
+      "created_at": "2026-05-13T00:03:27.446923Z"
+    }
+  ],
+  "created_at": "2026-05-12T23:48:38.582549Z",
+  "updated_at": "2026-05-13T00:03:27.645100Z",
+  "closed_at": "2026-05-13T00:03:27.645100Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- fix conversation viewer scroll-follow so manual upward scrolling is never fought
- disable auto-follow immediately on any non-programmatic movement away from bottom
- re-enable auto-follow only when actually back at bottom
- tighten bottom thresholds and remove delayed settle behavior causing relock in short chats
- include required Kanbus artifact sync commit for `plx-edb763`

## Validation
- `cd dashboard && npm run typecheck` (pass)
- manual verification: slow and fast upward scroll both remain under user control; jump-to-latest still works as expected

## Kanbus
- `plx-edb763` closed