### PR TITLE
fix: remove unreachable runtime pool fallback in TactusScore

### DIFF
--- a/plexus/scores/TactusScore.py
+++ b/plexus/scores/TactusScore.py
@@ -164,9 +164,6 @@ class TactusScore(Score):
                     self._pool_condition.notify()
                 raise
 
-        # Should be unreachable but keeps return type explicit.
-        raise RuntimeError("Failed to acquire runtime from pool")
-
     async def _release_runtime(self, runtime: TactusRuntime) -> None:
         """Return a runtime to the pool for reuse."""
         if self._runtime_isolation_mode == "strict":


### PR DESCRIPTION
## Summary
- remove unreachable fallback raise in `TactusScore._acquire_pooled_runtime`
- keep runtime-pool acquire logic unchanged (strict mode and pooled mode behavior are unaffected)

## Why
`github-code-quality` flagged the final fallback raise as unreachable. All valid control-flow paths in this method already return or raise.

## Validation
- `poetry run python -m py_compile plexus/scores/TactusScore.py`

## Impact
- no behavior change
- resolves static-analysis/code-quality warning
