### PR TITLE
fix(dashboard): console worker CloudWatch policy + account-key log routing

### DIFF
--- a/dashboard/amplify/functions/consoleRunWorker/app.py
+++ b/dashboard/amplify/functions/consoleRunWorker/app.py
@@ -13,7 +13,7 @@ from plexus.console.chat_runtime import (
     normalize_response_target,
     process_console_message,
 )
-from plexus.dashboard.api.client import PlexusDashboardClient
+from plexus.dashboard.api.client import ClientContext, PlexusDashboardClient
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -62,7 +62,9 @@ def _resolve_client() -> PlexusDashboardClient:
     auth_mode = str(os.getenv("PLEXUS_GRAPHQL_AUTH_MODE") or "").strip().lower()
     if auth_mode != "iam":
         raise RuntimeError("PLEXUS_GRAPHQL_AUTH_MODE must be iam")
-    return PlexusDashboardClient(api_url=api_url)
+    account_key = str(os.getenv("PLEXUS_ACCOUNT_KEY") or "").strip()
+    context = ClientContext(account_key=account_key or None)
+    return PlexusDashboardClient(api_url=api_url, context=context)
 
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:

--- a/dashboard/amplify/functions/consoleRunWorker/resource.ts
+++ b/dashboard/amplify/functions/consoleRunWorker/resource.ts
@@ -92,6 +92,7 @@ export class ConsoleChatResponderStack extends NestedStack {
           "logs:CreateLogStream",
           "logs:PutLogEvents",
           "logs:DescribeLogStreams",
+          "logs:PutDataProtectionPolicy",
         ],
         resources: [
           "arn:aws:logs:*:*:log-group:/plexus/procedures/*",

--- a/dashboard/amplify/functions/consoleRunWorker/resource.ts
+++ b/dashboard/amplify/functions/consoleRunWorker/resource.ts
@@ -97,6 +97,8 @@ export class ConsoleChatResponderStack extends NestedStack {
         resources: [
           "arn:aws:logs:*:*:log-group:/plexus/procedures/*",
           "arn:aws:logs:*:*:log-group:/plexus/procedures/*:*",
+          "arn:aws:logs:*:*:log-group:/plexus/console/*",
+          "arn:aws:logs:*:*:log-group:/plexus/console/*:*",
         ],
       }),
     );

--- a/project/events/2026-05-22T18:23:12.267Z__5e04f49e-14da-42c9-bf2b-acc6bf16c04c.json
+++ b/project/events/2026-05-22T18:23:12.267Z__5e04f49e-14da-42c9-bf2b-acc6bf16c04c.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "5e04f49e-14da-42c9-bf2b-acc6bf16c04c",
+  "issue_id": "plx-50029c31-9578-4721-abd4-ee26d8c1f906",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-22T18:23:12.267Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "ConsoleChatResponder Lambda fails in sandbox with AccessDenied on logs:PutDataProtectionPolicy when cloudwatch_logger attempts to apply data masking policy to /plexus/procedures/* log groups.\n\nFix scope:\n- Add missing IAM action to ConsoleChatResponder role policy in Amplify stack\n- Keep resource scope limited to procedure log groups\n- Validate amplify TypeScript compile",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-e923c4a1-aa01-434c-a5a8-4122d916b85d",
+    "priority": 1,
+    "status": "open",
+    "title": "Grant console worker permission for CloudWatch data protection policy"
+  }
+}

--- a/project/events/2026-05-22T18:23:16.865Z__ae50d5d3-439b-4b18-bc95-2b91b9f7d39a.json
+++ b/project/events/2026-05-22T18:23:16.865Z__ae50d5d3-439b-4b18-bc95-2b91b9f7d39a.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "ae50d5d3-439b-4b18-bc95-2b91b9f7d39a",
+  "issue_id": "plx-50029c31-9578-4721-abd4-ee26d8c1f906",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-22T18:23:16.865Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-22T18:23:29.655Z__74e7c27b-5213-4def-8713-12c4ce9737bb.json
+++ b/project/events/2026-05-22T18:23:29.655Z__74e7c27b-5213-4def-8713-12c4ce9737bb.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "74e7c27b-5213-4def-8713-12c4ce9737bb",
+  "issue_id": "plx-50029c31-9578-4721-abd4-ee26d8c1f906",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-22T18:23:29.655Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "6e01301b-921f-4bdf-a6e5-2205d99e1999"
+  }
+}

--- a/project/events/2026-05-22T18:23:34.945Z__31e6cdbb-8fd3-4b69-8be5-d61f75024ac0.json
+++ b/project/events/2026-05-22T18:23:34.945Z__31e6cdbb-8fd3-4b69-8be5-d61f75024ac0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "31e6cdbb-8fd3-4b69-8be5-d61f75024ac0",
+  "issue_id": "plx-50029c31-9578-4721-abd4-ee26d8c1f906",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-22T18:23:34.945Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-22T18:49:25.161Z__cd22a992-123a-4c2e-992d-3fdd7d0ed7a4.json
+++ b/project/events/2026-05-22T18:49:25.161Z__cd22a992-123a-4c2e-992d-3fdd7d0ed7a4.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "cd22a992-123a-4c2e-992d-3fdd7d0ed7a4",
+  "issue_id": "plx-867d2c1d-dc61-417c-8c70-e3638865eb11",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-22T18:49:25.161Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Follow-up to plx-50029c: ConsoleChatResponder can now apply data protection policy on /plexus/procedures/* but still fails on /plexus/console/* with AccessDenied for logs:PutDataProtectionPolicy.\n\nFix: extend IAM log-group resource scope for ConsoleChatResponder to include /plexus/console/* (and child streams) for existing CloudWatch Logs actions and policy application.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-e923c4a1-aa01-434c-a5a8-4122d916b85d",
+    "priority": 1,
+    "status": "open",
+    "title": "Allow console worker data-protection policy on /plexus/console log groups"
+  }
+}

--- a/project/events/2026-05-22T18:49:27.215Z__a003af80-9b40-401c-bbf9-b5238adbb53b.json
+++ b/project/events/2026-05-22T18:49:27.215Z__a003af80-9b40-401c-bbf9-b5238adbb53b.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a003af80-9b40-401c-bbf9-b5238adbb53b",
+  "issue_id": "plx-867d2c1d-dc61-417c-8c70-e3638865eb11",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-22T18:49:27.215Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-22T18:49:41.380Z__6220eb60-4ffa-491e-ad98-04bb98da0245.json
+++ b/project/events/2026-05-22T18:49:41.380Z__6220eb60-4ffa-491e-ad98-04bb98da0245.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "6220eb60-4ffa-491e-ad98-04bb98da0245",
+  "issue_id": "plx-867d2c1d-dc61-417c-8c70-e3638865eb11",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-22T18:49:41.380Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "dcd7678f-db30-4aec-bd59-c7121786deac"
+  }
+}

--- a/project/events/2026-05-22T18:49:43.248Z__5e16d89b-134b-496a-ba98-48f4f8d7a512.json
+++ b/project/events/2026-05-22T18:49:43.248Z__5e16d89b-134b-496a-ba98-48f4f8d7a512.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "5e16d89b-134b-496a-ba98-48f4f8d7a512",
+  "issue_id": "plx-867d2c1d-dc61-417c-8c70-e3638865eb11",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-22T18:49:43.248Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/events/2026-05-22T18:55:12.508Z__d91ac3f6-34b1-4f1b-87d2-7afbd1448976.json
+++ b/project/events/2026-05-22T18:55:12.508Z__d91ac3f6-34b1-4f1b-87d2-7afbd1448976.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "d91ac3f6-34b1-4f1b-87d2-7afbd1448976",
+  "issue_id": "plx-f2d75061-5418-40af-a5c2-478ee2a167d5",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-22T18:55:12.508Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Console worker procedure logs are written to /plexus/procedures/unknown because procedure executor reads client.context.account_key and the Lambda initializes PlexusDashboardClient without context.\n\nFix: in dashboard/amplify/functions/consoleRunWorker/app.py, initialize PlexusDashboardClient with ClientContext(account_key=PLEXUS_ACCOUNT_KEY) after secret load so procedure log group uses account key.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-e923c4a1-aa01-434c-a5a8-4122d916b85d",
+    "priority": 1,
+    "status": "open",
+    "title": "Pass account_key into console worker dashboard client context"
+  }
+}

--- a/project/events/2026-05-22T18:55:20.494Z__e201204e-1d31-467f-8abf-92e071713153.json
+++ b/project/events/2026-05-22T18:55:20.494Z__e201204e-1d31-467f-8abf-92e071713153.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "e201204e-1d31-467f-8abf-92e071713153",
+  "issue_id": "plx-f2d75061-5418-40af-a5c2-478ee2a167d5",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-22T18:55:20.494Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-22T18:55:30.111Z__85e8b551-8b20-47f9-b32c-8d7d5304eb7c.json
+++ b/project/events/2026-05-22T18:55:30.111Z__85e8b551-8b20-47f9-b32c-8d7d5304eb7c.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "85e8b551-8b20-47f9-b32c-8d7d5304eb7c",
+  "issue_id": "plx-f2d75061-5418-40af-a5c2-478ee2a167d5",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-22T18:55:30.111Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "f8cc828e-a6ab-4669-af60-70b41288e716"
+  }
+}

--- a/project/events/2026-05-22T18:55:33.836Z__b45e2dda-ce41-4609-a09e-b587450c3ff1.json
+++ b/project/events/2026-05-22T18:55:33.836Z__b45e2dda-ce41-4609-a09e-b587450c3ff1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "b45e2dda-ce41-4609-a09e-b587450c3ff1",
+  "issue_id": "plx-f2d75061-5418-40af-a5c2-478ee2a167d5",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-22T18:55:33.836Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-50029c31-9578-4721-abd4-ee26d8c1f906.json
+++ b/project/issues/plx-50029c31-9578-4721-abd4-ee26d8c1f906.json
@@ -1,0 +1,28 @@
+{
+  "id": "plx-50029c31-9578-4721-abd4-ee26d8c1f906",
+  "title": "Grant console worker permission for CloudWatch data protection policy",
+  "description": "ConsoleChatResponder Lambda fails in sandbox with AccessDenied on logs:PutDataProtectionPolicy when cloudwatch_logger attempts to apply data masking policy to /plexus/procedures/* log groups.\n\nFix scope:\n- Add missing IAM action to ConsoleChatResponder role policy in Amplify stack\n- Keep resource scope limited to procedure log groups\n- Validate amplify TypeScript compile",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-e923c4a1-aa01-434c-a5a8-4122d916b85d",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "6e01301b-921f-4bdf-a6e5-2205d99e1999",
+      "author": "derek.norrbom",
+      "text": "Implemented fix in `dashboard/amplify/functions/consoleRunWorker/resource.ts`:\n\n- Added `logs:PutDataProtectionPolicy` to ConsoleChatResponder IAM policy for `/plexus/procedures/*` log group resources.\n\nValidation:\n- `cd dashboard && npx tsc --noEmit -p amplify/tsconfig.json` passed.",
+      "created_at": "2026-05-22T18:23:29.655512Z"
+    }
+  ],
+  "created_at": "2026-05-22T18:23:12.267455Z",
+  "updated_at": "2026-05-22T18:23:34.945126Z",
+  "closed_at": "2026-05-22T18:23:34.945126Z",
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
+}

--- a/project/issues/plx-867d2c1d-dc61-417c-8c70-e3638865eb11.json
+++ b/project/issues/plx-867d2c1d-dc61-417c-8c70-e3638865eb11.json
@@ -1,0 +1,28 @@
+{
+  "id": "plx-867d2c1d-dc61-417c-8c70-e3638865eb11",
+  "title": "Allow console worker data-protection policy on /plexus/console log groups",
+  "description": "Follow-up to plx-50029c: ConsoleChatResponder can now apply data protection policy on /plexus/procedures/* but still fails on /plexus/console/* with AccessDenied for logs:PutDataProtectionPolicy.\n\nFix: extend IAM log-group resource scope for ConsoleChatResponder to include /plexus/console/* (and child streams) for existing CloudWatch Logs actions and policy application.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-e923c4a1-aa01-434c-a5a8-4122d916b85d",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "dcd7678f-db30-4aec-bd59-c7121786deac",
+      "author": "derek.norrbom",
+      "text": "Implemented IAM scope extension in `dashboard/amplify/functions/consoleRunWorker/resource.ts`:\n\n- Kept existing CloudWatch Logs actions unchanged.\n- Added `/plexus/console/*` and `/plexus/console/*:*` resource ARNs alongside existing `/plexus/procedures/*` scope.\n\nValidation:\n- `cd dashboard && npx tsc --noEmit -p amplify/tsconfig.json` passed.",
+      "created_at": "2026-05-22T18:49:41.380525Z"
+    }
+  ],
+  "created_at": "2026-05-22T18:49:25.161063Z",
+  "updated_at": "2026-05-22T18:49:43.248186Z",
+  "closed_at": "2026-05-22T18:49:43.248186Z",
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
+}

--- a/project/issues/plx-f2d75061-5418-40af-a5c2-478ee2a167d5.json
+++ b/project/issues/plx-f2d75061-5418-40af-a5c2-478ee2a167d5.json
@@ -1,0 +1,28 @@
+{
+  "id": "plx-f2d75061-5418-40af-a5c2-478ee2a167d5",
+  "title": "Pass account_key into console worker dashboard client context",
+  "description": "Console worker procedure logs are written to /plexus/procedures/unknown because procedure executor reads client.context.account_key and the Lambda initializes PlexusDashboardClient without context.\n\nFix: in dashboard/amplify/functions/consoleRunWorker/app.py, initialize PlexusDashboardClient with ClientContext(account_key=PLEXUS_ACCOUNT_KEY) after secret load so procedure log group uses account key.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-e923c4a1-aa01-434c-a5a8-4122d916b85d",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "f8cc828e-a6ab-4669-af60-70b41288e716",
+      "author": "derek.norrbom",
+      "text": "Implemented fix in `dashboard/amplify/functions/consoleRunWorker/app.py`:\n\n- Import `ClientContext` from `plexus.dashboard.api.client`.\n- `_resolve_client()` now builds `PlexusDashboardClient` with `ClientContext(account_key=PLEXUS_ACCOUNT_KEY)` instead of default empty context.\n\nThis aligns with procedure executor log routing, which reads `client.context.account_key` for CloudWatch procedure log group segmentation.\n\nValidation:\n- `python -m py_compile dashboard/amplify/functions/consoleRunWorker/app.py` passed.",
+      "created_at": "2026-05-22T18:55:30.111308Z"
+    }
+  ],
+  "created_at": "2026-05-22T18:55:12.508746Z",
+  "updated_at": "2026-05-22T18:55:33.836761Z",
+  "closed_at": "2026-05-22T18:55:33.836761Z",
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
+}


### PR DESCRIPTION
## Summary

This PR contains follow-up fixes for the ConsoleRunWorker Lambda in sandbox/dev deployments.

### 1) Allow data protection policy application on procedure log groups
- Added `logs:PutDataProtectionPolicy` to ConsoleChatResponder IAM permissions.
- File: `dashboard/amplify/functions/consoleRunWorker/resource.ts`

### 2) Allow data protection policy application on console log groups
- Expanded CloudWatch Logs resource scope to include:
  - `/plexus/console/*`
  - `/plexus/console/*:*`
- File: `dashboard/amplify/functions/consoleRunWorker/resource.ts`

### 3) Fix `/plexus/procedures/unknown` log group fallback
- Console worker now initializes `PlexusDashboardClient` with
  `ClientContext(account_key=PLEXUS_ACCOUNT_KEY)`.
- This ensures procedure executor log routing has the account key and no longer falls back to `unknown`.
- File: `dashboard/amplify/functions/consoleRunWorker/app.py`

## Why

CloudWatch logs showed `AccessDeniedException` for `logs:PutDataProtectionPolicy` and procedure logs were being written under `/plexus/procedures/unknown` instead of the account key. These fixes address both issues directly.

## Validation

- `cd dashboard && npx tsc --noEmit -p amplify/tsconfig.json`
- `python -m py_compile dashboard/amplify/functions/consoleRunWorker/app.py`
- Runtime verification in sandbox logs:
  - policy application now succeeds on expected log groups
  - account-key-based procedure log group naming works

## Kanbus

Closed bugs:
- `plx-50029c`
- `plx-867d2c`
- `plx-f2d750`
