### PR TITLE
fix(scorecard): restore fast no-bleed tactus scoring and bump tactus to 0.51.1

### DIFF
--- a/plexus/Scorecard.py
+++ b/plexus/Scorecard.py
@@ -98,6 +98,10 @@ class Scorecard:
         # Can be set by callers (e.g., CLI/MCP) after construction as well
         self.yaml_only = False
 
+        # Cache for score instances to avoid recreating them for each prediction
+        # Key: score name, Value: score instance
+        self._score_instance_cache = {}
+
         # For API-first loading
         if api_data is not None:
             self.properties = api_data
@@ -503,7 +507,16 @@ class Scorecard:
                 {"scorecard_name": scorecard, "score_name": score}
             )
 
-            score_instance = await score_class.create(**score_configuration)
+            # Check if we have a cached instance for this score
+            # Use score name as cache key since configuration shouldn't change during evaluation
+            if score in self._score_instance_cache:
+                logging.debug(f"Reusing cached score instance for: {score}")
+                score_instance = self._score_instance_cache[score]
+            else:
+                logging.info(f"Creating new score instance for: {score}")
+                score_instance = await score_class.create(**score_configuration)
+                # Cache the instance for reuse
+                self._score_instance_cache[score] = score_instance
 
             if score_instance is None:
                 logging.error(
@@ -1075,15 +1088,6 @@ class Scorecard:
 
         results_by_score_id = {}
         results = []
-        processing_queue = asyncio.Queue()
-
-        # Initialize queue with scores that have no dependencies
-        for score_id, score_info in dependency_graph.items():
-            if not score_info["deps"]:
-                await processing_queue.put(score_id)
-                logging.info(
-                    f"Added score with no dependencies to queue: {score_info['name']} (ID: {score_id})"
-                )
 
         async def process_score(score_id: str):
             score_name = dependency_graph[score_id]["name"]
@@ -1103,20 +1107,6 @@ class Scorecard:
                         ),
                     )
                     results_by_score_id[score_id] = result
-
-                    # Enqueue scores that depend on this one
-                    for dependent_id, dependent_info in dependency_graph.items():
-                        if score_id in dependent_info["deps"]:
-                            # Check if all dependencies for this dependent score are now processed
-                            if all(
-                                dep_id in results_by_score_id
-                                for dep_id in dependent_info["deps"]
-                            ):
-                                logging.info(
-                                    f"Enqueuing dependent score: {dependent_info['name']}"
-                                )
-                                await processing_queue.put(dependent_id)
-
                     return
 
                 logging.info(
@@ -1232,18 +1222,6 @@ class Scorecard:
                 results.append({"id": score_id, "name": score_name, "result": result})
                 logging.info(f"Processed score: {score_name} (ID: {score_id})")
 
-                # Check if any waiting scores can now be processed
-                # Only check scores that directly depend on this score
-                for waiting_score_id, waiting_score_info in dependency_graph.items():
-                    if (
-                        score_id in waiting_score_info["deps"]
-                    ):  # Only check if this score is a dependency
-                        if waiting_score_id not in results_by_score_id and all(
-                            dep in results_by_score_id
-                            for dep in waiting_score_info["deps"]
-                        ):
-                            await processing_queue.put(waiting_score_id)
-
             except Score.SkippedScoreException as e:
                 logging.info(f"Score {score_name} was skipped: {e.reason}")
                 return
@@ -1265,15 +1243,39 @@ class Scorecard:
         remaining_scores = set(dependency_graph.keys())
         while remaining_scores:
             try:
-                score_id_to_process = await processing_queue.get()
-                if score_id_to_process not in remaining_scores:
-                    continue
+                ready_scores = [
+                    score_id
+                    for score_id in remaining_scores
+                    if all(
+                        dep in results_by_score_id
+                        for dep in dependency_graph[score_id]["deps"]
+                    )
+                ]
+                if not ready_scores:
+                    unresolved = ", ".join(
+                        dependency_graph[score_id]["name"] for score_id in remaining_scores
+                    )
+                    raise RuntimeError(
+                        f"No dependency-ready scores found. Remaining: {unresolved}"
+                    )
 
+                ready_batch = ready_scores
                 logging.info(
-                    f"Processing score: {dependency_graph[score_id_to_process]['name']}"
+                    "Processing %s score(s) in parallel (remaining=%s)",
+                    len(ready_batch),
+                    len(remaining_scores),
                 )
-                await process_score(score_id_to_process)
-                remaining_scores.discard(score_id_to_process)
+
+                batch_outcomes = await asyncio.gather(
+                    *(process_score(score_id) for score_id in ready_batch),
+                    return_exceptions=True,
+                )
+                for score_id, outcome in zip(ready_batch, batch_outcomes):
+                    if isinstance(outcome, BatchProcessingPause):
+                        raise outcome
+                    if isinstance(outcome, Exception):
+                        raise outcome
+                    remaining_scores.discard(score_id)
 
             except BatchProcessingPause as e:
                 # Don't remove from remaining scores, just re-raise to be handled by caller

--- a/plexus/Scorecard_test.py
+++ b/plexus/Scorecard_test.py
@@ -1,4 +1,5 @@
 import unittest
+import asyncio
 from unittest.mock import Mock, MagicMock, AsyncMock
 from plexus.Scorecard import Scorecard
 import pytest
@@ -739,6 +740,66 @@ class TestScorecard:
         finally:
             self.scorecard.score_names_to_process = original_method
             self.scorecard.get_score_result = original_get_score_result
+
+    @pytest.mark.asyncio
+    async def test_score_entire_text_runs_independent_scores_in_parallel(self):
+        simple_config = {
+            'name': 'TestScorecard',
+            'id': 'test-scorecard-123',
+            'scores': [
+                {'name': 'ParallelScore1', 'id': 1},
+                {'name': 'ParallelScore2', 'id': 2},
+            ]
+        }
+        self.scorecard.properties = simple_config
+        self.scorecard.scores = simple_config['scores']
+
+        def get_properties_side_effect(score_name):
+            for score in simple_config['scores']:
+                if score['name'] == score_name:
+                    return score
+            return None
+
+        self.mock_registry.get_properties.side_effect = get_properties_side_effect
+
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+
+        async def mock_get_score_result(*_args, **_kwargs):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.05)
+            async with lock:
+                in_flight -= 1
+            return [Mock(value='Pass')]
+
+        original_get_score_result = self.scorecard.get_score_result
+        original_score_names = self.scorecard.score_names_to_process
+        self.scorecard.get_score_result = mock_get_score_result
+        self.scorecard.score_names_to_process = lambda: ['ParallelScore1', 'ParallelScore2']
+
+        import os
+        original_parallelism = os.environ.get('PLEXUS_SCORECARD_MAX_CONCURRENT_SCORES')
+        os.environ['PLEXUS_SCORECARD_MAX_CONCURRENT_SCORES'] = '4'
+
+        try:
+            result = await self.scorecard.score_entire_text(
+                text="Sample text",
+                metadata={},
+                modality="test"
+            )
+            assert len(result) == 2
+            assert max_in_flight >= 2
+        finally:
+            self.scorecard.get_score_result = original_get_score_result
+            self.scorecard.score_names_to_process = original_score_names
+            if original_parallelism is None:
+                os.environ.pop('PLEXUS_SCORECARD_MAX_CONCURRENT_SCORES', None)
+            else:
+                os.environ['PLEXUS_SCORECARD_MAX_CONCURRENT_SCORES'] = original_parallelism
 
     @pytest.mark.asyncio
     async def test_get_score_result_cleans_up_score_instance(self):

--- a/plexus/scores/TactusScore.py
+++ b/plexus/scores/TactusScore.py
@@ -8,8 +8,10 @@ Uses the Tactus runtime with in-process execution (no Docker containers)
 for high-volume Plexus scenarios with trusted code.
 """
 
+import asyncio
 import json
 import logging
+import os
 from typing import Optional, Union, List, Any, Dict
 from pydantic import ConfigDict, model_validator
 
@@ -95,22 +97,26 @@ class TactusScore(Score):
         """Initialize TactusScore with Tactus code."""
         Score.__init__(self, **parameters)
         self.parameters = self.Parameters(**parameters)
-        self._runtime: Optional[TactusRuntime] = None
+        isolation_mode = os.getenv("PLEXUS_TACTUS_RUNTIME_ISOLATION_MODE", "strict").lower()
+        self._strict_runtime_isolation = isolation_mode != "reuse"
+        self._runtime_pool: List[TactusRuntime] = []
+        self._pool_condition = asyncio.Condition()
+        self._active_runtimes = 0
+        configured_pool_size = os.getenv("PLEXUS_TACTUS_RUNTIME_POOL_SIZE", "8")
+        try:
+            self._max_runtime_pool_size = max(1, int(configured_pool_size))
+        except ValueError:
+            self._max_runtime_pool_size = 8
 
     @classmethod
     async def create(cls, **parameters) -> "TactusScore":
         """Factory method for async initialization."""
-        instance = cls(**parameters)
-        await instance._setup_runtime()
-        return instance
+        return cls(**parameters)
 
-    async def _setup_runtime(self):
-        """Initialize Tactus runtime with in-process execution."""
-        # Use MemoryStorage for stateless score execution
-        # (each prediction is independent, no need for persistence)
+    def _create_runtime(self) -> TactusRuntime:
+        """Create a runtime instance for pool use."""
         storage = MemoryStorage()
-
-        self._runtime = TactusRuntime(
+        runtime = TactusRuntime(
             procedure_id=self.parameters.name or "tactus_score",
             storage_backend=storage,
             openai_api_key=self._get_openai_api_key(),
@@ -118,12 +124,69 @@ class TactusScore(Score):
             verbosity=self.parameters.verbosity,
             max_tokens=self.parameters.max_tokens,
             temperature=self.parameters.temperature,
+            reset_state_on_execute=True,
         )
-        logger.info(f"TactusScore initialized for '{self.parameters.name}'")
+        logger.info(f"TactusScore created runtime for '{self.parameters.name}'")
+        return runtime
+
+    async def _acquire_runtime(self) -> TactusRuntime:
+        """Borrow a runtime from the pool, creating one if capacity allows."""
+        if self._strict_runtime_isolation:
+            return await asyncio.to_thread(self._create_runtime)
+
+        should_create = False
+        async with self._pool_condition:
+            if self._runtime_pool:
+                return self._runtime_pool.pop()
+            if self._active_runtimes < self._max_runtime_pool_size:
+                self._active_runtimes += 1
+                should_create = True
+            else:
+                await self._pool_condition.wait_for(lambda: bool(self._runtime_pool))
+                return self._runtime_pool.pop()
+
+        if should_create:
+            try:
+                return await asyncio.to_thread(self._create_runtime)
+            except Exception:
+                async with self._pool_condition:
+                    self._active_runtimes = max(0, self._active_runtimes - 1)
+                    self._pool_condition.notify()
+                raise
+
+        # Should be unreachable but keeps return type explicit.
+        raise RuntimeError("Failed to acquire runtime from pool")
+
+    async def _release_runtime(self, runtime: TactusRuntime) -> None:
+        """Return a runtime to the pool for reuse."""
+        if self._strict_runtime_isolation:
+            return
+        async with self._pool_condition:
+            self._runtime_pool.append(runtime)
+            self._pool_condition.notify()
+
+    @staticmethod
+    def _execute_runtime_sync(
+        runtime: TactusRuntime,
+        code: str,
+        tactus_context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Execute a runtime call inside a dedicated thread event loop.
+
+        Tactus runtime execution can be heavily synchronous before first await;
+        running it in threads allows true parallel score execution.
+        """
+        return asyncio.run(
+            runtime.execute(
+                code,
+                context=tactus_context,
+                format="lua",
+            )
+        )
 
     def _get_openai_api_key(self) -> Optional[str]:
         """Get OpenAI API key from environment if available."""
-        import os
         return os.environ.get("OPENAI_API_KEY")
 
     def _parse_metadata_json_strings(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
@@ -204,20 +267,8 @@ class TactusScore(Score):
         Score.Result
             The prediction result with value and explanation
         """
-        # Create a fresh runtime for each prediction
-        # TactusRuntime holds state that doesn't reset cleanly between executions
-        storage = MemoryStorage()
-        log_handler = CostCollectorLogHandler()
-        runtime = TactusRuntime(
-            procedure_id=self.parameters.name or "tactus_score",
-            storage_backend=storage,
-            openai_api_key=self._get_openai_api_key(),
-            log_handler=log_handler,
-            reasoning_effort=self.parameters.reasoning_effort,
-            verbosity=self.parameters.verbosity,
-            max_tokens=self.parameters.max_tokens,
-            temperature=self.parameters.temperature,
-        )
+        runtime = await self._acquire_runtime()
+        runtime.log_handler = CostCollectorLogHandler()
 
         try:
             # Build execution context for Tactus
@@ -234,11 +285,13 @@ class TactusScore(Score):
                 tactus_context['results'] = self._convert_results(model_input.results)
 
             # Execute the Tactus procedure
+            logger.info(f"Executing Tactus procedure with text preview: {model_input.text[:100]}...")
             logger.debug(f"Executing Tactus procedure with context keys: {list(tactus_context.keys())}")
-            result = await runtime.execute(
+            result = await asyncio.to_thread(
+                self._execute_runtime_sync,
+                runtime,
                 self.parameters.code,
-                context=tactus_context,
-                format="lua"
+                tactus_context,
             )
 
             # Extract value from result
@@ -254,6 +307,8 @@ class TactusScore(Score):
                 value = str(procedure_output)
                 explanation = None
                 confidence = None
+
+            logger.info(f"Tactus returned value: {value}, explanation preview: {str(explanation)[:100] if explanation else 'None'}...")
 
             # Validate required output
             if value is None:
@@ -286,6 +341,8 @@ class TactusScore(Score):
                 value='ERROR',
                 error=str(e)
             )
+        finally:
+            await self._release_runtime(runtime)
 
     def _record_tactus_costs(self, tactus_result: Dict[str, Any]) -> None:
         """

--- a/plexus/scores/TactusScore.py
+++ b/plexus/scores/TactusScore.py
@@ -98,15 +98,20 @@ class TactusScore(Score):
         Score.__init__(self, **parameters)
         self.parameters = self.Parameters(**parameters)
         isolation_mode = os.getenv("PLEXUS_TACTUS_RUNTIME_ISOLATION_MODE", "strict").lower()
-        self._strict_runtime_isolation = isolation_mode != "reuse"
-        self._runtime_pool: List[TactusRuntime] = []
-        self._pool_condition = asyncio.Condition()
+        self._runtime_isolation_mode = "reuse" if isolation_mode == "reuse" else "strict"
+        self._runtime_pool: Optional[List[TactusRuntime]] = None
+        self._pool_condition: Optional[asyncio.Condition] = None
         self._active_runtimes = 0
-        configured_pool_size = os.getenv("PLEXUS_TACTUS_RUNTIME_POOL_SIZE", "8")
-        try:
-            self._max_runtime_pool_size = max(1, int(configured_pool_size))
-        except ValueError:
-            self._max_runtime_pool_size = 8
+        self._max_runtime_pool_size = 0
+
+        if self._runtime_isolation_mode == "reuse":
+            self._runtime_pool = []
+            self._pool_condition = asyncio.Condition()
+            configured_pool_size = os.getenv("PLEXUS_TACTUS_RUNTIME_POOL_SIZE", "8")
+            try:
+                self._max_runtime_pool_size = max(1, int(configured_pool_size))
+            except ValueError:
+                self._max_runtime_pool_size = 8
 
     @classmethod
     async def create(cls, **parameters) -> "TactusScore":
@@ -126,14 +131,19 @@ class TactusScore(Score):
             temperature=self.parameters.temperature,
             reset_state_on_execute=True,
         )
-        logger.info(f"TactusScore created runtime for '{self.parameters.name}'")
+        logger.debug("Created Tactus runtime for '%s'", self.parameters.name)
         return runtime
 
     async def _acquire_runtime(self) -> TactusRuntime:
         """Borrow a runtime from the pool, creating one if capacity allows."""
-        if self._strict_runtime_isolation:
+        if self._runtime_isolation_mode == "strict":
             return await asyncio.to_thread(self._create_runtime)
+        return await self._acquire_pooled_runtime()
 
+    async def _acquire_pooled_runtime(self) -> TactusRuntime:
+        """Borrow a reusable runtime, creating one if pool capacity allows."""
+        if self._pool_condition is None or self._runtime_pool is None:
+            raise RuntimeError("Runtime pool is not initialized")
         should_create = False
         async with self._pool_condition:
             if self._runtime_pool:
@@ -159,8 +169,10 @@ class TactusScore(Score):
 
     async def _release_runtime(self, runtime: TactusRuntime) -> None:
         """Return a runtime to the pool for reuse."""
-        if self._strict_runtime_isolation:
+        if self._runtime_isolation_mode == "strict":
             return
+        if self._pool_condition is None or self._runtime_pool is None:
+            raise RuntimeError("Runtime pool is not initialized")
         async with self._pool_condition:
             self._runtime_pool.append(runtime)
             self._pool_condition.notify()
@@ -222,7 +234,7 @@ class TactusScore(Score):
                 try:
                     parsed_inner = json.loads(metadata['metadata'])
                     parsed['metadata'] = parsed_inner
-                    logger.info(
+                    logger.debug(
                         "Parsed nested metadata JSON string, got keys: "
                         f"{list(parsed_inner.keys()) if isinstance(parsed_inner, dict) else 'N/A'}"
                     )
@@ -230,7 +242,7 @@ class TactusScore(Score):
                     logger.warning(f"Failed to parse nested metadata JSON: {e}")
             elif isinstance(metadata['metadata'], dict):
                 # metadata.metadata is already a dict
-                logger.info("Found nested metadata dict, preserving outer metadata")
+                logger.debug("Found nested metadata dict, preserving outer metadata")
                 parsed['metadata'] = metadata['metadata'].copy()
 
         # Common fields that are JSON strings in Plexus metadata
@@ -240,12 +252,21 @@ class TactusScore(Score):
             if field in parsed and isinstance(parsed[field], str):
                 try:
                     parsed[field] = json.loads(parsed[field])
-                    logger.info(f"Parsed JSON string for metadata field '{field}', type={type(parsed[field])}, length={len(parsed[field]) if isinstance(parsed[field], (list, dict)) else 'N/A'}")
+                    logger.debug(
+                        "Parsed JSON string for metadata field '%s', type=%s, length=%s",
+                        field,
+                        type(parsed[field]),
+                        len(parsed[field]) if isinstance(parsed[field], (list, dict)) else "N/A",
+                    )
                 except json.JSONDecodeError as e:
                     logger.warning(f"Failed to parse JSON in metadata field '{field}': {e}")
                     # Keep the original string if parsing fails
             elif field in parsed:
-                logger.info(f"Metadata field '{field}' exists but is type {type(parsed[field])}, not a string")
+                logger.debug(
+                    "Metadata field '%s' exists but is type %s, not a string",
+                    field,
+                    type(parsed[field]),
+                )
 
         return parsed
 
@@ -285,8 +306,11 @@ class TactusScore(Score):
                 tactus_context['results'] = self._convert_results(model_input.results)
 
             # Execute the Tactus procedure
-            logger.info(f"Executing Tactus procedure with text preview: {model_input.text[:100]}...")
-            logger.debug(f"Executing Tactus procedure with context keys: {list(tactus_context.keys())}")
+            logger.debug(
+                "Executing Tactus procedure for score '%s' with context keys: %s",
+                self.parameters.name,
+                list(tactus_context.keys()),
+            )
             result = await asyncio.to_thread(
                 self._execute_runtime_sync,
                 runtime,
@@ -308,7 +332,7 @@ class TactusScore(Score):
                 explanation = None
                 confidence = None
 
-            logger.info(f"Tactus returned value: {value}, explanation preview: {str(explanation)[:100] if explanation else 'None'}...")
+            logger.debug("Tactus returned value '%s' for score '%s'", value, self.parameters.name)
 
             # Validate required output
             if value is None:

--- a/plexus/scores/test_tactus_score_runtime_controls.py
+++ b/plexus/scores/test_tactus_score_runtime_controls.py
@@ -1,4 +1,6 @@
 import importlib
+import time
+import asyncio
 
 import pytest
 
@@ -37,3 +39,163 @@ async def test_tactus_score_passes_runtime_gpt5_controls_to_prediction_runtime(m
     assert captured["verbosity"] == "medium"
     assert captured["max_tokens"] == 1200
     assert captured["temperature"] == 0.0
+    assert captured["reset_state_on_execute"] is True
+
+
+@pytest.mark.asyncio
+async def test_tactus_score_uses_fresh_runtime_per_prediction_by_default(monkeypatch):
+    seen_runtime_ids = []
+
+    class FakeRuntime:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            seen_runtime_ids.append(id(self))
+
+        async def execute(self, code, context, format):
+            return {
+                "result": {
+                    "value": context["text"],
+                    "explanation": f"echo:{context['text']}",
+                }
+            }
+
+    module = importlib.import_module("plexus.scores.TactusScore")
+    monkeypatch.setattr(module, "TactusRuntime", FakeRuntime)
+
+    score = TactusScore(
+        name="Reused Runtime",
+        code='default_model "openai/gpt-5.4-nano"\nClassifyProcedure {}',
+        valid_classes=["alpha", "beta"],
+    )
+
+    first = await score.predict(Score.Input(text="alpha", metadata={}))
+    second = await score.predict(Score.Input(text="beta", metadata={}))
+
+    assert first.value == "alpha"
+    assert second.value == "beta"
+    assert len(seen_runtime_ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_tactus_score_can_reuse_runtime_when_explicitly_enabled(monkeypatch):
+    seen_runtime_ids = []
+
+    class FakeRuntime:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            seen_runtime_ids.append(id(self))
+
+        async def execute(self, code, context, format):
+            return {
+                "result": {
+                    "value": context["text"],
+                    "explanation": f"echo:{context['text']}",
+                }
+            }
+
+    monkeypatch.setenv("PLEXUS_TACTUS_RUNTIME_ISOLATION_MODE", "reuse")
+    module = importlib.import_module("plexus.scores.TactusScore")
+    monkeypatch.setattr(module, "TactusRuntime", FakeRuntime)
+
+    score = TactusScore(
+        name="Reused Runtime",
+        code='default_model "openai/gpt-5.4-nano"\nClassifyProcedure {}',
+        valid_classes=["alpha", "beta"],
+    )
+
+    first = await score.predict(Score.Input(text="alpha", metadata={}))
+    second = await score.predict(Score.Input(text="beta", metadata={}))
+
+    assert first.value == "alpha"
+    assert second.value == "beta"
+    assert len(seen_runtime_ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_tactus_score_runtime_pool_allows_parallel_predictions(monkeypatch):
+    seen_runtime_ids = []
+
+    class FakeRuntime:
+        def __init__(self, **kwargs):
+            seen_runtime_ids.append(id(self))
+            self.agents = {}
+            self.log_handler = None
+            self.storage_backend = None
+            self.tool_primitive = None
+            self.message_history_manager = None
+
+        async def execute(self, code, context, format):
+            await asyncio.sleep(0.05)
+            return {
+                "result": {
+                    "value": context["text"],
+                    "explanation": f"echo:{context['text']}",
+                }
+            }
+
+    monkeypatch.setenv("PLEXUS_TACTUS_RUNTIME_POOL_SIZE", "2")
+    module = importlib.import_module("plexus.scores.TactusScore")
+    monkeypatch.setattr(module, "TactusRuntime", FakeRuntime)
+
+    score = TactusScore(
+        name="Runtime Pool",
+        code='default_model "openai/gpt-5.4-nano"\nClassifyProcedure {}',
+        valid_classes=["a", "b"],
+    )
+
+    start = time.perf_counter()
+    first, second = await asyncio.gather(
+        score.predict(Score.Input(text="a", metadata={})),
+        score.predict(Score.Input(text="b", metadata={})),
+    )
+    elapsed = time.perf_counter() - start
+
+    assert first.value == "a"
+    assert second.value == "b"
+    assert len(seen_runtime_ids) == 2
+    assert elapsed < 0.09
+
+
+@pytest.mark.asyncio
+async def test_tactus_score_parallel_predictions_with_blocking_runtime_execute(monkeypatch):
+    seen_runtime_ids = []
+
+    class FakeRuntime:
+        def __init__(self, **kwargs):
+            seen_runtime_ids.append(id(self))
+            self.agents = {}
+            self.log_handler = None
+            self.storage_backend = None
+            self.tool_primitive = None
+            self.message_history_manager = None
+
+        async def execute(self, code, context, format):
+            time.sleep(0.05)
+            return {
+                "result": {
+                    "value": context["text"],
+                    "explanation": f"echo:{context['text']}",
+                }
+            }
+
+    monkeypatch.setenv("PLEXUS_TACTUS_RUNTIME_POOL_SIZE", "2")
+    module = importlib.import_module("plexus.scores.TactusScore")
+    monkeypatch.setattr(module, "TactusRuntime", FakeRuntime)
+
+    score = TactusScore(
+        name="Runtime Pool Blocking Execute",
+        code='default_model "openai/gpt-5.4-nano"\nClassifyProcedure {}',
+        valid_classes=["a", "b"],
+    )
+
+    start = time.perf_counter()
+    first, second = await asyncio.gather(
+        score.predict(Score.Input(text="a", metadata={})),
+        score.predict(Score.Input(text="b", metadata={})),
+    )
+    elapsed = time.perf_counter() - start
+
+    assert first.value == "a"
+    assert second.value == "b"
+    assert len(seen_runtime_ids) == 2
+    assert elapsed < 0.095

--- a/poetry.lock
+++ b/poetry.lock
@@ -9306,14 +9306,14 @@ py-cpuinfo = "*"
 
 [[package]]
 name = "tactus"
-version = "0.50.0"
+version = "0.51.1"
 description = "Tactus: Lua-based DSL for agentic workflows"
 optional = false
 python-versions = "<3.14,>=3.10"
 groups = ["main"]
 files = [
-    {file = "tactus-0.50.0-py3-none-any.whl", hash = "sha256:1138b0077a969c9691fa31949ed0f17764754681f917cbad44c072939083855b"},
-    {file = "tactus-0.50.0.tar.gz", hash = "sha256:f61050f1109feed7427f3cd9fd9aac3e02fb9a1d27161cc88e611c56d85d4f2e"},
+    {file = "tactus-0.51.1-py3-none-any.whl", hash = "sha256:fca5c6a96b402a05277a0ddd21a592ec6f63de42ff99c569c980973e0cfdf647"},
+    {file = "tactus-0.51.1.tar.gz", hash = "sha256:18e73aacd4c69c3e79aa6bcd7d8c5bfa04f305f72b791e284e08f2ecd84e3814"},
 ]
 
 [package.dependencies]
@@ -10802,4 +10802,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "022a4f5ad4e1124d0bbf2bae8060d07692a25ce3f8abf271204897052043bbce"
+content-hash = "595b6005afa49acf8e5b11b84b5007ef6c9ae9d890375608723ef773cac9dc41"

--- a/project/events/2026-05-18T21:29:52.631Z__fe6c22ed-a7b6-47d7-89ca-ad920f281078.json
+++ b/project/events/2026-05-18T21:29:52.631Z__fe6c22ed-a7b6-47d7-89ca-ad920f281078.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "fe6c22ed-a7b6-47d7-89ca-ad920f281078",
+  "issue_id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-18T21:29:52.631Z",
+  "actor_id": "derek",
+  "payload": {
+    "assignee": null,
+    "description": "",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-e923c4a1-aa01-434c-a5a8-4122d916b85d",
+    "priority": 1,
+    "status": "open",
+    "title": "Fix Tactus evaluation persistence repeating first result across score runs"
+  }
+}

--- a/project/events/2026-05-18T21:29:55.908Z__9a8b44e9-924e-492a-b019-6770b32984ba.json
+++ b/project/events/2026-05-18T21:29:55.908Z__9a8b44e9-924e-492a-b019-6770b32984ba.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "9a8b44e9-924e-492a-b019-6770b32984ba",
+  "issue_id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T21:29:55.908Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "30a388ea-d78c-4be1-8e0f-295e3b18ba29"
+  }
+}

--- a/project/events/2026-05-18T21:29:55.948Z__49ae1853-1079-4c26-b645-06560948bb18.json
+++ b/project/events/2026-05-18T21:29:55.948Z__49ae1853-1079-4c26-b645-06560948bb18.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "49ae1853-1079-4c26-b645-06560948bb18",
+  "issue_id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-18T21:29:55.948Z",
+  "actor_id": "derek",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-18T21:37:03.738Z__6111b5e0-7e21-46ac-bbf8-b05ce8332f41.json
+++ b/project/events/2026-05-18T21:37:03.738Z__6111b5e0-7e21-46ac-bbf8-b05ce8332f41.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6111b5e0-7e21-46ac-bbf8-b05ce8332f41",
+  "issue_id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T21:37:03.738Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "3c40e572-9643-4f08-bdd5-6a21a362ec39"
+  }
+}

--- a/project/events/2026-05-18T21:41:21.954Z__27d03f84-80de-4c44-b560-31b7dd170daf.json
+++ b/project/events/2026-05-18T21:41:21.954Z__27d03f84-80de-4c44-b560-31b7dd170daf.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "27d03f84-80de-4c44-b560-31b7dd170daf",
+  "issue_id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T21:41:21.954Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "a3576a83-bd85-4bfd-8d15-5eb720196760"
+  }
+}

--- a/project/events/2026-05-18T21:49:07.377Z__07fa4122-da9a-4517-89d1-7eddae4a1793.json
+++ b/project/events/2026-05-18T21:49:07.377Z__07fa4122-da9a-4517-89d1-7eddae4a1793.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "07fa4122-da9a-4517-89d1-7eddae4a1793",
+  "issue_id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T21:49:07.377Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "89cfa324-9910-49a8-8dca-b9b9c71d3b38"
+  }
+}

--- a/project/events/2026-05-18T21:53:36.466Z__1a776e0f-939c-4deb-a0d6-e1ec6d60668e.json
+++ b/project/events/2026-05-18T21:53:36.466Z__1a776e0f-939c-4deb-a0d6-e1ec6d60668e.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "1a776e0f-939c-4deb-a0d6-e1ec6d60668e",
+  "issue_id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T21:53:36.466Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "73f2d6a6-9989-4a21-b0b5-7e75d70d62f7"
+  }
+}

--- a/project/events/2026-05-18T21:57:43.274Z__8b07e689-0cee-4819-a7c2-514a232b8e17.json
+++ b/project/events/2026-05-18T21:57:43.274Z__8b07e689-0cee-4819-a7c2-514a232b8e17.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "8b07e689-0cee-4819-a7c2-514a232b8e17",
+  "issue_id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-18T21:57:43.274Z",
+  "actor_id": "derek",
+  "payload": {
+    "comment_author": "derek",
+    "comment_id": "d8f2fa35-fbf7-4fd1-bd08-437bab7c710c"
+  }
+}

--- a/project/issues/plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967.json
+++ b/project/issues/plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967.json
@@ -1,0 +1,55 @@
+{
+  "id": "plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967",
+  "title": "Fix Tactus evaluation persistence repeating first result across score runs",
+  "description": "",
+  "type": "bug",
+  "status": "in_progress",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-e923c4a1-aa01-434c-a5a8-4122d916b85d",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "30a388ea-d78c-4be1-8e0f-295e3b18ba29",
+      "author": "derek",
+      "text": "Investigating regression after speed changes in plexus/Scorecard.py and plexus/scores/TactusScore.py. Symptom: LLM calls appear distinct but dashboard records repeat first result. Candidate root cause: reusing TactusRuntime across predictions despite prior note that runtime state does not reset cleanly.",
+      "created_at": "2026-05-18T21:29:55.907910765Z"
+    },
+    {
+      "id": "3c40e572-9643-4f08-bdd5-6a21a362ec39",
+      "author": "derek",
+      "text": "Root-cause analysis: the optimized path reused a single TactusRuntime instance per score. In Tactus runtime, procedure state is preloaded from storage on each execute; with MemoryStorage bound to a stable procedure_id this allows cross-call state carry-over. Implemented targeted fix in plexus/scores/TactusScore.py: keep score instance caching, but create a fresh runtime per prediction (isolated MemoryStorage), and construct it via asyncio.to_thread to reduce event-loop blocking. Added regression test in plexus/scores/test_tactus_score_runtime_controls.py ensuring two predictions use distinct runtime instances and preserve distinct outputs. Validation run: ./.venv/bin/python -m pytest -q plexus/scores/test_tactus_score_runtime_controls.py (pass), and ./.venv/bin/python -m pytest -q plexus/Scorecard_test.py -k cleans_up_score_instance (pass).",
+      "created_at": "2026-05-18T21:37:03.738745568Z"
+    },
+    {
+      "id": "a3576a83-bd85-4bfd-8d15-5eb720196760",
+      "author": "derek",
+      "text": "Implemented reuse-safe speed path in TactusScore: restored cached runtime reuse with a per-prediction reset hook. Before each execute we now clear execution-scoped storage state (when present), clear runtime message history, reset tool primitive state, clear agent history, and refresh cached agent _context to the current tactus context. This preserves one-time runtime setup speed while preventing stale-context cross-call bleed that produced repeated first-result persistence. Added/updated tests in plexus/scores/test_tactus_score_runtime_controls.py: (1) runtime controls still flow through; (2) runtime is reused across predictions; (3) reused runtime refreshes agent context so second prediction returns second input instead of repeating first. Validation: ./.venv/bin/python -m pytest -q plexus/scores/test_tactus_score_runtime_controls.py (3 passed), ./.venv/bin/python -m pytest -q plexus/Scorecard_test.py -k cleans_up_score_instance (pass).",
+      "created_at": "2026-05-18T21:41:21.954763573Z"
+    },
+    {
+      "id": "89cfa324-9910-49a8-8dca-b9b9c71d3b38",
+      "author": "derek",
+      "text": "Added concrete tracing + hardening to isolate repeated-result source without assumptions. In Evaluation.score_text: force score_result.parameters.id from active score_config when missing and log per-score persistence payload dimensions (score_name, score_id, value, explanation) immediately before ScoreResult creation. In Evaluation._create_score_result: added fallback scoreId resolution by score name from loaded scorecard configs and explicit logging of scoreName/scoreId sent to GraphQL. In Scorecard.get_score_result: deep-copy registry score config to avoid shared-mutation aliasing and switched score-instance cache key from score name to stable score ID (fallback name) with cache-key logging. Local validation pass: tactus runtime controls tests (3), scorecard cache/cleanup subset (1), evaluation score_text linkage subset (2).",
+      "created_at": "2026-05-18T21:49:07.377084469Z"
+    },
+    {
+      "id": "73f2d6a6-9989-4a21-b0b5-7e75d70d62f7",
+      "author": "derek",
+      "text": "Corrective update per user feedback: reverted the unrequested fallback-style changes in Evaluation/Scorecard, and removed single-runtime serialization in TactusScore. New approach is pooled runtime reuse in TactusScore (configurable via PLEXUS_TACTUS_RUNTIME_POOL_SIZE, default 8): borrow runtime, reset execution-scoped state/context, execute, return runtime to pool. This restores concurrency while keeping reuse speed and preserving non-repeated explanations. Added test coverage for pool parallelism in plexus/scores/test_tactus_score_runtime_controls.py (concurrent predictions complete in parallel and create 2 runtimes when pool size=2). Validation runs passed for TactusScore tests + selected Scorecard/Evaluation tests in ./.venv.",
+      "created_at": "2026-05-18T21:53:36.466528031Z"
+    },
+    {
+      "id": "d8f2fa35-fbf7-4fd1-bd08-437bab7c710c",
+      "author": "derek",
+      "text": "Moved the correctness fix into Tactus package (proper layer): patched /home/derek/projects/Tactus/tactus/core/runtime.py so reused agents are refreshed each execute (context/state/tool bindings + history clear), and added runtime option reset_state_on_execute=True to clear persisted mutable state per run. Updated Plexus TactusScore to use this official runtime option and removed direct runtime-internals reset logic. Kept runtime pool concurrency in TactusScore for speed. Installed editable Tactus into Plexus venv (pip install -e ../Tactus) and confirmed runtime import path points to /home/derek/projects/Tactus/tactus/core/runtime.py. Validation: tactus score runtime tests pass (3), scorecard cleanup subset pass (1).",
+      "created_at": "2026-05-18T21:57:43.274843981Z"
+    }
+  ],
+  "created_at": "2026-05-18T21:29:52.631344120Z",
+  "updated_at": "2026-05-18T21:57:43.274843981Z",
+  "closed_at": null,
+  "custom": {}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ langgraph = "0.6.7"
 "langgraph-checkpoint-postgres" = "2.0.9"
 psycopg = { version = ">=3.2.0,<4.0.0", extras = ["binary"] }
 lupa = "2.7"
-tactus = "^0.50.0"
+tactus = "^0.51.1"
 openpyxl = "3.1.5"
 rapidfuzz = "3.9.4"
 datasets = "*"


### PR DESCRIPTION
**Summary**
- restore parallel score execution in `plexus/Scorecard.py` by processing dependency-ready score nodes concurrently
- harden `plexus/scores/TactusScore.py` for no-bleed execution by defaulting to strict per-prediction runtime isolation and running runtime execution in worker threads for throughput
- keep optional runtime reuse mode behind explicit opt-in (`PLEXUS_TACTUS_RUNTIME_ISOLATION_MODE=reuse`)
- reduce noisy operational logging in `TactusScore` and simplify isolation/pool flow for readability
- add/update regression coverage in:
  - `plexus/scores/test_tactus_score_runtime_controls.py`
  - `plexus/Scorecard_test.py`
- bump Tactus dependency to `^0.51.1` and regenerate lock file:
  - `pyproject.toml`
  - `poetry.lock`
- include required Kanbus artifact updates under `project/events/` and `project/issues/`

**Why**
- fixes two production-critical issues in tandem: duplicate/bleed behavior under load and loss of high-throughput scoring speed
- ensures execution isolation by construction for Tactus score runs while preserving parallelism
- aligns Plexus dependency with the released Tactus runtime hardening changes

**Validation**
- `./.venv/bin/pytest -q plexus/scores/test_tactus_score_runtime_controls.py`
- `./.venv/bin/pytest -q plexus/Scorecard_test.py -k "parallel or score_entire_text"`

**Expected Outcome**
- Tactus-backed scores run fast in parallel for dependency-ready score nodes
- score outputs do not bleed across independent score executions
- Plexus resolves and locks against Tactus `0.51.1`

**Kanbus / Task Tracking**
- `plx-ed9c4f64-ff75-4d74-9701-c1e95f0b6967`
