### PR TITLE
fix(seed): resolve PR #383 code-quality findings

### DIFF
--- a/dashboard/amplify/seed/seed.ts
+++ b/dashboard/amplify/seed/seed.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { scryptSync } from 'node:crypto';
 import { appendFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { getSecret, createAndSignUpUser, signInUser } from '@aws-amplify/seed';
@@ -26,7 +26,7 @@ async function getTrimmedSecret(name: string): Promise<string> {
 }
 
 function getSeedUsername(password: string): string {
-  const passwordHash = createHash('sha256').update(password).digest('hex').slice(0, 12);
+  const passwordHash = scryptSync(password, 'plexus-sandbox-seed-user', 16).toString('hex').slice(0, 12);
   return `sandbox-seed-${passwordHash}@plexus.internal`;
 }
 
@@ -78,7 +78,7 @@ export default async function seed() {
     // Create/sign in seed user in sandbox
     logger.phase('Creating seed user');
     try {
-      const user = await createAndSignUpUser({
+      await createAndSignUpUser({
         username: seedUsername,
         password: seedUserPassword,
         signInAfterCreation: true,

--- a/project/events/2026-05-22T20:03:03.931Z__60e6d7c0-e2a2-4c37-a866-0113acccb3ae.json
+++ b/project/events/2026-05-22T20:03:03.931Z__60e6d7c0-e2a2-4c37-a866-0113acccb3ae.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "event_id": "60e6d7c0-e2a2-4c37-a866-0113acccb3ae",
+  "issue_id": "plx-ec157387-052e-4359-8092-94659bf47e32",
+  "event_type": "issue_created",
+  "occurred_at": "2026-05-22T20:03:03.931Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "assignee": null,
+    "description": "Fix GitHub bot findings on dashboard/amplify/seed/seed.ts from PR #383:\n- remove unused `user` binding when creating seed user\n- replace SHA-256 password hashing used for username derivation with a stronger KDF-based derivation to satisfy CodeQL (insufficient computational effort).\n\nValidation: run amplify TypeScript compile.",
+    "issue_type": "bug",
+    "labels": [],
+    "parent": "plx-b7c6d1b0-17f5-4145-9017-a78e999422d2",
+    "priority": 1,
+    "status": "open",
+    "title": "Address PR #383 bot findings in seed.ts"
+  }
+}

--- a/project/events/2026-05-22T20:03:05.839Z__eaad83f1-3ff1-4ba4-8f45-b9eb1394b220.json
+++ b/project/events/2026-05-22T20:03:05.839Z__eaad83f1-3ff1-4ba4-8f45-b9eb1394b220.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "eaad83f1-3ff1-4ba4-8f45-b9eb1394b220",
+  "issue_id": "plx-ec157387-052e-4359-8092-94659bf47e32",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-22T20:03:05.839Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "open",
+    "to_status": "in_progress"
+  }
+}

--- a/project/events/2026-05-22T20:03:27.517Z__a37f1ebb-be9e-488d-80f0-f80d0f168aa7.json
+++ b/project/events/2026-05-22T20:03:27.517Z__a37f1ebb-be9e-488d-80f0-f80d0f168aa7.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "a37f1ebb-be9e-488d-80f0-f80d0f168aa7",
+  "issue_id": "plx-ec157387-052e-4359-8092-94659bf47e32",
+  "event_type": "comment_added",
+  "occurred_at": "2026-05-22T20:03:27.517Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "comment_author": "derek.norrbom",
+    "comment_id": "97c81adf-7be3-407e-aa2f-025d320e9523"
+  }
+}

--- a/project/events/2026-05-22T20:03:31.815Z__35170058-46ca-4208-96d8-1ab0b4f40621.json
+++ b/project/events/2026-05-22T20:03:31.815Z__35170058-46ca-4208-96d8-1ab0b4f40621.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "event_id": "35170058-46ca-4208-96d8-1ab0b4f40621",
+  "issue_id": "plx-ec157387-052e-4359-8092-94659bf47e32",
+  "event_type": "state_transition",
+  "occurred_at": "2026-05-22T20:03:31.815Z",
+  "actor_id": "derek.norrbom",
+  "payload": {
+    "from_status": "in_progress",
+    "to_status": "closed"
+  }
+}

--- a/project/issues/plx-ec157387-052e-4359-8092-94659bf47e32.json
+++ b/project/issues/plx-ec157387-052e-4359-8092-94659bf47e32.json
@@ -1,0 +1,28 @@
+{
+  "id": "plx-ec157387-052e-4359-8092-94659bf47e32",
+  "title": "Address PR #383 bot findings in seed.ts",
+  "description": "Fix GitHub bot findings on dashboard/amplify/seed/seed.ts from PR #383:\n- remove unused `user` binding when creating seed user\n- replace SHA-256 password hashing used for username derivation with a stronger KDF-based derivation to satisfy CodeQL (insufficient computational effort).\n\nValidation: run amplify TypeScript compile.",
+  "type": "bug",
+  "status": "closed",
+  "priority": 1,
+  "assignee": null,
+  "creator": null,
+  "parent": "plx-b7c6d1b0-17f5-4145-9017-a78e999422d2",
+  "labels": [],
+  "dependencies": [],
+  "comments": [
+    {
+      "id": "97c81adf-7be3-407e-aa2f-025d320e9523",
+      "author": "derek.norrbom",
+      "text": "Implemented both PR #383 bot fixes in `dashboard/amplify/seed/seed.ts`:\n\n- Removed unused variable binding by changing `const user = await createAndSignUpUser(...)` to `await createAndSignUpUser(...)`.\n- Replaced `createHash('sha256')` password-derived username hash with `scryptSync(..., \"plexus-sandbox-seed-user\", 16)` to use a KDF and address CodeQL computational-effort finding.\n\nValidation:\n- `cd dashboard && npx tsc --noEmit -p amplify/tsconfig.json` passed.",
+      "created_at": "2026-05-22T20:03:27.516872Z"
+    }
+  ],
+  "created_at": "2026-05-22T20:03:03.930967Z",
+  "updated_at": "2026-05-22T20:03:31.815217Z",
+  "closed_at": "2026-05-22T20:03:31.815217Z",
+  "custom": {
+    "project_label": "plx",
+    "source": "shared"
+  }
+}


### PR DESCRIPTION
## Summary

Addresses bot feedback raised on PR #383 in `dashboard/amplify/seed/seed.ts`:

- Remove unused variable binding in seed-user creation path
- Replace SHA-256 password hashing used for username derivation with `scryptSync` (KDF)

## Changes

- `const user = await createAndSignUpUser(...)` -> `await createAndSignUpUser(...)`
- `createHash('sha256')` -> `scryptSync(password, "plexus-sandbox-seed-user", 16)`

## Validation

- `cd dashboard && npx tsc --noEmit -p amplify/tsconfig.json`

## Kanbus

- Closed bug: `plx-ec1573`
