### PR TITLE
Document agent internal research (docs_list / DocumentationRepository)

### DIFF
--- a/.cursor/rules/plexus-mcp.mdc
+++ b/.cursor/rules/plexus-mcp.mdc
@@ -20,6 +20,12 @@ return plexus.docs.list({})
 return plexus.docs.get({ key = "mcp.execute-tactus-overview" })
 ```
 
+## Internal research
+
+Use progressive disclosure: `docs_list` for metadata summaries, then
+`docs_get{ id = "..." }` for one full topic. No semantic search. Cookbook:
+`repo-workflows.internal-research` or [`skills/internal-research/SKILL.md`](mdc:skills/internal-research/SKILL.md).
+
 ## Where to read more
 
 - Top-level rules and Git Flow: [`AGENTS.md`](mdc:AGENTS.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,31 @@ not diagnose runs from dispatcher state alone.
 - **Report persistence.** ReportBlock output goes to S3 attachments;
 DynamoDB stores only a compact metadata envelope.
 
-## How agents discover documentation
+## Internal research (agent knowledge base)
+
+Before guessing how a feature works, research the indexed docs in two
+steps (progressive disclosure):
+
+1. **`plexus.docs.list`** — metadata only (`id`, `title`, `summary`,
+   `namespace`, `tags`, `related`). Cheap; safe to call often.
+2. **`plexus.docs.get`** — full markdown body for one canonical `id`.
+
+```lua
+return plexus.docs.list({ namespace = "score-authoring" })
+return plexus.docs.get({ key = "repo-workflows.internal-research" })
+```
+
+There is no semantic search over agent docs; filter by namespace and
+read summaries, then follow `related` links. The Python implementation
+is `plexus/documentation/repository.py` (`DocumentationRepository`).
+Canonical cookbook: load topic `repo-workflows.internal-research` via
+`plexus.docs.get`, or read `skills/internal-research/SKILL.md` when not
+using MCP.
+
+Scorecard **rubric memory** (Biblicus corpora under `*.knowledge-base/`)
+is a separate system — see `score-authoring.rubric-memory`, not agent KB.
+
+## How agents discover APIs and documentation
 
 Plexus exposes a single MCP tool: `**execute_tactus`**. Inside that tool,
 all functionality is accessed through the injected `plexus.`* runtime.
@@ -44,7 +68,7 @@ return plexus.docs.list({})
 return plexus.docs.list({ namespace = "score-authoring" })
 
 -- Load a topic by its canonical id.
-return plexus.docs.get({ id = "mcp.execute-tactus-overview" })
+return plexus.docs.get({ key = "mcp.execute-tactus-overview" })
 ```
 
 Each entry returned by `plexus.docs.list` carries `id`, `title`,

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The "Flywheel" of Plexus:
 Plexus is designed to be operated *by* AI agents as much as by humans. The `/MCP` directory contains a fully-featured Model Context Protocol server.
 
 - **AGENTS.md**: [Read the full Agent Integration Guide](AGENTS.md)
+- **Internal research**: Agent docs live under `documentation/agent/` and are queried via `plexus.docs.list` / `plexus.docs.get` inside `execute_tactus` (metadata first, then full topics by canonical id). See [skills/internal-research/SKILL.md](skills/internal-research/SKILL.md) and topic `repo-workflows.internal-research`.
 - **Capabilities**: Agents can read data, update configurations, run tests, and analyze results.
 - **Safety**: The system includes specialized "Agents" and "Skills" in `.claude/` to ensure safe operations (e.g., validating YAML before pushing).
 

--- a/documentation/agent/repo-workflows/_index.md
+++ b/documentation/agent/repo-workflows/_index.md
@@ -14,4 +14,8 @@ Kanbus, Git Flow, and local environment workflows used by humans and agents.
 
 ## Topics in this namespace
 
+- **internal-research** (`repo-workflows.internal-research`) — how to
+  run internal KB research via `docs_list` / `docs_get` and
+  `DocumentationRepository`.
+
 Use `plexus.docs.list({ namespace = "repo-workflows" })` to list every topic, then `plexus.docs.get({ key = "<id>" })` for the full doc.

--- a/documentation/agent/repo-workflows/internal-research.md
+++ b/documentation/agent/repo-workflows/internal-research.md
@@ -1,0 +1,122 @@
+---
+id: repo-workflows.internal-research
+title: Internal Research (Agent Knowledge Base)
+summary: How agents and scripts discover Plexus documentation via progressive disclosure (docs.list then docs.get).
+namespace: repo-workflows
+status: canonical
+disclosure: cookbook
+audience: agent
+tags: [docs, discovery, research, knowledge-base]
+related:
+  - mcp.discovery
+  - mcp.execute-tactus-overview
+  - repo-workflows._index
+---
+# Internal Research (Agent Knowledge Base)
+
+Plexus keeps agent-facing documentation in `documentation/agent/`. The
+runtime exposes it as a **frontmatter-indexed knowledge base**, not a
+semantic search engine. Research means listing metadata summaries,
+choosing canonical topic ids, then loading full bodies on demand.
+
+## Runtime API (inside `execute_tactus`)
+
+Use the injected helpers or the `plexus.docs` namespace. Both resolve
+to the same repository.
+
+```tactus
+-- 1. Bootstrap (cheap)
+local apis     = api_list()
+local overview = docs_get{ id = "mcp.execute-tactus-overview" }
+
+-- 2. Browse summaries only (no markdown bodies)
+local index = docs_list{}  -- all namespaces
+-- or:
+local score_docs = docs_list{ namespace = "score-authoring" }
+
+-- 3. Load one topic by canonical id
+local topic = docs_get{ id = "evaluation-feedback.optimizer-procedures" }
+return {
+  title   = topic.metadata.title,
+  related = topic.metadata.related,
+  body    = topic.content,
+}
+```
+
+`docs_list` / `plexus.docs.list` returns entries with `id`, `title`,
+`summary`, `namespace`, `status`, `disclosure`, `tags`, and `related`.
+`docs_get` / `plexus.docs.get` accepts `id` or `key` (same value).
+
+**Progressive disclosure:** always call `docs_list` first. Summaries are
+token-cheap. Call `docs_get` only for ids you intend to use. Follow
+`related` links for adjacent topics.
+
+**Namespaces:** `mcp`, `score-authoring`, `evaluation-feedback`,
+`procedures`, `reports`, `optimizer`, `repo-workflows`.
+
+**Excluded from listings:** `README.md` and `_index.md` files (fetch
+`_index` topics explicitly by id when you need a namespace overview).
+
+There is no full-text search API. Filter by:
+
+- `namespace` on `docs_list`
+- Reading `summary` and `tags` in list results
+- Matching substrings on `id` in Lua when you know a keyword
+- Walking `related` from a seed topic
+
+## Python API (local scripts and tests)
+
+The same index is implemented in
+`plexus/documentation/repository.py`:
+
+```python
+from pathlib import Path
+
+from plexus.documentation.repository import DocumentationRepository
+
+root = Path("documentation/agent")
+repo = DocumentationRepository(str(root))
+
+# Metadata only
+result = repo.list_docs(namespace="evaluation-feedback")
+for entry in result.entries:
+    print(entry["id"], entry["summary"])
+
+# Full document (metadata + body without frontmatter block)
+doc = repo.get_doc("mcp.discovery")
+print(doc.metadata["related"])
+print(doc.body[:500])
+```
+
+`list_docs` also reports `invalid` files (missing or malformed
+frontmatter) without failing the whole index.
+
+Behave coverage lives in `features/agent_documentation_kb.feature`.
+An end-to-end agent integration test wires `docs_list` / `docs_get` tools
+through the Tactus `AgentPrimitive` in
+`plexus/documentation/test_documentation_kb_integration.py` (marked
+`integration`, requires `OPENAI_API_KEY`).
+
+## Research workflow for a new task
+
+1. `docs_get{ id = "mcp.execute-tactus-overview" }` — runtime rules and
+   namespace map.
+2. `api_list()` — which `plexus.*` methods exist.
+3. `docs_list{ namespace = "<area>" }` — pick topics by summary/tags.
+4. `docs_get{ id = "<chosen-id>" }` — load bodies; chase `related`.
+5. Cite topic ids in your reply so humans can re-fetch the same sources.
+
+## Not the same as rubric-memory search
+
+Scorecard **rubric memory** uses Biblicus corpora under
+`*.knowledge-base/` folders (policy PDFs, emails, meeting notes). That
+path is documented in `score-authoring.rubric-memory` and uses
+`BiblicusRubricEvidenceRetriever`, not `DocumentationRepository`. Use
+agent KB research for Plexus product behavior; use rubric memory for
+score-specific policy evidence.
+
+## Human-readable tree
+
+Humans may browse `documentation/agent/` directly. Agents should prefer
+`docs_list` / `docs_get` so summaries stay consistent with runtime
+behavior.

--- a/skills/internal-research/SKILL.md
+++ b/skills/internal-research/SKILL.md
@@ -1,0 +1,55 @@
+# Internal research (agent knowledge base)
+
+Use this skill when you need to learn how Plexus works before changing
+code, running procedures, or answering architecture questions.
+
+## Do not
+
+- Read `documentation/agent/` markdown files directly unless the MCP
+  runtime is unavailable.
+- Invent documentation ids; every id comes from `docs_list` or `related`.
+- Assume semantic / vector search over agent docs (there is none).
+
+## Do
+
+1. Inside `execute_tactus`, run the progressive-disclosure pattern:
+
+```lua
+local overview = docs_get{ id = "mcp.execute-tactus-overview" }
+local index    = docs_list{ namespace = "<namespace-if-known>" }
+-- pick id from summaries, then:
+local topic    = docs_get{ id = "<canonical-id>" }
+return { overview = overview.content, topic = topic.content }
+```
+
+2. Load full canonical topic: `repo-workflows.internal-research`
+   (`plexus.docs.get({ key = "repo-workflows.internal-research" })`).
+
+3. For local Python (tests, one-off scripts):
+
+```python
+from plexus.documentation.repository import DocumentationRepository
+
+repo = DocumentationRepository("documentation/agent")
+print(repo.list_docs(namespace="mcp").entries)
+doc = repo.get_doc("mcp.discovery")
+```
+
+4. Cite the topic ids you relied on in your final answer.
+
+## Namespaces
+
+| Namespace | Use when |
+|-----------|----------|
+| `mcp` | execute_tactus, APIs, handles, budgets |
+| `score-authoring` | YAML, classifiers, rubric memory |
+| `evaluation-feedback` | alignment, optimizer |
+| `procedures` | procedure authoring/runtime |
+| `reports` | report blocks |
+| `optimizer` | CLI optimizer |
+| `repo-workflows` | Kanbus, git, internal research |
+
+## Related skills
+
+- Score work: `skills/score-setup/`, `skills/score-optimizer/`
+- MCP install: `MCP/README.md`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents how agents and scripts should perform **internal research** against the Plexus agent knowledge base using progressive disclosure (`docs_list` → `docs_get`) and the reusable Python `DocumentationRepository`.

## Changes

- New canonical agent topic: `documentation/agent/repo-workflows/internal-research.md` (`repo-workflows.internal-research`)
- New skill: `skills/internal-research/SKILL.md`
- Pointers in `AGENTS.md`, `README.md`, and `.cursor/rules/plexus-mcp.mdc`
- Updated `repo-workflows/_index.md`

## Notes

- No runtime code changes; documentation and agent guidance only.
- Clarifies that agent KB lookup is metadata-first indexing, not semantic search, and is separate from Biblicus rubric-memory corpora.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c6575bc-f4b4-49e3-aec2-629d90cb3c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c6575bc-f4b4-49e3-aec2-629d90cb3c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

