### PR TITLE
fix(cli): register score pull on scores command group

### DIFF
--- a/plexus/cli/score/scores.py
+++ b/plexus/cli/score/scores.py
@@ -1016,7 +1016,7 @@ def optimize(scorecard: str, score: str, output: Optional[str], model: str, debu
 
 score.add_command(optimize)
 
-@score.command()
+@scores.command()
 @click.option('--scorecard', required=True, help='Scorecard containing the score (accepts ID, name, key, or external ID)')
 @click.option('--score', required=False, help='Score to pull (accepts ID, name, key, or external ID). If not specified, pulls all scores in the scorecard.')
 @click.option('--use-cache', is_flag=True, help='Use cached file if available (default: always fetch fresh from API)')

--- a/project/events/2026-05-13T19:19:56.888Z__dc5381bc-7053-4d56-95a5-032c53274369.json
+++ b/project/events/2026-05-13T19:19:56.888Z__dc5381bc-7053-4d56-95a5-032c53274369.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "dc5381bc-7053-4d56-95a5-032c53274369",
+  "issue_id": "plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-13T19:19:56.888Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "## Problem\n`plexus score pull` is not registered on the correct Click group in `plexus/cli/score/scores.py`.\n\nThe decorator is currently:\n- `@score.command()`\n\nbut the module registers commands on the `scores` group (e.g., `@scores.command()`). This prevents expected pull command behavior/discovery.\n\n## Expected\n- `pull` is registered with the same group as other score subcommands.\n- `plexus score pull ...` is available and routes to the pull handler.\n\n## Scope\n- Update the command decorator to register `pull` on `scores`.\n- Validate CLI command availability locally.\n\n## Definition of Done\n- Decorator uses `@scores.command()`.\n- Local validation confirms `pull` appears in score CLI commands.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-a097a1b9-7d32-4d78-96fe-8a9aad61e097",
+    "priority": 2,
+    "status": "open",
+    "title": "Fix score pull command registration in score CLI group"
+  }
+}

--- a/project/events/2026-05-13T19:19:59.085Z__87917b91-782a-4f6b-afc2-5135e4549409.json
+++ b/project/events/2026-05-13T19:19:59.085Z__87917b91-782a-4f6b-afc2-5135e4549409.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "87917b91-782a-4f6b-afc2-5135e4549409",
+  "issue_id": "plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-13T19:19:59.085Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-13T19:19:59.105Z__3412874c-9679-46bb-9e30-2dcac80806a1.json
+++ b/project/events/2026-05-13T19:19:59.105Z__3412874c-9679-46bb-9e30-2dcac80806a1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3412874c-9679-46bb-9e30-2dcac80806a1",
+  "issue_id": "plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-13T19:19:59.105Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "bd2ca5bc-5609-4f15-bcbf-1d9927b41763"
+  }
+}

--- a/project/events/2026-05-13T19:20:02.154Z__10f204e1-b916-487b-b79b-6defeba7b088.json
+++ b/project/events/2026-05-13T19:20:02.154Z__10f204e1-b916-487b-b79b-6defeba7b088.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "10f204e1-b916-487b-b79b-6defeba7b088",
+  "issue_id": "plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-13T19:20:02.154Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "dd19ae72-e586-4563-962a-4c67d8c9f726"
+  }
+}

--- a/project/events/2026-05-13T19:20:27.333Z__0e575739-d054-40fe-8d31-97866af6eafb.json
+++ b/project/events/2026-05-13T19:20:27.333Z__0e575739-d054-40fe-8d31-97866af6eafb.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0e575739-d054-40fe-8d31-97866af6eafb",
+  "issue_id": "plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-13T19:20:27.333Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "e8bf489c-82fd-4435-b9ac-5913569a5874"
+  }
+}

--- a/project/events/2026-05-13T19:20:27.348Z__d287be07-bc2f-44b5-a20b-d122583c78ac.json
+++ b/project/events/2026-05-13T19:20:27.348Z__d287be07-bc2f-44b5-a20b-d122583c78ac.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d287be07-bc2f-44b5-a20b-d122583c78ac",
+  "issue_id": "plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-13T19:20:27.348Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556.json
+++ b/project/issues/plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556.json
@@ -1,0 +1,37 @@
+{
+  "id": "plx-83e2e59c-1c49-42d7-8b7a-78c14e8b7556",
+  "title": "Fix score pull command registration in score CLI group",
+  "description": "## Problem\n`plexus score pull` is not registered on the correct Click group in `plexus/cli/score/scores.py`.\n\nThe decorator is currently:\n- `@score.command()`\n\nbut the module registers commands on the `scores` group (e.g., `@scores.command()`). This prevents expected pull command behavior/discovery.\n\n## Expected\n- `pull` is registered with the same group as other score subcommands.\n- `plexus score pull ...` is available and routes to the pull handler.\n\n## Scope\n- Update the command decorator to register `pull` on `scores`.\n- Validate CLI command availability locally.\n\n## Definition of Done\n- Decorator uses `@scores.command()`.\n- Local validation confirms `pull` appears in score CLI commands.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 2,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-a097a1b9-7d32-4d78-96fe-8a9aad61e097",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "bd2ca5bc-5609-4f15-bcbf-1d9927b41763",
+      "author": "derek",
+      "text": "Starting fix. Confirmed current diff changes  to  for pull registration. Next: validate CLI command discovery and open PR.",
+      "created_at": "2026-05-13T19:19:59.105416811Z"
+    },
+    {
+      "id": "dd19ae72-e586-4563-962a-4c67d8c9f726",
+      "author": "derek",
+      "text": "Starting fix. Confirmed current local diff switches pull registration from `@score.command()` to `@scores.command()`.\n\nNext steps:\n- validate CLI command discovery locally\n- commit fix + Kanbus artifacts on a dedicated bugfix branch\n- push and open PR to `develop`",
+      "created_at": "2026-05-13T19:20:02.154040755Z"
+    },
+    {
+      "id": "e8bf489c-82fd-4435-b9ac-5913569a5874",
+      "author": "derek",
+      "text": "Implemented fix on branch `bugfix/score-pull-command-registration` by registering pull under `@scores.command()`.\n\nLocal validation:\n- `/home/derek/miniconda3/envs/py311/bin/python -m plexus.cli score --help`\n- Output now includes `pull` in score subcommands.",
+      "created_at": "2026-05-13T19:20:27.333030471Z"
+    }
+  ],
+  "created_at": "2026-05-13T19:19:56.888525582Z",
+  "updated_at": "2026-05-13T19:20:27.348813649Z",
+  "closed_at": "2026-05-13T19:20:27.348813649Z",
+  "custom": {}
+}


### PR DESCRIPTION
## Summary
- fix score pull registration in `plexus/cli/score/scores.py`
- change decorator from `@score.command()` to `@scores.command()` so `pull` is correctly attached to the score CLI group
- include Kanbus artifacts for `plx-83e2e5`

## Kanbus
- Closed: `plx-83e2e5` (Fix score pull command registration in score CLI group)

## Validation
- `/home/derek/miniconda3/envs/py311/bin/python -m plexus.cli score --help`
- Verified `pull` is listed under `score` commands
