### PR TITLE
feat(procedures): add scorecard retargeting and frontier runtime controls

### DIFF
--- a/MCP/tools/tactus_runtime/execute.py
+++ b/MCP/tools/tactus_runtime/execute.py
@@ -376,6 +376,7 @@ HELPER_BINDINGS: tuple[tuple[str, str, str], ...] = (
     ("model_frontier_plan", "model_frontier", "plan"),
     ("model_frontier_build_result_row", "model_frontier", "build_result_row"),
     ("model_frontier_finalize", "model_frontier", "finalize"),
+    ("scorecard_retarget_plan_score", "scorecard_retarget", "plan_score"),
     ("scorecards", "scorecards", "list"),
     ("scorecard", "scorecards", "info"),
     ("evaluate", "evaluation", "run"),
@@ -503,6 +504,7 @@ RUNTIME_METHOD_SPECS: dict[tuple[str, str], RuntimeMethodSpec] = {
     ("model_frontier", "plan"): _method_spec("_call_model_frontier", planning_allowed=True),
     ("model_frontier", "build_result_row"): _method_spec("_call_model_frontier", planning_allowed=True),
     ("model_frontier", "finalize"): _method_spec("_call_model_frontier", planning_allowed=False),
+    ("scorecard_retarget", "plan_score"): _method_spec("_call_scorecard_retarget", planning_allowed=True),
 }
 
 
@@ -6514,6 +6516,28 @@ class PlexusRuntimeModule:
             }
         finally:
             self._budget.record_after("model_frontier", method)
+
+    def _call_scorecard_retarget(
+        self, namespace: str, method: str, args: Any = None
+    ) -> Any:
+        if namespace != "scorecard_retarget" or method != "plan_score":
+            raise ValueError(
+                f"Unsupported Plexus runtime API: plexus.{namespace}.{method}"
+            )
+        self._budget.check_before("scorecard_retarget", method)
+        self._record_api_call("scorecard_retarget", method)
+        try:
+            parsed = _args(args)
+            from plexus.cli.procedure.scorecard_model_retarget import (
+                plan_score_retarget,
+            )
+
+            return plan_score_retarget(
+                yaml_content=parsed.get("yaml_content") or "",
+                target=parsed.get("target") or {},
+            )
+        finally:
+            self._budget.record_after("scorecard_retarget", method)
 
     def _call_report_read(
         self, namespace: str, method: str, args: Any = None

--- a/MCP/tools/tactus_runtime/test_scorecard_retarget_runtime.py
+++ b/MCP/tools/tactus_runtime/test_scorecard_retarget_runtime.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from . import execute
+
+pytestmark = pytest.mark.unit
+
+
+def test_scorecard_retarget_runtime_plans_single_score():
+    module = execute.PlexusRuntimeModule()
+
+    result = module.scorecard_retarget.plan_score(
+        {
+            "yaml_content": (
+                "name: Test\n"
+                "class: LangGraphScore\n"
+                "model_provider: ChatOpenAI\n"
+                "model_name: gpt-5-mini\n"
+                "base_model_name: gpt-5-mini\n"
+            ),
+            "target": {"model_name": "gpt-5.4-nano"},
+        }
+    )
+
+    assert result["changed"] is True
+    assert result["candidate"]["model_name"] == "gpt-5.4-nano"
+    assert module.api_calls == ["plexus.scorecard_retarget.plan_score"]
+
+
+def test_scorecard_retarget_is_listed_in_plexus_api_list():
+    module = execute.PlexusRuntimeModule()
+
+    catalog = module.api.list()
+
+    assert "plexus.scorecard_retarget" in catalog
+    assert "plan_score" in catalog["plexus.scorecard_retarget"]

--- a/plexus/cli/procedure/model_performance_frontier.py
+++ b/plexus/cli/procedure/model_performance_frontier.py
@@ -29,6 +29,7 @@ TACTUS_ROOT_RUNTIME_FIELDS = (
 
 TACTUS_CLASSIFY_FIELDS = (
     "temperature",
+    "max_tokens",
 )
 
 TACTUS_PROVIDER_ALIASES = {

--- a/plexus/cli/procedure/model_performance_frontier.py
+++ b/plexus/cli/procedure/model_performance_frontier.py
@@ -25,9 +25,6 @@ ROOT_MODEL_FIELDS = (
 TACTUS_ROOT_RUNTIME_FIELDS = (
     "reasoning_effort",
     "verbosity",
-)
-
-TACTUS_CLASSIFY_FIELDS = (
     "temperature",
     "max_tokens",
 )
@@ -252,37 +249,6 @@ def _replace_or_insert_tactus_default_model(code: str, model_id: str) -> str:
     return f'default_model "{model_id}"\n\n{code}'
 
 
-def _format_tactus_value(value: Any) -> str:
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return repr(value)
-    return json.dumps(str(value))
-
-
-def _replace_or_insert_classify_field(code: str, field: str, value: Any) -> str:
-    classify_pattern = re.compile(r'ClassifyProcedure\s*\{(?P<body>.*?)\n(?P<indent>[ \t]*)\}', flags=re.S)
-    match = classify_pattern.search(code)
-    if not match:
-        raise ValueError(f"TactusScore code must define ClassifyProcedure before setting {field!r}")
-    block = match.group(0)
-    value_text = _format_tactus_value(value)
-    field_pattern = re.compile(rf'(?m)^([ \t]*){re.escape(field)}\s*=\s*[^,\n]+,?')
-    if field_pattern.search(block):
-        updated_block = field_pattern.sub(
-            lambda field_match: f"{field_match.group(1)}{field} = {value_text},",
-            block,
-            count=1,
-        )
-        return code[: match.start()] + updated_block + code[match.end() :]
-
-    body = match.group("body")
-    non_empty_lines = [line for line in body.splitlines() if line.strip()]
-    indent = re.match(r"([ \t]*)", non_empty_lines[0]).group(1) if non_empty_lines else "  "
-    insert_at = match.start("body")
-    return code[:insert_at] + f"\n{indent}{field} = {value_text}," + code[insert_at:]
-
-
 def _apply_tactus_variant(
     candidate: MutableMapping[str, Any],
     model: Mapping[str, Any],
@@ -296,14 +262,6 @@ def _apply_tactus_variant(
     for field in TACTUS_ROOT_RUNTIME_FIELDS:
         if field in parameter_set and parameter_set[field] is not None:
             candidate[field] = parameter_set[field]
-
-    for field in TACTUS_CLASSIFY_FIELDS:
-        if field in parameter_set and parameter_set[field] is not None:
-            candidate["code"] = _replace_or_insert_classify_field(
-                candidate.get("code") or "",
-                field,
-                parameter_set[field],
-            )
 
 
 def build_variants(

--- a/plexus/cli/procedure/scorecard_model_retarget.py
+++ b/plexus/cli/procedure/scorecard_model_retarget.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from plexus.cli.procedure.model_performance_frontier import (
+    _extract_fields,
+    _load_yaml,
+    build_variants,
+)
+
+
+SUPPORTED_SCORE_CLASSES = {"LangGraphScore", "TactusScore"}
+
+
+def _target_value(target: Mapping[str, Any], key: str) -> Any:
+    value = target.get(key)
+    return value if value not in ("", None) else None
+
+
+def plan_score_retarget(
+    *,
+    yaml_content: str,
+    target: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Plan a single score model retarget using frontier variant generation."""
+
+    if not isinstance(target, Mapping):
+        raise ValueError("target must be an object")
+
+    model_name = _target_value(target, "model_name")
+    if not model_name:
+        raise ValueError("target.model_name is required")
+
+    parsed = _load_yaml(yaml_content)
+    if not isinstance(parsed, Mapping):
+        raise ValueError("Score YAML must parse to a mapping")
+
+    score_class = str(parsed.get("class") or "")
+    if score_class not in SUPPORTED_SCORE_CLASSES:
+        raise ValueError(
+            f"Unsupported score class {score_class!r}; supported classes are "
+            "LangGraphScore and TactusScore."
+        )
+
+    if score_class == "TactusScore":
+        if _target_value(target, "max_tokens") is not None:
+            raise ValueError("max_tokens is not supported for TactusScore retargeting")
+        model_provider = (
+            _target_value(target, "tactus_model_provider")
+            or _target_value(target, "model_provider")
+            or "openai"
+        )
+    else:
+        current_fields = _extract_fields(parsed)
+        model_provider = (
+            _target_value(target, "langgraph_model_provider")
+            or _target_value(target, "model_provider")
+            or current_fields.get("model_provider")
+            or "ChatOpenAI"
+        )
+
+    parameter_set: dict[str, Any] = {"label": "target"}
+    for key in ("reasoning_effort", "verbosity", "temperature", "max_tokens"):
+        value = _target_value(target, key)
+        if value is not None:
+            parameter_set[key] = value
+    if isinstance(target.get("extra_overrides"), Mapping):
+        parameter_set["extra_overrides"] = dict(target["extra_overrides"])
+
+    plan = build_variants(
+        yaml_content,
+        {
+            "include_current": True,
+            "models": [
+                {
+                    "label": str(model_name),
+                    "model_provider": model_provider,
+                    "model_name": model_name,
+                }
+            ],
+            "parameter_sets": [parameter_set],
+        },
+    )
+    changed_variants = [variant for variant in plan if not variant.get("is_current")]
+    current = next((variant for variant in plan if variant.get("is_current")), None)
+
+    if not changed_variants:
+        return {
+            "changed": False,
+            "score_class": score_class,
+            "current": current,
+            "target": dict(target),
+            "message": "Score already matches target model configuration.",
+        }
+
+    candidate = changed_variants[0]
+    return {
+        "changed": True,
+        "score_class": score_class,
+        "current": current,
+        "target": dict(target),
+        "candidate": candidate,
+        "yaml_content": candidate["yaml_content"],
+        "message": "Retargeted score YAML planned.",
+    }

--- a/plexus/cli/procedure/scorecard_model_retarget.py
+++ b/plexus/cli/procedure/scorecard_model_retarget.py
@@ -43,8 +43,6 @@ def plan_score_retarget(
         )
 
     if score_class == "TactusScore":
-        if _target_value(target, "max_tokens") is not None:
-            raise ValueError("max_tokens is not supported for TactusScore retargeting")
         model_provider = (
             _target_value(target, "tactus_model_provider")
             or _target_value(target, "model_provider")

--- a/plexus/cli/procedure/test_model_performance_frontier.py
+++ b/plexus/cli/procedure/test_model_performance_frontier.py
@@ -139,14 +139,43 @@ def test_build_variants_supports_tactus_score_default_model_and_runtime_controls
     generated = yaml.safe_load(variants[0]["yaml_content"])
     assert generated["class"] == "TactusScore"
     assert 'default_model "openai/gpt-5.4-mini"' in generated["code"]
-    assert "temperature = 0," in generated["code"]
-    assert "max_tokens = 1200," in generated["code"]
     assert generated["reasoning_effort"] == "high"
     assert generated["verbosity"] == "medium"
+    assert generated["temperature"] == 0
+    assert generated["max_tokens"] == 1200
+    assert "temperature = 0," not in generated["code"]
+    assert "max_tokens = 1200," not in generated["code"]
     assert "model_provider" not in generated
     assert "model_name" not in generated
     assert variants[0]["model_provider"] == "openai"
     assert variants[0]["model_name"] == "gpt-5.4-mini"
+
+
+def test_build_variants_preserves_tactus_classifyprocedure_local_controls():
+    yaml_content = TACTUS_SCORE_YAML.replace(
+        "    user_message = [[{{ text }}]]",
+        "    user_message = [[{{ text }}]],\n    max_tokens = 600,\n    verbosity = \"low\"",
+    )
+    variants = build_variants(
+        yaml_content,
+        {
+            "models": [{"label": "mini", "model_provider": "openai", "model_name": "gpt-5.4-mini"}],
+            "parameter_sets": [
+                {
+                    "label": "root-defaults",
+                    "verbosity": "medium",
+                    "max_tokens": 1200,
+                }
+            ],
+        },
+        include_current=False,
+    )
+
+    generated = yaml.safe_load(variants[0]["yaml_content"])
+    assert generated["verbosity"] == "medium"
+    assert generated["max_tokens"] == 1200
+    assert "max_tokens = 600," in generated["code"]
+    assert 'verbosity = "low"' in generated["code"]
 
 
 def test_build_variants_extracts_current_tactus_score_model_from_code():

--- a/plexus/cli/procedure/test_model_performance_frontier.py
+++ b/plexus/cli/procedure/test_model_performance_frontier.py
@@ -129,6 +129,7 @@ def test_build_variants_supports_tactus_score_default_model_and_runtime_controls
                     "reasoning_effort": "high",
                     "verbosity": "medium",
                     "temperature": 0,
+                    "max_tokens": 1200,
                 }
             ],
         },
@@ -139,6 +140,7 @@ def test_build_variants_supports_tactus_score_default_model_and_runtime_controls
     assert generated["class"] == "TactusScore"
     assert 'default_model "openai/gpt-5.4-mini"' in generated["code"]
     assert "temperature = 0," in generated["code"]
+    assert "max_tokens = 1200," in generated["code"]
     assert generated["reasoning_effort"] == "high"
     assert generated["verbosity"] == "medium"
     assert "model_provider" not in generated

--- a/plexus/cli/procedure/test_scorecard_model_retarget.py
+++ b/plexus/cli/procedure/test_scorecard_model_retarget.py
@@ -77,9 +77,10 @@ def test_plan_score_retarget_updates_tactus_default_model_and_runtime_controls()
     assert plan["changed"] is True
     assert plan["score_class"] == "TactusScore"
     assert 'default_model "openai/gpt-5.4-mini"' in generated["code"]
-    assert "max_tokens = 1000," in generated["code"]
     assert generated["reasoning_effort"] == "medium"
     assert generated["verbosity"] == "medium"
+    assert generated["max_tokens"] == 1000
+    assert "max_tokens = 1000," not in generated["code"]
     assert "model_provider" not in generated
     assert "model_name" not in generated
 
@@ -111,7 +112,7 @@ def test_scorecard_model_retarget_procedure_declares_contract_and_behavior():
     assert config["params"]["dry_run"]["default"] is True
     assert config["params"]["langgraph_model_provider"]["default"] == "ChatOpenAI"
     assert config["params"]["tactus_model_provider"]["default"] == "openai"
-    assert "ClassifyProcedure" in config["params"]["max_tokens"]["description"]
+    assert "TactusScore root runtime default" in config["params"]["max_tokens"]["description"]
     assert config["outputs"]["created_count"]["type"] == "number"
     assert config["outputs"]["skipped_count"]["type"] == "number"
     assert config["agents"]["placeholder"]["initial_message"] == "Ready."

--- a/plexus/cli/procedure/test_scorecard_model_retarget.py
+++ b/plexus/cli/procedure/test_scorecard_model_retarget.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+
+import pytest
+
+from plexus.cli.procedure.scorecard_model_retarget import plan_score_retarget
+
+
+PROCEDURE_PATH = Path(__file__).resolve().parents[2] / "procedures" / "scorecard_model_retarget.yaml"
+
+
+LANGGRAPH_SCORE_YAML = """\
+name: Test Score
+class: LangGraphScore
+model_provider: ChatOpenAI
+model_name: gpt-5-mini
+base_model_name: gpt-5-mini
+reasoning_effort: low
+verbosity: low
+max_tokens: 1200
+"""
+
+
+TACTUS_SCORE_YAML = """\
+name: Acknowledges Before Redirecting
+class: TactusScore
+valid_classes:
+  - Yes
+  - No
+code: |-
+  default_model "openai/gpt-5.4-nano"
+
+  ClassifyProcedure {
+    classes = {"Yes", "No"},
+    system_message = [[Classify the text.]],
+    user_message = [[{{ text }}]]
+  }
+"""
+
+
+def test_plan_score_retarget_updates_langgraph_root_model_fields():
+    plan = plan_score_retarget(
+        yaml_content=LANGGRAPH_SCORE_YAML,
+        target={
+            "model_name": "gpt-5.4-nano",
+            "reasoning_effort": "medium",
+            "verbosity": "medium",
+            "max_tokens": 2000,
+        },
+    )
+
+    generated = yaml.safe_load(plan["yaml_content"])
+    assert plan["changed"] is True
+    assert plan["score_class"] == "LangGraphScore"
+    assert generated["model_provider"] == "ChatOpenAI"
+    assert generated["model_name"] == "gpt-5.4-nano"
+    assert generated["base_model_name"] == "gpt-5.4-nano"
+    assert generated["reasoning_effort"] == "medium"
+    assert generated["verbosity"] == "medium"
+    assert generated["max_tokens"] == 2000
+
+
+def test_plan_score_retarget_updates_tactus_default_model_and_runtime_controls():
+    plan = plan_score_retarget(
+        yaml_content=TACTUS_SCORE_YAML,
+        target={
+            "model_name": "gpt-5.4-mini",
+            "reasoning_effort": "medium",
+            "verbosity": "medium",
+        },
+    )
+
+    generated = yaml.safe_load(plan["yaml_content"])
+    assert plan["changed"] is True
+    assert plan["score_class"] == "TactusScore"
+    assert 'default_model "openai/gpt-5.4-mini"' in generated["code"]
+    assert generated["reasoning_effort"] == "medium"
+    assert generated["verbosity"] == "medium"
+    assert "model_provider" not in generated
+    assert "model_name" not in generated
+
+
+def test_plan_score_retarget_returns_unchanged_when_target_matches_current():
+    plan = plan_score_retarget(
+        yaml_content=TACTUS_SCORE_YAML,
+        target={"model_name": "gpt-5.4-nano"},
+    )
+
+    assert plan["changed"] is False
+    assert plan["message"] == "Score already matches target model configuration."
+
+
+def test_plan_score_retarget_fails_for_unsupported_classes():
+    with pytest.raises(ValueError, match="Unsupported score class"):
+        plan_score_retarget(
+            yaml_content="name: Unsupported\nclass: OtherScore\n",
+            target={"model_name": "gpt-5.4-nano"},
+        )
+
+
+def test_plan_score_retarget_rejects_tactus_max_tokens_until_runtime_support_exists():
+    with pytest.raises(ValueError, match="max_tokens is not supported"):
+        plan_score_retarget(
+            yaml_content=TACTUS_SCORE_YAML,
+            target={"model_name": "gpt-5.4-mini", "max_tokens": 1000},
+        )
+
+
+def test_scorecard_model_retarget_procedure_declares_contract_and_behavior():
+    config = yaml.safe_load(PROCEDURE_PATH.read_text(encoding="utf-8"))
+
+    assert config["name"] == "Scorecard Model Retarget"
+    assert config["params"]["scorecard"]["required"] is True
+    assert config["params"]["model_name"]["required"] is True
+    assert config["params"]["dry_run"]["default"] is True
+    assert config["params"]["langgraph_model_provider"]["default"] == "ChatOpenAI"
+    assert config["params"]["tactus_model_provider"]["default"] == "openai"
+    assert config["outputs"]["created_count"]["type"] == "number"
+    assert config["agents"]["placeholder"]["initial_message"] == "Ready."
+
+    code = config["code"]
+    assert "Feature: Scorecard model retargeting" in code
+    assert "plexus.scorecards.info" in code
+    assert "plexus.score.pull" in code
+    assert "plexus.scorecard_retarget.plan_score" in code
+    assert "plexus.score.update" in code
+    assert "plexus.score.set_champion" not in code
+    assert "dry_run=true so no ScoreVersions were created" in code

--- a/plexus/cli/procedure/test_scorecard_model_retarget.py
+++ b/plexus/cli/procedure/test_scorecard_model_retarget.py
@@ -131,4 +131,7 @@ def test_scorecard_model_retarget_procedure_declares_contract_and_behavior():
     assert 'status = "skipped"' in code
     assert 'skip_reason = "missing_champion"' in code
     assert "skipped_count = skipped" in code
+    assert "guidelines_by_score" in code
+    assert "guidelines = guidelines_by_score[row.score_id] or \"\"" in code
+    assert "guidelines_preserved = true" in code
     assert "dry_run=true so no ScoreVersions were created" in code

--- a/plexus/cli/procedure/test_scorecard_model_retarget.py
+++ b/plexus/cli/procedure/test_scorecard_model_retarget.py
@@ -118,6 +118,7 @@ def test_scorecard_model_retarget_procedure_declares_contract_and_behavior():
     assert config["params"]["langgraph_model_provider"]["default"] == "ChatOpenAI"
     assert config["params"]["tactus_model_provider"]["default"] == "openai"
     assert config["outputs"]["created_count"]["type"] == "number"
+    assert config["outputs"]["skipped_count"]["type"] == "number"
     assert config["agents"]["placeholder"]["initial_message"] == "Ready."
 
     code = config["code"]
@@ -127,4 +128,7 @@ def test_scorecard_model_retarget_procedure_declares_contract_and_behavior():
     assert "plexus.scorecard_retarget.plan_score" in code
     assert "plexus.score.update" in code
     assert "plexus.score.set_champion" not in code
+    assert 'status = "skipped"' in code
+    assert 'skip_reason = "missing_champion"' in code
+    assert "skipped_count = skipped" in code
     assert "dry_run=true so no ScoreVersions were created" in code

--- a/plexus/cli/procedure/test_scorecard_model_retarget.py
+++ b/plexus/cli/procedure/test_scorecard_model_retarget.py
@@ -69,6 +69,7 @@ def test_plan_score_retarget_updates_tactus_default_model_and_runtime_controls()
             "model_name": "gpt-5.4-mini",
             "reasoning_effort": "medium",
             "verbosity": "medium",
+            "max_tokens": 1000,
         },
     )
 
@@ -76,6 +77,7 @@ def test_plan_score_retarget_updates_tactus_default_model_and_runtime_controls()
     assert plan["changed"] is True
     assert plan["score_class"] == "TactusScore"
     assert 'default_model "openai/gpt-5.4-mini"' in generated["code"]
+    assert "max_tokens = 1000," in generated["code"]
     assert generated["reasoning_effort"] == "medium"
     assert generated["verbosity"] == "medium"
     assert "model_provider" not in generated
@@ -100,14 +102,6 @@ def test_plan_score_retarget_fails_for_unsupported_classes():
         )
 
 
-def test_plan_score_retarget_rejects_tactus_max_tokens_until_runtime_support_exists():
-    with pytest.raises(ValueError, match="max_tokens is not supported"):
-        plan_score_retarget(
-            yaml_content=TACTUS_SCORE_YAML,
-            target={"model_name": "gpt-5.4-mini", "max_tokens": 1000},
-        )
-
-
 def test_scorecard_model_retarget_procedure_declares_contract_and_behavior():
     config = yaml.safe_load(PROCEDURE_PATH.read_text(encoding="utf-8"))
 
@@ -117,6 +111,7 @@ def test_scorecard_model_retarget_procedure_declares_contract_and_behavior():
     assert config["params"]["dry_run"]["default"] is True
     assert config["params"]["langgraph_model_provider"]["default"] == "ChatOpenAI"
     assert config["params"]["tactus_model_provider"]["default"] == "openai"
+    assert "ClassifyProcedure" in config["params"]["max_tokens"]["description"]
     assert config["outputs"]["created_count"]["type"] == "number"
     assert config["outputs"]["skipped_count"]["type"] == "number"
     assert config["agents"]["placeholder"]["initial_message"] == "Ready."

--- a/plexus/procedures/README.md
+++ b/plexus/procedures/README.md
@@ -156,6 +156,32 @@ For `TactusScore` scores using `ClassifyProcedure`, pass the Tactus provider
 name such as `openai`; the procedure rewrites `default_model "openai/<model>"`
 inside `code` and forwards `reasoning_effort`/`verbosity` through the score root.
 
+### 6. scorecard_model_retarget.yaml - Bulk Model Version Creation
+
+**Purpose**: Creates non-champion model-retargeted ScoreVersions for selected
+scores on a scorecard. This is for rollout preparation when there is no ground
+truth for a cost/accuracy frontier comparison.
+
+**What it demonstrates**:
+- Scorecard-wide score iteration
+- Class-aware model retargeting using the shared frontier YAML mutation helpers
+- Dry-run planning by default
+- Non-champion ScoreVersion creation with champion parent versions
+- Include/exclude filters for controlled rollout batches
+
+**How to run**:
+```bash
+plexus procedure run --yaml plexus/procedures/scorecard_model_retarget.yaml \
+  -s scorecard="<scorecard name>" \
+  -s model_name="gpt-5.4-nano" \
+  -s reasoning_effort="medium" \
+  -s verbosity="medium" \
+  -s dry_run=true
+```
+
+Set `dry_run=false` to create the new ScoreVersions. The procedure never
+promotes candidates to champion.
+
 ## Directory Structure
 
 ```

--- a/plexus/procedures/model_performance_frontier.yaml
+++ b/plexus/procedures/model_performance_frontier.yaml
@@ -18,7 +18,7 @@ params:
   candidate_matrix:
     type: object
     required: true
-    description: "Structured model/parameter matrix. Shape: {include_current=true, models=[{label, model_provider, model_name, base_model_name?}], parameter_sets=[{label, reasoning_effort?, verbosity?, temperature?, max_tokens?, extra_overrides?}]}. LangGraphScore variants update root model fields. TactusScore variants update the embedded default_model directive, put reasoning_effort/verbosity on the score root for TactusRuntime, and apply temperature/max_tokens inside ClassifyProcedure. If base_model_name exists in a LangGraphScore and a candidate sets model_name without base_model_name, base_model_name is updated to match model_name."
+    description: "Structured model/parameter matrix. Shape: {include_current=true, models=[{label, model_provider, model_name, base_model_name?}], parameter_sets=[{label, reasoning_effort?, verbosity?, temperature?, max_tokens?, extra_overrides?}]}. LangGraphScore variants update root model fields. TactusScore variants update the embedded default_model directive and write reasoning_effort, verbosity, temperature, and max_tokens as score-root TactusRuntime defaults. Local ClassifyProcedure/model overrides are changed only through explicit extra_overrides. If base_model_name exists in a LangGraphScore and a candidate sets model_name without base_model_name, base_model_name is updated to match model_name."
 
   days:
     type: number

--- a/plexus/procedures/model_performance_frontier.yaml
+++ b/plexus/procedures/model_performance_frontier.yaml
@@ -18,7 +18,7 @@ params:
   candidate_matrix:
     type: object
     required: true
-    description: "Structured model/parameter matrix. Shape: {include_current=true, models=[{label, model_provider, model_name, base_model_name?}], parameter_sets=[{label, reasoning_effort?, verbosity?, temperature?, max_tokens?, extra_overrides?}]}. LangGraphScore variants update root model fields. TactusScore variants update the embedded default_model directive, put reasoning_effort/verbosity on the score root for TactusRuntime, and apply temperature inside ClassifyProcedure. If base_model_name exists in a LangGraphScore and a candidate sets model_name without base_model_name, base_model_name is updated to match model_name."
+    description: "Structured model/parameter matrix. Shape: {include_current=true, models=[{label, model_provider, model_name, base_model_name?}], parameter_sets=[{label, reasoning_effort?, verbosity?, temperature?, max_tokens?, extra_overrides?}]}. LangGraphScore variants update root model fields. TactusScore variants update the embedded default_model directive, put reasoning_effort/verbosity on the score root for TactusRuntime, and apply temperature/max_tokens inside ClassifyProcedure. If base_model_name exists in a LangGraphScore and a candidate sets model_name without base_model_name, base_model_name is updated to match model_name."
 
   days:
     type: number

--- a/plexus/procedures/scorecard_model_retarget.yaml
+++ b/plexus/procedures/scorecard_model_retarget.yaml
@@ -134,6 +134,11 @@ code: |
   -- When I run the retarget procedure
   -- Then that score is marked skipped
   -- And the procedure continues with subsequent selected scores.
+  --
+  -- Scenario: Champion guidelines are preserved
+  -- Given a selected score champion version has guidelines
+  -- When I run the retarget procedure with dry_run=false
+  -- Then the created non-champion ScoreVersion preserves the champion guidelines exactly.
 
   local function has_text(value)
     return value ~= nil and tostring(value) ~= ""
@@ -227,6 +232,7 @@ code: |
   Stage.set("plan")
   local rows = {}
   local planned = {}
+  local guidelines_by_score = {}
   local skipped = 0
   local target = target_config()
   for _, score in ipairs(scores) do
@@ -280,10 +286,12 @@ code: |
         message = plan.message,
         current = plan.current,
         candidate = plan.candidate,
+        guidelines_preserved = true,
       }
       table.insert(rows, row)
       if plan.changed then
         row.yaml_content = plan.yaml_content
+        guidelines_by_score[row.score_id] = pull.guidelines or ""
         table.insert(planned, row)
       end
     end
@@ -334,6 +342,7 @@ code: |
       scorecard_identifier = params.scorecard,
       score_identifier = row.score_id,
       code = row.yaml_content,
+      guidelines = guidelines_by_score[row.score_id] or "",
       parent_version_id = row.champion_version_id,
       version_note = has_text(params.version_note)
         and params.version_note

--- a/plexus/procedures/scorecard_model_retarget.yaml
+++ b/plexus/procedures/scorecard_model_retarget.yaml
@@ -1,0 +1,361 @@
+name: Scorecard Model Retarget
+version: 1.0.0
+class: Tactus
+procedure_type: Scorecard Maintenance Procedure
+description: "Create non-champion ScoreVersions for selected scores on a scorecard using a new model configuration. This procedure does not evaluate, promote, or choose winners."
+
+params:
+  scorecard:
+    type: string
+    required: true
+    description: "Scorecard identifier (name, key, ID, or external ID)"
+
+  model_name:
+    type: string
+    required: true
+    description: "Target model name, for example gpt-5.4-nano"
+
+  model_provider:
+    type: string
+    required: false
+    description: "Optional provider applied to both supported classes. Prefer class-specific provider params for mixed scorecards."
+
+  langgraph_model_provider:
+    type: string
+    default: ChatOpenAI
+    required: false
+    description: "Provider value for LangGraphScore root model_provider"
+
+  tactus_model_provider:
+    type: string
+    default: openai
+    required: false
+    description: "Provider value for TactusScore default_model provider prefix"
+
+  reasoning_effort:
+    type: string
+    required: false
+    description: "Optional reasoning effort to apply where supported"
+
+  verbosity:
+    type: string
+    required: false
+    description: "Optional verbosity to apply where supported"
+
+  temperature:
+    type: number
+    required: false
+    description: "Optional temperature to apply where supported"
+
+  max_tokens:
+    type: number
+    required: false
+    description: "Optional max_tokens for LangGraphScore. TactusScore does not support max_tokens in this flow and will fail loudly."
+
+  include_scores:
+    type: array
+    required: false
+    description: "Optional allow-list of score IDs, names, keys, or external IDs"
+
+  exclude_scores:
+    type: array
+    required: false
+    description: "Optional deny-list of score IDs, names, keys, or external IDs"
+
+  dry_run:
+    type: boolean
+    default: true
+    description: "If true, plan only and create no ScoreVersions"
+
+  version_note:
+    type: string
+    required: false
+    description: "Note to attach to created ScoreVersions"
+
+outputs:
+  success:
+    type: boolean
+    required: true
+  status:
+    type: string
+    required: true
+  message:
+    type: string
+    required: true
+  scorecard_id:
+    type: string
+    required: false
+  planned_count:
+    type: number
+    required: false
+  changed_count:
+    type: number
+    required: false
+  created_count:
+    type: number
+    required: false
+  rows:
+    type: array
+    required: false
+
+agents:
+  placeholder:
+    system_prompt: |
+      This deterministic procedure does not use agent reasoning.
+    initial_message: "Ready."
+    tools: []
+
+code: |
+  -- Feature: Scorecard model retargeting
+  --
+  -- Scenario: Dry run previews changed score versions
+  -- Given a scorecard with LangGraphScore and TactusScore scores
+  -- When I run the retarget procedure with dry_run=true
+  -- Then it returns the planned YAML changes for each selected score
+  -- And it creates no ScoreVersions.
+  --
+  -- Scenario: Apply creates non-champion versions
+  -- Given selected scores whose champion YAML changes after retargeting
+  -- When I run the retarget procedure with dry_run=false
+  -- Then it creates one non-champion ScoreVersion per changed score
+  -- And each new version uses the champion version as parent
+  -- And no candidate is promoted to champion.
+  --
+  -- Scenario: Unsupported classes fail loudly
+  -- Given a selected score with an unsupported class
+  -- When I run the retarget procedure
+  -- Then the procedure fails with a clear unsupported class error unless that score is excluded.
+
+  local function has_text(value)
+    return value ~= nil and tostring(value) ~= ""
+  end
+
+  local function array_contains(values, score)
+    if type(values) ~= "table" then return false end
+    for _, value in ipairs(values) do
+      local needle = tostring(value)
+      if needle == tostring(score.id)
+        or needle == tostring(score.name)
+        or needle == tostring(score.key)
+        or needle == tostring(score.externalId) then
+        return true
+      end
+    end
+    return false
+  end
+
+  local function selected_score(score)
+    local include = params.include_scores
+    local exclude = params.exclude_scores
+    if type(include) == "table" and #include > 0 and not array_contains(include, score) then
+      return false
+    end
+    if type(exclude) == "table" and array_contains(exclude, score) then
+      return false
+    end
+    return true
+  end
+
+  local function score_sort_key(score)
+    return tostring(score.order or "") .. ":" .. tostring(score.name or "") .. ":" .. tostring(score.id or "")
+  end
+
+  local function flatten_scores(scorecard_info)
+    local rows = {}
+    local sections = ((scorecard_info or {}).sections or {}).items or {}
+    for _, section in ipairs(sections) do
+      local scores = ((section or {}).scores or {}).items or {}
+      for _, score in ipairs(scores) do
+        if selected_score(score) then
+          score.section_id = section.id
+          score.section_name = section.name
+          table.insert(rows, score)
+        end
+      end
+    end
+    table.sort(rows, function(a, b) return score_sort_key(a) < score_sort_key(b) end)
+    return rows
+  end
+
+  local function target_config()
+    local target = {
+      model_name = params.model_name,
+      model_provider = params.model_provider,
+      langgraph_model_provider = params.langgraph_model_provider,
+      tactus_model_provider = params.tactus_model_provider,
+      reasoning_effort = params.reasoning_effort,
+      verbosity = params.verbosity,
+      temperature = params.temperature,
+      max_tokens = params.max_tokens,
+    }
+    return target
+  end
+
+  if not has_text(params.scorecard) then
+    return {success = false, status = "error", message = "scorecard is required"}
+  end
+  if not has_text(params.model_name) then
+    return {success = false, status = "error", message = "model_name is required"}
+  end
+
+  Stage.set("setup")
+  Human.notify({message = "Resolving scorecard and planning model retarget...", level = "info"})
+
+  local scorecard_info = plexus.scorecards.info({scorecard_identifier = params.scorecard})
+  if not scorecard_info or not scorecard_info.additionalDetails then
+    return {success = false, status = "error", message = "Scorecard not found: " .. tostring(params.scorecard)}
+  end
+  local scorecard_id = scorecard_info.additionalDetails.id
+  local scores = flatten_scores(scorecard_info)
+  if #scores == 0 then
+    return {success = false, status = "error", message = "No selected scores found on scorecard.", scorecard_id = scorecard_id}
+  end
+
+  State.set("procedure_type", "Scorecard Model Retarget")
+  State.set("scorecard_id", scorecard_id)
+  State.set("scorecard_name", scorecard_info.name or params.scorecard)
+
+  Stage.set("plan")
+  local rows = {}
+  local planned = {}
+  local target = target_config()
+  for _, score in ipairs(scores) do
+    local pull = plexus.score.pull({
+      scorecard_identifier = params.scorecard,
+      score_identifier = score.id
+    })
+    if not pull or not pull.success then
+      return {
+        success = false,
+        status = "error",
+        message = "Failed to pull champion score YAML for " .. tostring(score.name),
+        scorecard_id = scorecard_id,
+        rows = rows,
+      }
+    end
+
+    local ok, plan = pcall(function()
+      return plexus.scorecard_retarget.plan_score({
+        yaml_content = pull.yaml_content or "",
+        target = target,
+      })
+    end)
+    if not ok then
+      return {
+        success = false,
+        status = "error",
+        message = "Failed to plan retarget for " .. tostring(score.name) .. ": " .. tostring(plan),
+        scorecard_id = scorecard_id,
+        rows = rows,
+      }
+    end
+
+    local row = {
+      score_id = score.id,
+      score_name = score.name,
+      score_key = score.key,
+      external_id = score.externalId,
+      section_name = score.section_name,
+      champion_version_id = pull.version_id,
+      score_class = plan.score_class,
+      changed = plan.changed == true,
+      status = plan.changed and "planned" or "unchanged",
+      message = plan.message,
+      current = plan.current,
+      candidate = plan.candidate,
+    }
+    table.insert(rows, row)
+    if plan.changed then
+      row.yaml_content = plan.yaml_content
+      table.insert(planned, row)
+    end
+  end
+
+  State.set("scorecard_model_retarget", {
+    status = params.dry_run and "dry_run" or "planned",
+    scorecard_id = scorecard_id,
+    planned_count = #rows,
+    changed_count = #planned,
+    rows = rows,
+  })
+
+  if #planned == 0 then
+    return {
+      success = true,
+      status = "no_changes",
+      message = "All selected scores already match the target model configuration.",
+      scorecard_id = scorecard_id,
+      planned_count = #rows,
+      changed_count = 0,
+      created_count = 0,
+      rows = rows,
+    }
+  end
+
+  if params.dry_run then
+    return {
+      success = true,
+      status = "dry_run",
+      message = "Planned " .. tostring(#planned) .. " score version(s); dry_run=true so no ScoreVersions were created.",
+      scorecard_id = scorecard_id,
+      planned_count = #rows,
+      changed_count = #planned,
+      created_count = 0,
+      rows = rows,
+    }
+  end
+
+  Stage.set("apply")
+  Human.notify({message = "Creating non-champion retargeted score versions...", level = "info"})
+  local created = 0
+  for _, row in ipairs(planned) do
+    local update = plexus.score.update({
+      scorecard_identifier = params.scorecard,
+      score_identifier = row.score_id,
+      code = row.yaml_content,
+      parent_version_id = row.champion_version_id,
+      version_note = has_text(params.version_note)
+        and params.version_note
+        or ("Retarget model to " .. tostring(params.model_name))
+    })
+    row.yaml_content = nil
+    if not update or update.success == false or not update.version_id then
+      row.status = "error"
+      row.error = tostring(update and update.error or "unknown")
+      return {
+        success = false,
+        status = "partial_failure",
+        message = "Failed to create ScoreVersion for " .. tostring(row.score_name) .. ": " .. tostring(row.error),
+        scorecard_id = scorecard_id,
+        planned_count = #rows,
+        changed_count = #planned,
+        created_count = created,
+        rows = rows,
+      }
+    end
+    created = created + 1
+    row.status = "created"
+    row.new_version_id = update.version_id
+    row.parent_version_id = update.parent_version_id or row.champion_version_id
+  end
+
+  Stage.set("complete")
+  State.set("scorecard_model_retarget", {
+    status = "completed",
+    scorecard_id = scorecard_id,
+    planned_count = #rows,
+    changed_count = #planned,
+    created_count = created,
+    rows = rows,
+  })
+
+  return {
+    success = true,
+    status = "completed",
+    message = "Created " .. tostring(created) .. " non-champion retargeted ScoreVersion(s).",
+    scorecard_id = scorecard_id,
+    planned_count = #rows,
+    changed_count = #planned,
+    created_count = created,
+    rows = rows,
+  }

--- a/plexus/procedures/scorecard_model_retarget.yaml
+++ b/plexus/procedures/scorecard_model_retarget.yaml
@@ -50,7 +50,7 @@ params:
   max_tokens:
     type: number
     required: false
-    description: "Optional max_tokens for LangGraphScore root config or TactusScore ClassifyProcedure config."
+    description: "Optional max_tokens for LangGraphScore root config or TactusScore root runtime default."
 
   include_scores:
     type: array

--- a/plexus/procedures/scorecard_model_retarget.yaml
+++ b/plexus/procedures/scorecard_model_retarget.yaml
@@ -50,7 +50,7 @@ params:
   max_tokens:
     type: number
     required: false
-    description: "Optional max_tokens for LangGraphScore. TactusScore does not support max_tokens in this flow and will fail loudly."
+    description: "Optional max_tokens for LangGraphScore root config or TactusScore ClassifyProcedure config."
 
   include_scores:
     type: array

--- a/plexus/procedures/scorecard_model_retarget.yaml
+++ b/plexus/procedures/scorecard_model_retarget.yaml
@@ -94,6 +94,9 @@ outputs:
   created_count:
     type: number
     required: false
+  skipped_count:
+    type: number
+    required: false
   rows:
     type: array
     required: false
@@ -125,6 +128,12 @@ code: |
   -- Given a selected score with an unsupported class
   -- When I run the retarget procedure
   -- Then the procedure fails with a clear unsupported class error unless that score is excluded.
+  --
+  -- Scenario: Missing champion versions are skipped
+  -- Given a selected score has no champion ScoreVersion
+  -- When I run the retarget procedure
+  -- Then that score is marked skipped
+  -- And the procedure continues with subsequent selected scores.
 
   local function has_text(value)
     return value ~= nil and tostring(value) ~= ""
@@ -218,56 +227,65 @@ code: |
   Stage.set("plan")
   local rows = {}
   local planned = {}
+  local skipped = 0
   local target = target_config()
   for _, score in ipairs(scores) do
-    local pull = plexus.score.pull({
-      scorecard_identifier = params.scorecard,
-      score_identifier = score.id
-    })
-    if not pull or not pull.success then
-      return {
-        success = false,
-        status = "error",
-        message = "Failed to pull champion score YAML for " .. tostring(score.name),
-        scorecard_id = scorecard_id,
-        rows = rows,
-      }
-    end
-
-    local ok, plan = pcall(function()
-      return plexus.scorecard_retarget.plan_score({
-        yaml_content = pull.yaml_content or "",
-        target = target,
+    local pull_ok, pull = pcall(function()
+      return plexus.score.pull({
+        scorecard_identifier = params.scorecard,
+        score_identifier = score.id
       })
     end)
-    if not ok then
-      return {
-        success = false,
-        status = "error",
-        message = "Failed to plan retarget for " .. tostring(score.name) .. ": " .. tostring(plan),
-        scorecard_id = scorecard_id,
-        rows = rows,
-      }
-    end
+    if not pull_ok or not pull or not pull.success then
+      skipped = skipped + 1
+      table.insert(rows, {
+        score_id = score.id,
+        score_name = score.name,
+        score_key = score.key,
+        external_id = score.externalId,
+        section_name = score.section_name,
+        changed = false,
+        status = "skipped",
+        skip_reason = "missing_champion",
+        error = tostring((pull_ok and pull and pull.error) or pull or "Failed to pull champion score YAML")
+      })
+    else
 
-    local row = {
-      score_id = score.id,
-      score_name = score.name,
-      score_key = score.key,
-      external_id = score.externalId,
-      section_name = score.section_name,
-      champion_version_id = pull.version_id,
-      score_class = plan.score_class,
-      changed = plan.changed == true,
-      status = plan.changed and "planned" or "unchanged",
-      message = plan.message,
-      current = plan.current,
-      candidate = plan.candidate,
-    }
-    table.insert(rows, row)
-    if plan.changed then
-      row.yaml_content = plan.yaml_content
-      table.insert(planned, row)
+      local ok, plan = pcall(function()
+        return plexus.scorecard_retarget.plan_score({
+          yaml_content = pull.yaml_content or "",
+          target = target,
+        })
+      end)
+      if not ok then
+        return {
+          success = false,
+          status = "error",
+          message = "Failed to plan retarget for " .. tostring(score.name) .. ": " .. tostring(plan),
+          scorecard_id = scorecard_id,
+          rows = rows,
+        }
+      end
+
+      local row = {
+        score_id = score.id,
+        score_name = score.name,
+        score_key = score.key,
+        external_id = score.externalId,
+        section_name = score.section_name,
+        champion_version_id = pull.version_id,
+        score_class = plan.score_class,
+        changed = plan.changed == true,
+        status = plan.changed and "planned" or "unchanged",
+        message = plan.message,
+        current = plan.current,
+        candidate = plan.candidate,
+      }
+      table.insert(rows, row)
+      if plan.changed then
+        row.yaml_content = plan.yaml_content
+        table.insert(planned, row)
+      end
     end
   end
 
@@ -276,6 +294,7 @@ code: |
     scorecard_id = scorecard_id,
     planned_count = #rows,
     changed_count = #planned,
+    skipped_count = skipped,
     rows = rows,
   })
 
@@ -288,6 +307,7 @@ code: |
       planned_count = #rows,
       changed_count = 0,
       created_count = 0,
+      skipped_count = skipped,
       rows = rows,
     }
   end
@@ -301,6 +321,7 @@ code: |
       planned_count = #rows,
       changed_count = #planned,
       created_count = 0,
+      skipped_count = skipped,
       rows = rows,
     }
   end
@@ -330,6 +351,7 @@ code: |
         planned_count = #rows,
         changed_count = #planned,
         created_count = created,
+        skipped_count = skipped,
         rows = rows,
       }
     end
@@ -346,6 +368,7 @@ code: |
     planned_count = #rows,
     changed_count = #planned,
     created_count = created,
+    skipped_count = skipped,
     rows = rows,
   })
 
@@ -357,5 +380,6 @@ code: |
     planned_count = #rows,
     changed_count = #planned,
     created_count = created,
+    skipped_count = skipped,
     rows = rows,
   }

--- a/plexus/scores/TactusScore.py
+++ b/plexus/scores/TactusScore.py
@@ -62,17 +62,17 @@ class TactusScore(Score):
         # Output mapping (optional - defaults to value/explanation)
         output: Optional[Dict[str, str]] = None
 
-        # Deprecated model fields are ignored by TactusScore execution.
-        # The model is specified inside the Lua code. These are kept so
-        # existing YAML configs parse without error during migration.
+        # Model identity is specified inside the Tactus code.
+        # These identity fields are kept so existing YAML configs parse.
         model_provider: Optional[str] = None
         model_name: Optional[str] = None
         base_model_name: Optional[str] = None
+
+        # Score-wide runtime defaults. Local Tactus Model/ClassifyProcedure
+        # config can still override these values.
         max_tokens: Optional[int] = None
         temperature: Optional[float] = None
         top_p: Optional[float] = None
-        # Runtime GPT-5 controls. These are forwarded to TactusRuntime so
-        # ClassifyProcedure's LLMModel path can apply them.
         reasoning_effort: Optional[str] = None
         verbosity: Optional[str] = None
         model_region: Optional[str] = None
@@ -116,6 +116,8 @@ class TactusScore(Score):
             openai_api_key=self._get_openai_api_key(),
             reasoning_effort=self.parameters.reasoning_effort,
             verbosity=self.parameters.verbosity,
+            max_tokens=self.parameters.max_tokens,
+            temperature=self.parameters.temperature,
         )
         logger.info(f"TactusScore initialized for '{self.parameters.name}'")
 
@@ -213,6 +215,8 @@ class TactusScore(Score):
             log_handler=log_handler,
             reasoning_effort=self.parameters.reasoning_effort,
             verbosity=self.parameters.verbosity,
+            max_tokens=self.parameters.max_tokens,
+            temperature=self.parameters.temperature,
         )
 
         try:

--- a/plexus/scores/test_tactus_score_runtime_controls.py
+++ b/plexus/scores/test_tactus_score_runtime_controls.py
@@ -26,6 +26,8 @@ async def test_tactus_score_passes_runtime_gpt5_controls_to_prediction_runtime(m
         valid_classes=["Yes", "No"],
         reasoning_effort="high",
         verbosity="medium",
+        max_tokens=1200,
+        temperature=0.0,
     )
 
     result = await score.predict(Score.Input(text="hello", metadata={}))
@@ -33,3 +35,5 @@ async def test_tactus_score_passes_runtime_gpt5_controls_to_prediction_runtime(m
     assert result.value == "Yes"
     assert captured["reasoning_effort"] == "high"
     assert captured["verbosity"] == "medium"
+    assert captured["max_tokens"] == 1200
+    assert captured["temperature"] == 0.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -9306,14 +9306,14 @@ py-cpuinfo = "*"
 
 [[package]]
 name = "tactus"
-version = "0.49.0"
+version = "0.50.0"
 description = "Tactus: Lua-based DSL for agentic workflows"
 optional = false
 python-versions = "<3.14,>=3.10"
 groups = ["main"]
 files = [
-    {file = "tactus-0.49.0-py3-none-any.whl", hash = "sha256:ccbf0900329d37e257b25c12963880d0adf578b392a972da119e8730c5470e54"},
-    {file = "tactus-0.49.0.tar.gz", hash = "sha256:c0a5d44cd5a018e6364c384a6537eead61970557d680e5c56aad15997422d156"},
+    {file = "tactus-0.50.0-py3-none-any.whl", hash = "sha256:1138b0077a969c9691fa31949ed0f17764754681f917cbad44c072939083855b"},
+    {file = "tactus-0.50.0.tar.gz", hash = "sha256:f61050f1109feed7427f3cd9fd9aac3e02fb9a1d27161cc88e611c56d85d4f2e"},
 ]
 
 [package.dependencies]
@@ -10802,4 +10802,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "5e30aca4e307ddf191b9004c11d20751efa84bf98c6a449ae5cae5588bdbd40a"
+content-hash = "022a4f5ad4e1124d0bbf2bae8060d07692a25ce3f8abf271204897052043bbce"

--- a/project/events/2026-05-15T22:06:22.963Z__881e88fd-67a9-49ba-a000-ed2246f2d42f.json
+++ b/project/events/2026-05-15T22:06:22.963Z__881e88fd-67a9-49ba-a000-ed2246f2d42f.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "881e88fd-67a9-49ba-a000-ed2246f2d42f",
+  "issue_id": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-15T22:06:22.963Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Purpose: create a deterministic procedure that bulk-creates non-champion score versions for every selected score on a scorecard with a new model configuration.\n\nDefinition of Done:\n- Procedure supports dry-run and apply modes.\n- LangGraphScore root model fields and TactusScore default_model/runtime controls are updated deterministically.\n- Existing champion versions are used as parents.\n- No score is promoted to champion.\n- Unsupported score classes fail loudly unless excluded.\n- Behavior is covered by Gherkin and executable tests.",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Scorecard model retarget procedure"
+  }
+}

--- a/project/events/2026-05-15T22:06:29.406Z__418d3806-1dae-4cce-9977-e9aa9a31f5be.json
+++ b/project/events/2026-05-15T22:06:29.406Z__418d3806-1dae-4cce-9977-e9aa9a31f5be.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "418d3806-1dae-4cce-9977-e9aa9a31f5be",
+  "issue_id": "plx-08d313f7-bb48-4daa-b84c-3284e767d545",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-15T22:06:29.406Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "As a scorecard operator, I want to create model-retargeted score versions for all selected scores on a scorecard, so that I can roll out a new model configuration without manually editing every score.\n\nFeature: Scorecard model retargeting\n\nScenario: Dry run previews changed score versions\nGiven a scorecard with LangGraphScore and TactusScore scores\nWhen I run the retarget procedure with dry_run=true\nThen it returns the planned YAML changes for each selected score\nAnd it creates no ScoreVersions.\n\nScenario: Apply creates non-champion versions\nGiven selected scores whose champion YAML changes after retargeting\nWhen I run the retarget procedure with dry_run=false\nThen it creates one non-champion ScoreVersion per changed score\nAnd each new version uses the champion version as parent\nAnd no candidate is promoted to champion.\n\nScenario: Unsupported classes fail loudly\nGiven a selected score with an unsupported class\nWhen I run the retarget procedure\nThen the procedure fails with a clear unsupported class error unless that score is excluded.\n\nScenario: Include and exclude filters select scores deterministically\nGiven include_scores and exclude_scores are provided\nWhen the procedure plans scores\nThen only included non-excluded scores are retargeted in stable order.",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+    "priority": 1,
+    "status": "open",
+    "title": "Bulk retarget scorecard models"
+  }
+}

--- a/project/events/2026-05-15T22:06:29.417Z__ea5afc1e-4bc8-44aa-91d7-0af12e71d3c9.json
+++ b/project/events/2026-05-15T22:06:29.417Z__ea5afc1e-4bc8-44aa-91d7-0af12e71d3c9.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "ea5afc1e-4bc8-44aa-91d7-0af12e71d3c9",
+  "issue_id": "plx-772fe5e6-f2ae-443d-9b13-7c88ae76336f",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-15T22:06:29.417Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Add the procedure YAML, runtime helper module/tests, and README docs for bulk model retargeting across LangGraphScore and TactusScore scores.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+    "priority": 1,
+    "status": "open",
+    "title": "Implement scorecard model retarget procedure"
+  }
+}

--- a/project/events/2026-05-15T22:06:29.427Z__0d8721b2-3a10-44ed-9f63-d449387018cc.json
+++ b/project/events/2026-05-15T22:06:29.427Z__0d8721b2-3a10-44ed-9f63-d449387018cc.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0d8721b2-3a10-44ed-9f63-d449387018cc",
+  "issue_id": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:06:29.427Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-15T22:06:37.023Z__213ac538-8ff1-4072-b83d-f514e269f987.json
+++ b/project/events/2026-05-15T22:06:37.023Z__213ac538-8ff1-4072-b83d-f514e269f987.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "213ac538-8ff1-4072-b83d-f514e269f987",
+  "issue_id": "plx-08d313f7-bb48-4daa-b84c-3284e767d545",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:06:37.023Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-15T22:06:37.034Z__e9f79b57-1d8d-48c4-9964-1b0d271cbc38.json
+++ b/project/events/2026-05-15T22:06:37.034Z__e9f79b57-1d8d-48c4-9964-1b0d271cbc38.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e9f79b57-1d8d-48c4-9964-1b0d271cbc38",
+  "issue_id": "plx-772fe5e6-f2ae-443d-9b13-7c88ae76336f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:06:37.034Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-15T22:06:37.045Z__109ff6a5-6003-4018-bce4-96bc9337ca9b.json
+++ b/project/events/2026-05-15T22:06:37.045Z__109ff6a5-6003-4018-bce4-96bc9337ca9b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "109ff6a5-6003-4018-bce4-96bc9337ca9b",
+  "issue_id": "plx-772fe5e6-f2ae-443d-9b13-7c88ae76336f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-15T22:06:37.045Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "6691665c-0d0c-412b-86ed-919319def5ab"
+  }
+}

--- a/project/events/2026-05-15T22:16:01.307Z__2e4b5eaa-9c86-4712-87ac-9bb511739aac.json
+++ b/project/events/2026-05-15T22:16:01.307Z__2e4b5eaa-9c86-4712-87ac-9bb511739aac.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2e4b5eaa-9c86-4712-87ac-9bb511739aac",
+  "issue_id": "plx-772fe5e6-f2ae-443d-9b13-7c88ae76336f",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-15T22:16:01.307Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "8565351b-f09e-499f-97bc-27e90004309b"
+  }
+}

--- a/project/events/2026-05-15T22:16:01.319Z__81925bd2-93f4-4400-84b0-6ea7649fe5b8.json
+++ b/project/events/2026-05-15T22:16:01.319Z__81925bd2-93f4-4400-84b0-6ea7649fe5b8.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "81925bd2-93f4-4400-84b0-6ea7649fe5b8",
+  "issue_id": "plx-08d313f7-bb48-4daa-b84c-3284e767d545",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:16:01.319Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-15T22:16:01.330Z__09e904b8-c726-4372-ac3e-83bc15a93eae.json
+++ b/project/events/2026-05-15T22:16:01.330Z__09e904b8-c726-4372-ac3e-83bc15a93eae.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "09e904b8-c726-4372-ac3e-83bc15a93eae",
+  "issue_id": "plx-772fe5e6-f2ae-443d-9b13-7c88ae76336f",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:16:01.330Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-15T22:16:01.340Z__d2bca876-d9b6-49da-96d9-5f1f20fccca1.json
+++ b/project/events/2026-05-15T22:16:01.340Z__d2bca876-d9b6-49da-96d9-5f1f20fccca1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "d2bca876-d9b6-49da-96d9-5f1f20fccca1",
+  "issue_id": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:16:01.340Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-15T22:33:36.121Z__a31b4f65-60aa-4444-90fd-71299c40a6f2.json
+++ b/project/events/2026-05-15T22:33:36.121Z__a31b4f65-60aa-4444-90fd-71299c40a6f2.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "a31b4f65-60aa-4444-90fd-71299c40a6f2",
+  "issue_id": "plx-c037bce7-22d8-4921-82b7-59fe96ac12fc",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-15T22:33:36.121Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Observed behavior: scorecard_model_retarget fails the whole procedure when plexus.score.pull raises 'No champion version for score'.\n\nExpected behavior: because this is a bulk scorecard maintenance procedure, a selected score with no champion version should be skipped with a clear row status, and the procedure should continue retargeting other selected scores.\n\nFeature: Scorecard model retarget skips scores without champions\n\nScenario: Selected score has no champion version\nGiven a selected score has no champion ScoreVersion\nWhen the scorecard model retarget procedure plans scores\nThen that score is marked skipped with the pull error\nAnd the procedure continues planning subsequent scores.\n\nScenario: All selected scores are skipped\nGiven no selected score can be retargeted\nWhen the procedure finishes planning\nThen it completes with no_changes and reports skipped rows.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+    "priority": 1,
+    "status": "open",
+    "title": "Skip scores without champion during model retarget"
+  }
+}

--- a/project/events/2026-05-15T22:33:39.769Z__e09ea12d-cdab-47ae-8b24-fcf86e8f707a.json
+++ b/project/events/2026-05-15T22:33:39.769Z__e09ea12d-cdab-47ae-8b24-fcf86e8f707a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e09ea12d-cdab-47ae-8b24-fcf86e8f707a",
+  "issue_id": "plx-c037bce7-22d8-4921-82b7-59fe96ac12fc",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:33:39.769Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-15T22:33:39.778Z__3604701f-5e5e-4ddc-88d7-35ecd0d87bcf.json
+++ b/project/events/2026-05-15T22:33:39.778Z__3604701f-5e5e-4ddc-88d7-35ecd0d87bcf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "3604701f-5e5e-4ddc-88d7-35ecd0d87bcf",
+  "issue_id": "plx-c037bce7-22d8-4921-82b7-59fe96ac12fc",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-15T22:33:39.778Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "3ec5f071-114e-4c90-894c-a0de12f87bd7"
+  }
+}

--- a/project/events/2026-05-15T22:34:18.120Z__2351ea3d-4772-481d-91b6-8d95d04081ed.json
+++ b/project/events/2026-05-15T22:34:18.120Z__2351ea3d-4772-481d-91b6-8d95d04081ed.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "2351ea3d-4772-481d-91b6-8d95d04081ed",
+  "issue_id": "plx-c037bce7-22d8-4921-82b7-59fe96ac12fc",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-15T22:34:18.120Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "7e325d4f-1ce3-4224-aa92-31d484325820"
+  }
+}

--- a/project/events/2026-05-15T22:34:18.130Z__0006f05b-bc27-433f-9a84-9bee81833b98.json
+++ b/project/events/2026-05-15T22:34:18.130Z__0006f05b-bc27-433f-9a84-9bee81833b98.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "0006f05b-bc27-433f-9a84-9bee81833b98",
+  "issue_id": "plx-c037bce7-22d8-4921-82b7-59fe96ac12fc",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:34:18.130Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-15T22:56:18.083Z__b60302d6-8b69-4fa2-b1eb-c662fb162b1c.json
+++ b/project/events/2026-05-15T22:56:18.083Z__b60302d6-8b69-4fa2-b1eb-c662fb162b1c.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "b60302d6-8b69-4fa2-b1eb-c662fb162b1c",
+  "issue_id": "plx-d08d5ec2-c3f4-433d-8d8f-66aae321beae",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-15T22:56:18.083Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Gherkin:\nGiven a selected score champion version has guidelines\nWhen scorecard_model_retarget creates a non-champion retargeted ScoreVersion\nThen the new ScoreVersion preserves the champion guidelines exactly\nAnd the procedure row records that guidelines were preserved.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+    "priority": 1,
+    "status": "open",
+    "title": "Preserve guidelines during scorecard model retarget"
+  }
+}

--- a/project/events/2026-05-15T22:56:19.913Z__ccd183c3-3035-4b43-9fcf-ddf46ee0d08b.json
+++ b/project/events/2026-05-15T22:56:19.913Z__ccd183c3-3035-4b43-9fcf-ddf46ee0d08b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ccd183c3-3035-4b43-9fcf-ddf46ee0d08b",
+  "issue_id": "plx-d08d5ec2-c3f4-433d-8d8f-66aae321beae",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:56:19.913Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-15T22:56:59.565Z__ba8e6e63-79ab-48ac-ac49-e0c7dea8211c.json
+++ b/project/events/2026-05-15T22:56:59.565Z__ba8e6e63-79ab-48ac-ac49-e0c7dea8211c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ba8e6e63-79ab-48ac-ac49-e0c7dea8211c",
+  "issue_id": "plx-d08d5ec2-c3f4-433d-8d8f-66aae321beae",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-15T22:56:59.565Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "29c0ae86-500c-40bd-8b0f-893bc41b790b"
+  }
+}

--- a/project/events/2026-05-15T22:57:02.310Z__de903f58-d49b-4c21-b791-ed3a29049aee.json
+++ b/project/events/2026-05-15T22:57:02.310Z__de903f58-d49b-4c21-b791-ed3a29049aee.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "de903f58-d49b-4c21-b791-ed3a29049aee",
+  "issue_id": "plx-d08d5ec2-c3f4-433d-8d8f-66aae321beae",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-15T22:57:02.310Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-18T15:52:35.643Z__4d71223e-cf60-4e76-b65a-d28383c2765a.json
+++ b/project/events/2026-05-18T15:52:35.643Z__4d71223e-cf60-4e76-b65a-d28383c2765a.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "4d71223e-cf60-4e76-b65a-d28383c2765a",
+  "issue_id": "plx-ec90178a-d1b7-43a6-85e1-82e19ebdf7b3",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-18T15:52:35.643Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Feature: TactusScore model retarget token limits\n\nScenario: TactusScore retarget applies max_tokens\nGiven a TactusScore YAML with ClassifyProcedure\nWhen scorecard_model_retarget receives max_tokens\nThen the planned candidate YAML includes max_tokens inside ClassifyProcedure\nAnd the procedure does not reject the target.\n\nScenario: Frontier variants apply Tactus max_tokens\nGiven a TactusScore candidate matrix parameter_set includes max_tokens\nWhen frontier variants are generated\nThen the candidate YAML includes max_tokens inside ClassifyProcedure.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+    "priority": 1,
+    "status": "open",
+    "title": "Support max_tokens for Tactus retarget variants"
+  }
+}

--- a/project/events/2026-05-18T15:52:38.624Z__f4057afe-da60-4859-974b-9472778ee3b3.json
+++ b/project/events/2026-05-18T15:52:38.624Z__f4057afe-da60-4859-974b-9472778ee3b3.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f4057afe-da60-4859-974b-9472778ee3b3",
+  "issue_id": "plx-ec90178a-d1b7-43a6-85e1-82e19ebdf7b3",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T15:52:38.624Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-18T15:53:54.315Z__051355d5-b3f4-4ffd-967b-9a50682df2a9.json
+++ b/project/events/2026-05-18T15:53:54.315Z__051355d5-b3f4-4ffd-967b-9a50682df2a9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "051355d5-b3f4-4ffd-967b-9a50682df2a9",
+  "issue_id": "plx-ec90178a-d1b7-43a6-85e1-82e19ebdf7b3",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T15:53:54.315Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "8a9eb16a-b243-41a3-988a-28c5bf5c499c"
+  }
+}

--- a/project/events/2026-05-18T15:53:54.325Z__bf15c13a-47ab-4c8c-a8a7-52e85d51bf98.json
+++ b/project/events/2026-05-18T15:53:54.325Z__bf15c13a-47ab-4c8c-a8a7-52e85d51bf98.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "bf15c13a-47ab-4c8c-a8a7-52e85d51bf98",
+  "issue_id": "plx-ec90178a-d1b7-43a6-85e1-82e19ebdf7b3",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T15:53:54.325Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-18T16:50:23.299Z__6b033816-8842-4bd6-b86f-3ea7f30ad5b9.json
+++ b/project/events/2026-05-18T16:50:23.299Z__6b033816-8842-4bd6-b86f-3ea7f30ad5b9.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "6b033816-8842-4bd6-b86f-3ea7f30ad5b9",
+  "issue_id": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-18T16:50:23.299Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Align Plexus score YAML generation with the final Tactus model-control shape: TactusScore root/runtime controls are the score-wide defaults, and explicit ClassifyProcedure or model-local overrides remain local overrides. Frontier and retarget procedures should stop treating max_tokens and temperature as special ClassifyProcedure-only fields.",
+    "issue_type": "epic",
+    "labels": [],
+    "parent": null,
+    "priority": 1,
+    "status": "open",
+    "title": "Unified TactusScore model control retargeting"
+  }
+}

--- a/project/events/2026-05-18T16:50:23.322Z__19219a52-fc6c-4270-ab07-c9cbd5acf53a.json
+++ b/project/events/2026-05-18T16:50:23.322Z__19219a52-fc6c-4270-ab07-c9cbd5acf53a.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "19219a52-fc6c-4270-ab07-c9cbd5acf53a",
+  "issue_id": "plx-94e940ca-bbea-472e-bb04-ed48d98ee448",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-18T16:50:23.322Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Feature: TactusScore model control retargeting\n  Scenario: Score-wide model controls are written to TactusScore root\n    Given a TactusScore YAML and a model retarget includes reasoning_effort, verbosity, temperature, and max_tokens\n    When Plexus generates the candidate YAML\n    Then all score-wide controls are written to the TactusScore root\n    And ClassifyProcedure code is not modified for score-wide controls\n\n  Scenario: Existing ClassifyProcedure overrides are preserved\n    Given a TactusScore YAML already has ClassifyProcedure-local model controls\n    When Plexus retargets score-wide model defaults\n    Then the local ClassifyProcedure override remains unchanged\n    And the root defaults apply only where local overrides are absent\n\n  Scenario: Existing TactusScore YAML remains loadable\n    Given an existing TactusScore YAML with supported root or local model fields\n    When Plexus loads and retargets the score\n    Then the procedure preserves unrelated score content and only changes requested model-control fields",
+    "issue_type": "story",
+    "labels": [],
+    "parent": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+    "priority": 1,
+    "status": "open",
+    "title": "TactusScore procedures write score-wide model controls to root"
+  }
+}

--- a/project/events/2026-05-18T16:50:23.351Z__a5a762ef-699f-4579-b138-1f0baad1f0dd.json
+++ b/project/events/2026-05-18T16:50:23.351Z__a5a762ef-699f-4579-b138-1f0baad1f0dd.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "a5a762ef-699f-4579-b138-1f0baad1f0dd",
+  "issue_id": "plx-45a37bd3-cc04-49c2-82f7-51abc9176e9e",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-18T16:50:23.351Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Story: plx-94e940. Update TactusScore runtime setup so root max_tokens and temperature participate in runtime defaults alongside reasoning_effort and verbosity.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+    "priority": 1,
+    "status": "open",
+    "title": "Pass TactusScore max_tokens and temperature into TactusRuntime"
+  }
+}

--- a/project/events/2026-05-18T16:50:23.369Z__0c707f11-0423-43f7-86e0-39adc1959688.json
+++ b/project/events/2026-05-18T16:50:23.369Z__0c707f11-0423-43f7-86e0-39adc1959688.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "0c707f11-0423-43f7-86e0-39adc1959688",
+  "issue_id": "plx-32efc444-7d76-4c2d-9a3d-3df60f9b81db",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-18T16:50:23.369Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Story: plx-94e940. Update model_performance_frontier and scorecard_model_retarget variant generation so score-wide Tactus controls are root fields, with procedure-local changes only through explicit extra_overrides.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+    "priority": 1,
+    "status": "open",
+    "title": "Write Tactus procedure variants to root runtime fields"
+  }
+}

--- a/project/events/2026-05-18T16:50:23.386Z__f68df092-d864-4732-bbed-34c6949ecb75.json
+++ b/project/events/2026-05-18T16:50:23.386Z__f68df092-d864-4732-bbed-34c6949ecb75.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "f68df092-d864-4732-bbed-34c6949ecb75",
+  "issue_id": "plx-bc4bcab2-5027-4b5a-9f88-5511e30d7ff8",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-18T16:50:23.386Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Story: plx-94e940. Update procedure YAML descriptions and tests to assert root-field generation, preservation of local overrides, and no ClassifyProcedure mutation for score-wide controls.",
+    "issue_type": "task",
+    "labels": [],
+    "parent": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+    "priority": 1,
+    "status": "open",
+    "title": "Update procedure docs and tests for final control shape"
+  }
+}

--- a/project/events/2026-05-18T16:50:23.398Z__f66af79b-584a-4245-965d-21c5c8662b2d.json
+++ b/project/events/2026-05-18T16:50:23.398Z__f66af79b-584a-4245-965d-21c5c8662b2d.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "f66af79b-584a-4245-965d-21c5c8662b2d",
+  "issue_id": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T16:50:23.398Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-18T16:50:23.410Z__c0abf76f-2d89-4ac6-86c2-6ffb2e3fc815.json
+++ b/project/events/2026-05-18T16:50:23.410Z__c0abf76f-2d89-4ac6-86c2-6ffb2e3fc815.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "c0abf76f-2d89-4ac6-86c2-6ffb2e3fc815",
+  "issue_id": "plx-94e940ca-bbea-472e-bb04-ed48d98ee448",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T16:50:23.410Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-18T16:50:23.420Z__ce4fbbd6-d5b2-4df4-9e42-5b253e1d8c4b.json
+++ b/project/events/2026-05-18T16:50:23.420Z__ce4fbbd6-d5b2-4df4-9e42-5b253e1d8c4b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ce4fbbd6-d5b2-4df4-9e42-5b253e1d8c4b",
+  "issue_id": "plx-94e940ca-bbea-472e-bb04-ed48d98ee448",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T16:50:23.420Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "6f445a2a-b5e5-4ee6-9b6b-772b01e6967d"
+  }
+}

--- a/project/events/2026-05-18T16:54:59.910Z__7795ae88-ef46-48ae-ad96-0c6d3383d6a9.json
+++ b/project/events/2026-05-18T16:54:59.910Z__7795ae88-ef46-48ae-ad96-0c6d3383d6a9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "7795ae88-ef46-48ae-ad96-0c6d3383d6a9",
+  "issue_id": "plx-45a37bd3-cc04-49c2-82f7-51abc9176e9e",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T16:54:59.910Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-18T16:54:59.922Z__73867771-5665-4794-a1bf-7bda8d10c526.json
+++ b/project/events/2026-05-18T16:54:59.922Z__73867771-5665-4794-a1bf-7bda8d10c526.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "73867771-5665-4794-a1bf-7bda8d10c526",
+  "issue_id": "plx-32efc444-7d76-4c2d-9a3d-3df60f9b81db",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T16:54:59.922Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-18T16:54:59.933Z__007f669f-5f15-4ac3-9ea8-d6b6419e4412.json
+++ b/project/events/2026-05-18T16:54:59.933Z__007f669f-5f15-4ac3-9ea8-d6b6419e4412.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "007f669f-5f15-4ac3-9ea8-d6b6419e4412",
+  "issue_id": "plx-bc4bcab2-5027-4b5a-9f88-5511e30d7ff8",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T16:54:59.933Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-18T16:54:59.943Z__54e64308-614c-4867-892c-ce9205b46376.json
+++ b/project/events/2026-05-18T16:54:59.943Z__54e64308-614c-4867-892c-ce9205b46376.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "54e64308-614c-4867-892c-ce9205b46376",
+  "issue_id": "plx-94e940ca-bbea-472e-bb04-ed48d98ee448",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T16:54:59.943Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-18T16:54:59.954Z__5ac5e11b-7ead-4272-a81c-90c424a383be.json
+++ b/project/events/2026-05-18T16:54:59.954Z__5ac5e11b-7ead-4272-a81c-90c424a383be.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5ac5e11b-7ead-4272-a81c-90c424a383be",
+  "issue_id": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T16:54:59.954Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-18T16:54:59.965Z__06e12325-457e-4d5f-ad77-578c3120a0e9.json
+++ b/project/events/2026-05-18T16:54:59.965Z__06e12325-457e-4d5f-ad77-578c3120a0e9.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "06e12325-457e-4d5f-ad77-578c3120a0e9",
+  "issue_id": "plx-94e940ca-bbea-472e-bb04-ed48d98ee448",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T16:54:59.965Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "8af005c4-2847-4763-8b2b-55e07095aac4"
+  }
+}

--- a/project/issues/plx-08d313f7-bb48-4daa-b84c-3284e767d545.json
+++ b/project/issues/plx-08d313f7-bb48-4daa-b84c-3284e767d545.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-08d313f7-bb48-4daa-b84c-3284e767d545",
+  "title": "Bulk retarget scorecard models",
+  "description": "As a scorecard operator, I want to create model-retargeted score versions for all selected scores on a scorecard, so that I can roll out a new model configuration without manually editing every score.\n\nFeature: Scorecard model retargeting\n\nScenario: Dry run previews changed score versions\nGiven a scorecard with LangGraphScore and TactusScore scores\nWhen I run the retarget procedure with dry_run=true\nThen it returns the planned YAML changes for each selected score\nAnd it creates no ScoreVersions.\n\nScenario: Apply creates non-champion versions\nGiven selected scores whose champion YAML changes after retargeting\nWhen I run the retarget procedure with dry_run=false\nThen it creates one non-champion ScoreVersion per changed score\nAnd each new version uses the champion version as parent\nAnd no candidate is promoted to champion.\n\nScenario: Unsupported classes fail loudly\nGiven a selected score with an unsupported class\nWhen I run the retarget procedure\nThen the procedure fails with a clear unsupported class error unless that score is excluded.\n\nScenario: Include and exclude filters select scores deterministically\nGiven include_scores and exclude_scores are provided\nWhen the procedure plans scores\nThen only included non-excluded scores are retargeted in stable order.",
+  "type": "story",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-15T22:06:29.405934Z",
+  "updated_at": "2026-05-15T22:16:01.318894Z",
+  "closed_at": "2026-05-15T22:16:01.318894Z",
+  "custom": {}
+}

--- a/project/issues/plx-32efc444-7d76-4c2d-9a3d-3df60f9b81db.json
+++ b/project/issues/plx-32efc444-7d76-4c2d-9a3d-3df60f9b81db.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-32efc444-7d76-4c2d-9a3d-3df60f9b81db",
+  "title": "Write Tactus procedure variants to root runtime fields",
+  "description": "Story: plx-94e940. Update model_performance_frontier and scorecard_model_retarget variant generation so score-wide Tactus controls are root fields, with procedure-local changes only through explicit extra_overrides.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-18T16:50:23.369549Z",
+  "updated_at": "2026-05-18T16:54:59.922412Z",
+  "closed_at": "2026-05-18T16:54:59.922412Z",
+  "custom": {}
+}

--- a/project/issues/plx-45a37bd3-cc04-49c2-82f7-51abc9176e9e.json
+++ b/project/issues/plx-45a37bd3-cc04-49c2-82f7-51abc9176e9e.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-45a37bd3-cc04-49c2-82f7-51abc9176e9e",
+  "title": "Pass TactusScore max_tokens and temperature into TactusRuntime",
+  "description": "Story: plx-94e940. Update TactusScore runtime setup so root max_tokens and temperature participate in runtime defaults alongside reasoning_effort and verbosity.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-18T16:50:23.351144Z",
+  "updated_at": "2026-05-18T16:54:59.910727Z",
+  "closed_at": "2026-05-18T16:54:59.910727Z",
+  "custom": {}
+}

--- a/project/issues/plx-772fe5e6-f2ae-443d-9b13-7c88ae76336f.json
+++ b/project/issues/plx-772fe5e6-f2ae-443d-9b13-7c88ae76336f.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-772fe5e6-f2ae-443d-9b13-7c88ae76336f",
+  "title": "Implement scorecard model retarget procedure",
+  "description": "Add the procedure YAML, runtime helper module/tests, and README docs for bulk model retargeting across LangGraphScore and TactusScore scores.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "6691665c-0d0c-412b-86ed-919319def5ab",
+      "author": "derek.norrbom",
+      "text": "Branch created from updated develop: feature/scorecard-model-retarget-procedure. Implementation target: new procedure that lists scorecard scores, pulls champion YAML per score, plans deterministic model retarget changes, supports dry_run, and creates non-champion ScoreVersions via plexus.score.update only in apply mode.",
+      "created_at": "2026-05-15T22:06:37.045117Z"
+    },
+    {
+      "id": "8565351b-f09e-499f-97bc-27e90004309b",
+      "author": "derek.norrbom",
+      "text": "Implemented scorecard_model_retarget procedure using the merged model_frontier variant helper rather than duplicating class-specific YAML mutation logic. Added plexus.scorecard_retarget.plan_score runtime helper, unit tests for LangGraphScore/TactusScore planning, procedure contract tests, runtime API catalog tests, and README docs. Validation: focused retarget/frontier runtime tests passed, YAML parse passed, py_compile passed.",
+      "created_at": "2026-05-15T22:16:01.307461Z"
+    }
+  ],
+  "created_at": "2026-05-15T22:06:29.417284Z",
+  "updated_at": "2026-05-15T22:16:01.330460Z",
+  "closed_at": "2026-05-15T22:16:01.330460Z",
+  "custom": {}
+}

--- a/project/issues/plx-94e940ca-bbea-472e-bb04-ed48d98ee448.json
+++ b/project/issues/plx-94e940ca-bbea-472e-bb04-ed48d98ee448.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-94e940ca-bbea-472e-bb04-ed48d98ee448",
+  "title": "TactusScore procedures write score-wide model controls to root",
+  "description": "Feature: TactusScore model control retargeting\n  Scenario: Score-wide model controls are written to TactusScore root\n    Given a TactusScore YAML and a model retarget includes reasoning_effort, verbosity, temperature, and max_tokens\n    When Plexus generates the candidate YAML\n    Then all score-wide controls are written to the TactusScore root\n    And ClassifyProcedure code is not modified for score-wide controls\n\n  Scenario: Existing ClassifyProcedure overrides are preserved\n    Given a TactusScore YAML already has ClassifyProcedure-local model controls\n    When Plexus retargets score-wide model defaults\n    Then the local ClassifyProcedure override remains unchanged\n    And the root defaults apply only where local overrides are absent\n\n  Scenario: Existing TactusScore YAML remains loadable\n    Given an existing TactusScore YAML with supported root or local model fields\n    When Plexus loads and retargets the score\n    Then the procedure preserves unrelated score content and only changes requested model-control fields",
+  "type": "story",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "6f445a2a-b5e5-4ee6-9b6b-772b01e6967d",
+      "author": "derek.norrbom",
+      "text": "Planning complete. Implementation should follow the Tactus precedence chain: local config overrides TactusScore root/runtime defaults, then provider defaults.",
+      "created_at": "2026-05-18T16:50:23.420189Z"
+    },
+    {
+      "id": "8af005c4-2847-4763-8b2b-55e07095aac4",
+      "author": "derek.norrbom",
+      "text": "Implemented and verified. TactusScore now passes root max_tokens and temperature to TactusRuntime; frontier and retarget procedures write score-wide Tactus controls to root and preserve local ClassifyProcedure overrides.",
+      "created_at": "2026-05-18T16:54:59.965454Z"
+    }
+  ],
+  "created_at": "2026-05-18T16:50:23.322170Z",
+  "updated_at": "2026-05-18T16:54:59.965454Z",
+  "closed_at": "2026-05-18T16:54:59.943627Z",
+  "custom": {}
+}

--- a/project/issues/plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3.json
+++ b/project/issues/plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+  "title": "Unified TactusScore model control retargeting",
+  "description": "Align Plexus score YAML generation with the final Tactus model-control shape: TactusScore root/runtime controls are the score-wide defaults, and explicit ClassifyProcedure or model-local overrides remain local overrides. Frontier and retarget procedures should stop treating max_tokens and temperature as special ClassifyProcedure-only fields.",
+  "type": "epic",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-18T16:50:23.299140Z",
+  "updated_at": "2026-05-18T16:54:59.954591Z",
+  "closed_at": "2026-05-18T16:54:59.954591Z",
+  "custom": {}
+}

--- a/project/issues/plx-bc4bcab2-5027-4b5a-9f88-5511e30d7ff8.json
+++ b/project/issues/plx-bc4bcab2-5027-4b5a-9f88-5511e30d7ff8.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-bc4bcab2-5027-4b5a-9f88-5511e30d7ff8",
+  "title": "Update procedure docs and tests for final control shape",
+  "description": "Story: plx-94e940. Update procedure YAML descriptions and tests to assert root-field generation, preservation of local overrides, and no ClassifyProcedure mutation for score-wide controls.",
+  "type": "task",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-a9690a9c-4a6c-42b3-9a66-c87fc7c14ac3",
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-18T16:50:23.386053Z",
+  "updated_at": "2026-05-18T16:54:59.933175Z",
+  "closed_at": "2026-05-18T16:54:59.933175Z",
+  "custom": {}
+}

--- a/project/issues/plx-c037bce7-22d8-4921-82b7-59fe96ac12fc.json
+++ b/project/issues/plx-c037bce7-22d8-4921-82b7-59fe96ac12fc.json
@@ -1,0 +1,31 @@
+{
+  "id": "plx-c037bce7-22d8-4921-82b7-59fe96ac12fc",
+  "title": "Skip scores without champion during model retarget",
+  "description": "Observed behavior: scorecard_model_retarget fails the whole procedure when plexus.score.pull raises 'No champion version for score'.\n\nExpected behavior: because this is a bulk scorecard maintenance procedure, a selected score with no champion version should be skipped with a clear row status, and the procedure should continue retargeting other selected scores.\n\nFeature: Scorecard model retarget skips scores without champions\n\nScenario: Selected score has no champion version\nGiven a selected score has no champion ScoreVersion\nWhen the scorecard model retarget procedure plans scores\nThen that score is marked skipped with the pull error\nAnd the procedure continues planning subsequent scores.\n\nScenario: All selected scores are skipped\nGiven no selected score can be retargeted\nWhen the procedure finishes planning\nThen it completes with no_changes and reports skipped rows.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "3ec5f071-114e-4c90-894c-a0de12f87bd7",
+      "author": "derek.norrbom",
+      "text": "Implementing as procedure-only behavior: wrap plexus.score.pull in pcall, append a skipped row on missing champion/pull failure, and continue. No change to the lower-level score.pull API because other callers should still fail loudly for direct pulls.",
+      "created_at": "2026-05-15T22:33:39.778734Z"
+    },
+    {
+      "id": "7e325d4f-1ce3-4224-aa92-31d484325820",
+      "author": "derek.norrbom",
+      "text": "Implemented: scorecard_model_retarget now wraps plexus.score.pull in pcall. Pull failures, including missing champion versions, append a row with status=skipped, skip_reason=missing_champion, and the original error text, then continue with subsequent scores. Added contract assertions for skipped_count and skip status. Validation: retarget procedure/runtime tests passed and YAML parsed.",
+      "created_at": "2026-05-15T22:34:18.120499Z"
+    }
+  ],
+  "created_at": "2026-05-15T22:33:36.121654Z",
+  "updated_at": "2026-05-15T22:34:18.130712Z",
+  "closed_at": "2026-05-15T22:34:18.130712Z",
+  "custom": {}
+}

--- a/project/issues/plx-d08d5ec2-c3f4-433d-8d8f-66aae321beae.json
+++ b/project/issues/plx-d08d5ec2-c3f4-433d-8d8f-66aae321beae.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-d08d5ec2-c3f4-433d-8d8f-66aae321beae",
+  "title": "Preserve guidelines during scorecard model retarget",
+  "description": "Gherkin:\nGiven a selected score champion version has guidelines\nWhen scorecard_model_retarget creates a non-champion retargeted ScoreVersion\nThen the new ScoreVersion preserves the champion guidelines exactly\nAnd the procedure row records that guidelines were preserved.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "29c0ae86-500c-40bd-8b0f-893bc41b790b",
+      "author": "derek.norrbom",
+      "text": "Implemented guideline preservation for scorecard_model_retarget: pulled champion guidelines are retained out-of-band during planning and passed to plexus.score.update for each created non-champion ScoreVersion. Added contract assertions and validated with focused tests plus YAML parse.",
+      "created_at": "2026-05-15T22:56:59.565157Z"
+    }
+  ],
+  "created_at": "2026-05-15T22:56:18.083396Z",
+  "updated_at": "2026-05-15T22:57:02.309695Z",
+  "closed_at": "2026-05-15T22:57:02.309695Z",
+  "custom": {}
+}

--- a/project/issues/plx-ec90178a-d1b7-43a6-85e1-82e19ebdf7b3.json
+++ b/project/issues/plx-ec90178a-d1b7-43a6-85e1-82e19ebdf7b3.json
@@ -1,0 +1,25 @@
+{
+  "id": "plx-ec90178a-d1b7-43a6-85e1-82e19ebdf7b3",
+  "title": "Support max_tokens for Tactus retarget variants",
+  "description": "Feature: TactusScore model retarget token limits\n\nScenario: TactusScore retarget applies max_tokens\nGiven a TactusScore YAML with ClassifyProcedure\nWhen scorecard_model_retarget receives max_tokens\nThen the planned candidate YAML includes max_tokens inside ClassifyProcedure\nAnd the procedure does not reject the target.\n\nScenario: Frontier variants apply Tactus max_tokens\nGiven a TactusScore candidate matrix parameter_set includes max_tokens\nWhen frontier variants are generated\nThen the candidate YAML includes max_tokens inside ClassifyProcedure.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "8a9eb16a-b243-41a3-988a-28c5bf5c499c",
+      "author": "derek.norrbom",
+      "text": "Implemented Plexus support for TactusScore max_tokens variants: shared frontier generation inserts max_tokens into ClassifyProcedure, scorecard_model_retarget no longer rejects max_tokens for TactusScore, and procedure descriptions/tests now reflect the supported behavior. Validated 21 focused Plexus tests.",
+      "created_at": "2026-05-18T15:53:54.315695Z"
+    }
+  ],
+  "created_at": "2026-05-18T15:52:35.643295Z",
+  "updated_at": "2026-05-18T15:53:54.325235Z",
+  "closed_at": "2026-05-18T15:53:54.325235Z",
+  "custom": {}
+}

--- a/project/issues/plx-fb6c27b7-9d52-4955-b202-465dd7047f2a.json
+++ b/project/issues/plx-fb6c27b7-9d52-4955-b202-465dd7047f2a.json
@@ -1,0 +1,18 @@
+{
+  "id": "plx-fb6c27b7-9d52-4955-b202-465dd7047f2a",
+  "title": "Scorecard model retarget procedure",
+  "description": "Purpose: create a deterministic procedure that bulk-creates non-champion score versions for every selected score on a scorecard with a new model configuration.\n\nDefinition of Done:\n- Procedure supports dry-run and apply modes.\n- LangGraphScore root model fields and TactusScore default_model/runtime controls are updated deterministically.\n- Existing champion versions are used as parents.\n- No score is promoted to champion.\n- Unsupported score classes fail loudly unless excluded.\n- Behavior is covered by Gherkin and executable tests.",
+  "type": "epic",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": null,
+  "labels": [],
+  "dependencies": [],
+  "comments": [],
+  "created_at": "2026-05-15T22:06:22.963348Z",
+  "updated_at": "2026-05-15T22:16:01.340592Z",
+  "closed_at": "2026-05-15T22:16:01.340592Z",
+  "custom": {}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ langgraph = "0.6.7"
 "langgraph-checkpoint-postgres" = "2.0.9"
 psycopg = { version = ">=3.2.0,<4.0.0", extras = ["binary"] }
 lupa = "2.7"
-tactus = "^0.49.0"
+tactus = "^0.50.0"
 openpyxl = "3.1.5"
 rapidfuzz = "3.9.4"
 datasets = "*"


### PR DESCRIPTION
**Summary**
- add `scorecard_model_retarget` procedure to create non-champion score versions across a scorecard with updated model controls
- update `model_performance_frontier` so Tactus score-wide controls (`reasoning_effort`, `verbosity`, `temperature`, `max_tokens`) are written to score root runtime fields
- preserve local `ClassifyProcedure` overrides unless explicitly changed via `extra_overrides`
- update `TactusScore` runtime wiring to pass root `max_tokens` and `temperature` into `TactusRuntime`
- refresh procedure/test coverage for Tactus and LangGraph paths, plus dependency bump to the Tactus release containing unified runtime control support

**Why**
- enables automated model retargeting when evaluation ground truth is unavailable
- aligns Plexus procedure behavior with the final Tactus control-precedence model
- removes split behavior where some Tactus controls were being injected into procedure code while others lived at runtime

**Validation**
- `poetry run pytest -q plexus/cli/procedure/test_model_performance_frontier.py plexus/cli/procedure/test_scorecard_model_retarget.py plexus/scores/test_tactus_score_runtime_controls.py`
- `poetry run ruff check plexus/cli/procedure/model_performance_frontier.py plexus/cli/procedure/test_model_performance_frontier.py plexus/cli/procedure/test_scorecard_model_retarget.py plexus/scores/TactusScore.py plexus/scores/test_tactus_score_runtime_controls.py`

**Expected Outcome**
- procedure users can retarget all scores in a scorecard without champion promotion side effects
- frontier variants for Tactus scores use root runtime defaults and keep local per-procedure overrides intact
- Plexus uses the updated Tactus runtime control behavior from the bumped dependency

**Kanbus / Task Tracking**
- `plx-d8f121` Scorecard model retarget procedure
- `plx-fb6c27` Model performance frontier procedure
- `plx-a9690a` Unified TactusScore model control retargeting
- `plx-94e940` TactusScore procedures write score-wide model controls to root