### PR TITLE
feat(score-result): add quote timestamp fields (start_time_seconds, end_time_seconds)

### DIFF
--- a/dashboard/amplify/data/resource.ts
+++ b/dashboard/amplify/data/resource.ts
@@ -390,6 +390,8 @@ const schema = a.schema({
             value: a.string().required(),
             explanation: a.string(),
             confidence: a.float(),
+            startTimeSeconds: a.float(),
+            endTimeSeconds: a.float(),
             metadata: a.json(),
             trace: a.json(),
             correct: a.boolean(),

--- a/plexus/dashboard/api/models/score_result.py
+++ b/plexus/dashboard/api/models/score_result.py
@@ -89,6 +89,8 @@ class ScoreResult(BaseModel):
     status: Optional[str] = 'COMPLETED'  # Status of score result: "COMPLETED", "ERROR", etc.
     createdAt: Optional[datetime] = None
     updatedAt: Optional[datetime] = None
+    start_time_seconds: Optional[float] = None
+    end_time_seconds: Optional[float] = None
 
     def __init__(
         self,
@@ -115,6 +117,8 @@ class ScoreResult(BaseModel):
         status: Optional[str] = 'COMPLETED',
         createdAt: Optional[datetime] = None,
         updatedAt: Optional[datetime] = None,
+        start_time_seconds: Optional[float] = None,
+        end_time_seconds: Optional[float] = None,
         client: Optional['_BaseAPIClient'] = None
     ):
         super().__init__(id, client)
@@ -140,6 +144,8 @@ class ScoreResult(BaseModel):
         self.status = status
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+        self.start_time_seconds = start_time_seconds
+        self.end_time_seconds = end_time_seconds
     
     @property
     def scoreName(self) -> Optional[str]:
@@ -185,6 +191,8 @@ class ScoreResult(BaseModel):
             status
             createdAt
             updatedAt
+            startTimeSeconds
+            endTimeSeconds
         """
 
     @classmethod
@@ -263,6 +271,8 @@ class ScoreResult(BaseModel):
             status=data.get('status'),
             createdAt=created_at,
             updatedAt=updated_at,
+            start_time_seconds=data.get('startTimeSeconds'),
+            end_time_seconds=data.get('endTimeSeconds'),
             client=client
         )
 

--- a/plexus/scores/Score.py
+++ b/plexus/scores/Score.py
@@ -209,7 +209,9 @@ class Score(ABC,
         parameters: 'Score.Parameters'
         value:      Union[str, bool]
         explanation: Optional[str] = None
-        confidence:  Optional[float] = None
+        confidence:          Optional[float] = None
+        start_time_seconds:  Optional[float] = None
+        end_time_seconds:    Optional[float] = None
         metadata:   dict = {}
         error:      Optional[str] = None
         code:       Optional[str] = None


### PR DESCRIPTION
## Summary

Adds two new first-class fields to `ScoreResult` and `Score.Result` to store the start and end timestamps of the audio quote that supports a score's answer/explanation.

- **`start_time_seconds`** — start position (in seconds) of the supporting quote within the audio
- **`end_time_seconds`** — end position (in seconds) of the supporting quote within the audio

These fields are on par with `value`, `explanation`, and `confidence`. The `_seconds` suffix makes the unit explicit and avoids ambiguity.

## Changes

- **`dashboard/amplify/data/resource.ts`** — adds `startTimeSeconds` and `endTimeSeconds` (`a.float()`) to the `ScoreResult` Amplify Gen2 schema, making them available in the GraphQL API
- **`plexus/dashboard/api/models/score_result.py`** — adds `start_time_seconds` / `end_time_seconds` to the Python `ScoreResult` dataclass, `__init__`, `fields()` GraphQL query, and `from_dict()`
- **`plexus/scores/Score.py`** — adds `start_time_seconds` / `end_time_seconds` to `Score.Result` (the local scoring output model)

## Backwards Compatibility

Both fields are `Optional[float]` with a default of `None`, so existing code that doesn't populate them continues to work without changes.

## Test plan

- [ ] Deploy Amplify schema and confirm `startTimeSeconds` / `endTimeSeconds` appear in the generated GraphQL schema
- [ ] Verify a score that populates `start_time_seconds` / `end_time_seconds` on `Score.Result` has those values reflected in the stored `ScoreResult`
- [ ] Confirm existing scores that don't set these fields continue to work (values are `null`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)