### PR TITLE
Fix attributed ScoreVersion metadata serialization

### DIFF
--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -5319,7 +5319,7 @@ def _default_score_update(args: dict[str, Any]) -> dict[str, Any]:
                     source="execute_tactus",
                 )
             if isinstance(payload.get("metadata"), (dict, list)):
-                payload["metadata"] = json.dumps(payload["metadata"])
+                payload["metadata"] = json.dumps(payload["metadata"], default=str)
             try:
                 resp = client.execute(version_mutation, {"input": payload})
                 new_version = (resp or {}).get("createScoreVersion") or {}

--- a/MCP/tools/tactus_runtime/execute_test.py
+++ b/MCP/tools/tactus_runtime/execute_test.py
@@ -242,6 +242,70 @@ def test_plexus_facade_uses_direct_scorecards_handler_without_mcp_loopback() -> 
     ]
 
 
+def test_default_score_update_applies_actor_attribution(monkeypatch) -> None:
+    from plexus.cli.shared import client_utils, direct_identifier_resolution
+    from plexus.linting import schemas
+
+    mutation_inputs: list[dict[str, Any]] = []
+
+    class FakeClient:
+        context = SimpleNamespace(
+            actor_user_id="user-123",
+            actor_type="agent",
+            actor_key="optimizer-agent",
+            actor_source="agent",
+        )
+
+        def execute(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+            if "createScoreVersion" in query:
+                mutation_inputs.append(variables["input"])
+                return {"createScoreVersion": {"id": "version-123", "createdAt": "now"}}
+            raise AssertionError(f"Unexpected query: {query}")
+
+    monkeypatch.setattr(client_utils, "create_client", lambda: FakeClient())
+    monkeypatch.setattr(
+        direct_identifier_resolution,
+        "direct_resolve_scorecard_identifier",
+        lambda client, identifier: "scorecard-123",
+    )
+    monkeypatch.setattr(
+        direct_identifier_resolution,
+        "direct_resolve_score_identifier",
+        lambda client, scorecard_id, identifier: "score-123",
+    )
+    monkeypatch.setattr(
+        schemas,
+        "create_score_linter",
+        lambda: SimpleNamespace(
+            lint=lambda code: SimpleNamespace(is_valid=True, messages=[])
+        ),
+    )
+
+    result = execute._default_score_update(
+        {
+            "scorecard_identifier": "SelectQuote HCS Medium-Risk",
+            "score_identifier": "Medication Review: Dosage",
+            "code": "name: Test\nkey: test\nclass: LangGraphScore\n",
+            "parent_version_id": "parent-123",
+            "version_note": "candidate",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["version_id"] == "version-123"
+    assert mutation_inputs
+    created = mutation_inputs[0]
+    assert created["createdByUserId"] == "user-123"
+    assert isinstance(created["metadata"], str)
+    metadata = json.loads(created["metadata"])
+    assert metadata["attribution"] == {
+        "actorType": "agent",
+        "actorKey": "optimizer-agent",
+        "source": "agent",
+        "requestUserId": "user-123",
+    }
+
+
 def test_default_rubric_memory_recent_entries_runs_provider_awaitable(monkeypatch) -> None:
     class FakeCitation:
         def model_dump(self, mode: str = "json") -> dict:

--- a/plexus/Evaluation.py
+++ b/plexus/Evaluation.py
@@ -65,6 +65,42 @@ _RCA_HEADING_RE = re.compile(
 )
 
 
+def _rca_llm_timeout_seconds() -> float:
+    value = os.getenv("PLEXUS_RCA_LLM_TIMEOUT_SECONDS", "").strip()
+    if not value:
+        return 60.0
+    try:
+        timeout = float(value)
+    except ValueError:
+        logging.warning(
+            "Invalid PLEXUS_RCA_LLM_TIMEOUT_SECONDS=%r; using default 60s",
+            value,
+        )
+        return 60.0
+    if timeout <= 0:
+        logging.warning(
+            "Invalid non-positive PLEXUS_RCA_LLM_TIMEOUT_SECONDS=%r; using default 60s",
+            value,
+        )
+        return 60.0
+    return timeout
+
+
+def _bedrock_runtime_client_for_rca():
+    import boto3 as _boto3
+    from botocore.config import Config as _BotocoreConfig
+
+    return _boto3.client(
+        "bedrock-runtime",
+        region_name="us-east-1",
+        config=_BotocoreConfig(
+            connect_timeout=10,
+            read_timeout=_rca_llm_timeout_seconds(),
+            retries={"max_attempts": 2, "mode": "standard"},
+        ),
+    )
+
+
 def _sanitize_rca_generated_prose(text: str, *, max_sentences: int = 3, max_chars: int = 900) -> str:
     """Keep RCA generated prose concise and remove headings supplied by the UI."""
     if not text:
@@ -4678,9 +4714,8 @@ class FeedbackEvaluation(Evaluation):
             def _bedrock_converse(system: str, messages: list, max_tokens: int = 1000) -> str:
                 """Run a Bedrock Claude conversation and return the assistant response."""
                 import json as _json
-                import boto3 as _boto3
                 try:
-                    brt = _boto3.client("bedrock-runtime", region_name="us-east-1")
+                    brt = _bedrock_runtime_client_for_rca()
                     body = _json.dumps({
                         "anthropic_version": "bedrock-2023-05-31",
                         "max_tokens": max_tokens,
@@ -5440,10 +5475,9 @@ class FeedbackEvaluation(Evaluation):
             rca_item_failures.extend(item_failure_diagnostics)
 
         def _bedrock_converse(system: str, prompt: str, max_tokens: int = 500) -> str:
-            import boto3 as _boto3
             import json as _json
 
-            brt = _boto3.client("bedrock-runtime", region_name="us-east-1")
+            brt = _bedrock_runtime_client_for_rca()
             body = _json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
                 "max_tokens": max_tokens,

--- a/plexus/cli/score/scores.py
+++ b/plexus/cli/score/scores.py
@@ -1379,6 +1379,11 @@ def push(scorecard: str, score: str, note: str):
             client_context=getattr(client, "context", None),
             source="cli",
         )
+        if isinstance(mutation_input["input"].get("metadata"), dict):
+            mutation_input["input"]["metadata"] = json.dumps(
+                mutation_input["input"]["metadata"],
+                default=str,
+            )
 
         with client as session:
             result = session.execute(gql(mutation), mutation_input)

--- a/plexus/cli/score_chat/repl.py
+++ b/plexus/cli/score_chat/repl.py
@@ -1128,15 +1128,17 @@ You can also just ask me questions or tell me what you'd like to do in plain Eng
             }
             """
             
-            result = self.client.execute(mutation, {
-                'input': apply_actor_attribution({
+            version_input = apply_actor_attribution({
                     'scoreId': score_id,
                     'configuration': yaml_content,
                     'parentVersionId': score_data.get('championVersionId'),
                     'note': 'Updated via CLI push command',
                     'isFeatured': "true"
                 }, client_context=getattr(self.client, "context", None), source="agent")
-            })
+            if isinstance(version_input.get("metadata"), dict):
+                version_input["metadata"] = json.dumps(version_input["metadata"], default=str)
+
+            result = self.client.execute(mutation, {'input': version_input})
             
             if result.get('createScoreVersion'):
                 self.console.print(f"[green]Successfully created new version for score: {score_data['name']}[/green]")

--- a/plexus/cli/score_chat/service.py
+++ b/plexus/cli/score_chat/service.py
@@ -547,15 +547,17 @@ Then ask the user what they would like to change about the scorecard."""
             }
             """
             
-            result = self.client.execute(mutation, {
-                'input': apply_actor_attribution({
+            version_input = apply_actor_attribution({
                     'scoreId': score_id,
                     'configuration': yaml_content,
                     'parentVersionId': score_data.get('championVersionId'),
                     'note': 'Updated via API chat command',
                     'isFeatured': "true"
                 }, client_context=getattr(self.client, "context", None), source="agent")
-            })
+            if isinstance(version_input.get("metadata"), dict):
+                version_input["metadata"] = json.dumps(version_input["metadata"], default=str)
+
+            result = self.client.execute(mutation, {'input': version_input})
             
             if result.get('createScoreVersion'):
                 success_msg = (

--- a/plexus/cli/shared/plexus_tool.py
+++ b/plexus/cli/shared/plexus_tool.py
@@ -8,6 +8,7 @@ This module implements the Plexus tool protocol for Claude to:
 4. Push score version updates from YAML
 """
 
+import json
 from typing import Dict, List, Optional, Any
 from pathlib import Path
 import yaml
@@ -346,6 +347,8 @@ class PlexusTool:
                     client_context=getattr(self.client, "context", None),
                     source="agent",
                 )
+                if isinstance(version_input.get("metadata"), dict):
+                    version_input["metadata"] = json.dumps(version_input["metadata"], default=str)
                 
                 result = self.client.execute(mutation, {'input': version_input})
                 new_version = result.get('createScoreVersion')

--- a/plexus/dashboard/api/models/attribution_create_test.py
+++ b/plexus/dashboard/api/models/attribution_create_test.py
@@ -185,4 +185,7 @@ def test_score_create_version_injects_actor_attribution():
     assert result["success"] is True
     mutation_input = client.execute.call_args_list[1][0][1]["input"]
     assert mutation_input["createdByUserId"] == "user-123"
-    assert mutation_input["metadata"]["attribution"]["actorType"] == "agent"
+    metadata = mutation_input["metadata"]
+    if isinstance(metadata, str):
+        metadata = json.loads(metadata)
+    assert metadata["attribution"]["actorType"] == "agent"

--- a/plexus/dashboard/api/models/score.py
+++ b/plexus/dashboard/api/models/score.py
@@ -8,6 +8,7 @@ Represents a scoring method within a scorecard section, tracking:
 - Version history
 """
 
+import json
 import logging
 import yaml
 from typing import Optional, Dict, Any, List, TYPE_CHECKING
@@ -1028,6 +1029,8 @@ class Score(BaseModel):
                 client_context=getattr(self._client, "context", None),
                 source="agent",
             )
+            if isinstance(version_input.get("metadata"), dict):
+                version_input["metadata"] = json.dumps(version_input["metadata"], default=str)
             
             result = self._client.execute(mutation, {'input': version_input})
             

--- a/plexus/rca_analysis.py
+++ b/plexus/rca_analysis.py
@@ -7,6 +7,7 @@ and the on-demand plexus_score_result_investigate MCP tool.
 """
 import json
 import logging
+import os
 import re
 from collections import Counter
 from datetime import datetime
@@ -20,6 +21,30 @@ logger = logging.getLogger(__name__)
 RCA_OPENAI_MODEL = "gpt-5-mini"
 RCA_OPENAI_REASONING_EFFORT = "low"
 RCA_MIN_OUTPUT_TOKENS = 1000
+RCA_LLM_TIMEOUT_SECONDS = 60
+
+
+def _rca_llm_timeout_seconds() -> float:
+    value = os.getenv("PLEXUS_RCA_LLM_TIMEOUT_SECONDS", "").strip()
+    if not value:
+        return float(RCA_LLM_TIMEOUT_SECONDS)
+    try:
+        timeout = float(value)
+    except ValueError:
+        logger.warning(
+            "Invalid PLEXUS_RCA_LLM_TIMEOUT_SECONDS=%r; using default %ss",
+            value,
+            RCA_LLM_TIMEOUT_SECONDS,
+        )
+        return float(RCA_LLM_TIMEOUT_SECONDS)
+    if timeout <= 0:
+        logger.warning(
+            "Invalid non-positive PLEXUS_RCA_LLM_TIMEOUT_SECONDS=%r; using default %ss",
+            value,
+            RCA_LLM_TIMEOUT_SECONDS,
+        )
+        return float(RCA_LLM_TIMEOUT_SECONDS)
+    return timeout
 
 
 def _invoke_rca_openai_text(
@@ -35,7 +60,7 @@ def _invoke_rca_openai_text(
     from plexus.cli.procedure.logging_utils import capture_llm_context_for_agent
 
     load_dotenv(override=False)
-    client = OpenAI()
+    client = OpenAI(timeout=_rca_llm_timeout_seconds(), max_retries=1)
     current_messages = list(messages)
     last_empty = False
     for attempt in range(2):

--- a/plexus/rca_analysis_test.py
+++ b/plexus/rca_analysis_test.py
@@ -708,6 +708,7 @@ def test_explainer_compacts_wordy_rationale(monkeypatch):
 
 def test_invoke_rca_openai_text_captures_context(tmp_path, monkeypatch):
     calls = []
+    client_kwargs = []
 
     class FakeResponses:
         def create(self, **kwargs):
@@ -715,7 +716,8 @@ def test_invoke_rca_openai_text_captures_context(tmp_path, monkeypatch):
             return types.SimpleNamespace(output_text="ok")
 
     class FakeOpenAI:
-        def __init__(self):
+        def __init__(self, **kwargs):
+            client_kwargs.append(kwargs)
             self.responses = FakeResponses()
 
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=FakeOpenAI))
@@ -729,6 +731,7 @@ def test_invoke_rca_openai_text_captures_context(tmp_path, monkeypatch):
     )
 
     assert result == "ok"
+    assert client_kwargs == [{"timeout": 60.0, "max_retries": 1}]
     assert calls[0]["reasoning"] == {"effort": "low"}
     assert calls[0]["max_output_tokens"] == 1000
     json_files = list(tmp_path.glob("*.json"))
@@ -749,7 +752,7 @@ def test_invoke_rca_openai_text_retries_empty_response(tmp_path, monkeypatch):
             return types.SimpleNamespace(output_text=outputs.pop(0))
 
     class FakeOpenAI:
-        def __init__(self):
+        def __init__(self, **_kwargs):
             self.responses = FakeResponses()
 
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=FakeOpenAI))

--- a/project/events/2026-05-06T03:53:38.547Z__df3d3bb0-8e7e-4d58-bf3e-9c2ede5cfed8.json
+++ b/project/events/2026-05-06T03:53:38.547Z__df3d3bb0-8e7e-4d58-bf3e-9c2ede5cfed8.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "df3d3bb0-8e7e-4d58-bf3e-9c2ede5cfed8",
+  "issue_id": "plx-4d5585f0-0eba-46e4-bf8a-7f5a49ef3647",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-06T03:53:38.547Z",
+  "actor_id": "ryan",
+  "payload": {
+    "assignee": null,
+    "description": "Optimizer procedure candidate submission fails in ScoreEditorToolset with apply_actor_attribution undefined when creating ScoreVersion through _default_score_update. Fix the score update path and rerun SelectQuote HCS Medium-Risk / Medication Review: Dosage optimizer smoke.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": null,
+    "priority": 0,
+    "status": "open",
+    "title": "Fix optimizer score version attribution import"
+  }
+}

--- a/project/events/2026-05-06T03:53:43.101Z__456f54c9-1796-4802-95d3-757a8b139bc5.json
+++ b/project/events/2026-05-06T03:53:43.101Z__456f54c9-1796-4802-95d3-757a8b139bc5.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "456f54c9-1796-4802-95d3-757a8b139bc5",
+  "issue_id": "plx-4d5585f0-0eba-46e4-bf8a-7f5a49ef3647",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T03:53:43.101Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-06T05:10:09.916Z__3ba8c315-86bd-47b0-b328-94cf035f29ac.json
+++ b/project/events/2026-05-06T05:10:09.916Z__3ba8c315-86bd-47b0-b328-94cf035f29ac.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3ba8c315-86bd-47b0-b328-94cf035f29ac",
+  "issue_id": "plx-4d5585f0-0eba-46e4-bf8a-7f5a49ef3647",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-06T05:10:09.916Z",
+  "actor_id": "ryan",
+  "payload": {
+    "comment_author": "ryan",
+    "comment_id": "81c0e8cb-22b8-4145-bc3e-228bab3d0e99"
+  }
+}

--- a/project/events/2026-05-06T05:10:09.930Z__6ec627d6-bbaa-42e1-8902-b2ee8627b479.json
+++ b/project/events/2026-05-06T05:10:09.930Z__6ec627d6-bbaa-42e1-8902-b2ee8627b479.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6ec627d6-bbaa-42e1-8902-b2ee8627b479",
+  "issue_id": "plx-4d5585f0-0eba-46e4-bf8a-7f5a49ef3647",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-06T05:10:09.930Z",
+  "actor_id": "ryan",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-4d5585f0-0eba-46e4-bf8a-7f5a49ef3647.json
+++ b/project/issues/plx-4d5585f0-0eba-46e4-bf8a-7f5a49ef3647.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-4d5585f0-0eba-46e4-bf8a-7f5a49ef3647",
+  "title": "Fix optimizer score version attribution import",
+  "description": "Optimizer procedure candidate submission fails in ScoreEditorToolset with apply_actor_attribution undefined when creating ScoreVersion through _default_score_update. Fix the score update path and rerun SelectQuote HCS Medium-Risk / Medication Review: Dosage optimizer smoke.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 0,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "81c0e8cb-22b8-4145-bc3e-228bab3d0e99",
+      "author": "ryan",
+      "text": "Optimizer smoke completed successfully for SelectQuote HCS Medium-Risk / Medication Review: Dosage (365 days, max_cycles=1, max_samples=100). Fixed ScoreVersion attribution metadata serialization and added RCA LLM client timeouts after observing an unbounded network wait in feedback RCA finalization. Verified Procedure 18bf53ce-128e-4767-b508-67ec3fae24a1 and Task 3b3cc20c-9b62-4a2e-b985-b3a99a02f063 completed; all created Evaluation records are COMPLETED and tagged with createdByUserId d8a1d300-b011-70e4-f87b-08fd516a1f74.",
+      "created_at": "2026-05-06T05:10:09.915800Z"
+    }
+  ],
+  "created_at": "2026-05-06T03:53:38.546122Z",
+  "updated_at": "2026-05-06T05:10:09.930810Z",
+  "closed_at": "2026-05-06T05:10:09.930810Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- serialize actor-attribution metadata before ScoreVersion create mutations in execute_tactus, score push, score chat, and PlexusTool paths
- preserve the Kanbus artifacts for the optimizer score-version attribution bug
- add RCA LLM timeout guards observed during attribution smoke verification

## Tests
- `python -m pytest MCP/tools/tactus_runtime/execute_test.py -k default_score_update_applies_actor_attribution -q`
- `python -m pytest plexus/dashboard/api/models/attribution_create_test.py plexus/rca_analysis_test.py -k 'invoke_rca_openai_text or score_create_version' -q`